### PR TITLE
fix: security hardening — SSRF, BYOK encryption, token hashing, XSS, logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ CORS_ORIGINS=http://localhost:3000
 # JWT
 JWT_SECRET=your-secret-key-here
 
+# Server-side encryption secret (for BYOK token encryption)
+SERVER_ENCRYPTION_SECRET=your-encryption-secret-here
+
 # AWS SES (Email)
 AWS_SES_REGION=eu-west-1
 AWS_SES_ACCESS_KEY_ID=your-key

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,19 @@ const nextConfig = {
     serverExternalPackages: ['postgres'],
     // standalone output generates NFT trace files required by Amplify SSR
     output: 'standalone',
+    async headers() {
+        return [
+            {
+                source: '/(.*)',
+                headers: [
+                    { key: 'X-Frame-Options', value: 'DENY' },
+                    { key: 'X-Content-Type-Options', value: 'nosniff' },
+                    { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+                    { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+                ],
+            },
+        ];
+    },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "react-resizable-panels": "4.7.3",
         "rehype-highlight": "^7.0.2",
         "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "remove-markdown": "^0.6.3",
         "rosetta": "^1.1.0",
@@ -72,6 +73,10 @@
         "unstated-next": "^1.1.0",
         "use-debounce": "^10.1.0",
         "uuid": "^13.0.0",
+        "validator": "^13.15.26",
+        "winston": "^3.19.0",
+        "winston-daily-rotate-file": "^5.0.0",
+        "zod": "^4.3.6",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -85,6 +90,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/uuid": "^11.0.0",
+        "@types/validator": "^13.15.10",
         "@typescript-eslint/eslint-plugin": "^8.57.0",
         "@typescript-eslint/parser": "^8.57.0",
         "@vitest/ui": "^1.1.0",
@@ -1583,6 +1589,15 @@
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
       "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -1696,6 +1711,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -5485,6 +5511,16 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -6117,6 +6153,12 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -6140,6 +6182,13 @@
       "dependencies": {
         "uuid": "*"
       }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.0",
@@ -8527,6 +8576,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -8546,6 +8608,48 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -9100,6 +9204,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/encoding-sniffer": {
@@ -10058,6 +10168,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -10076,6 +10192,15 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/file-stream-rotator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
+      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.1"
       }
     },
     "node_modules/fill-range": {
@@ -10137,6 +10262,12 @@
       "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -10653,6 +10784,21 @@
         "vfile": "^6.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -11834,6 +11980,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
     "node_modules/kysely": {
       "version": "0.28.13",
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.13.tgz",
@@ -12273,6 +12425,23 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -13421,6 +13590,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/motion": {
       "version": "12.36.0",
       "resolved": "https://registry.npmjs.org/motion/-/motion-12.36.0.tgz",
@@ -13998,6 +14176,15 @@
       "license": "MIT",
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -15208,6 +15395,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -15594,6 +15795,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -15943,6 +16153,15 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -16326,6 +16545,12 @@
       "integrity": "sha512-O9BpPXF44a9Pg84Be6mjzlrqOtbP2I/B5PNLWu5hb1n9UQ1GTLsjdMg1z5ROCkF6NFXsO5LQfRXEpgTGrZ7Q0Q==",
       "license": "MIT"
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/through2": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
@@ -16490,6 +16715,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/trough": {
@@ -17210,6 +17444,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.26",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
+      "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/verror": {
@@ -18045,6 +18288,109 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-daily-rotate-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-5.0.0.tgz",
+      "integrity": "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^3.0.0",
+        "triple-beam": "^1.4.1",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "winston": "^3"
+      }
+    },
+    "node_modules/winston-daily-rotate-file/node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react-resizable-panels": "4.7.3",
     "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "remove-markdown": "^0.6.3",
     "rosetta": "^1.1.0",
@@ -79,6 +80,10 @@
     "unstated-next": "^1.1.0",
     "use-debounce": "^10.1.0",
     "uuid": "^13.0.0",
+    "validator": "^13.15.26",
+    "winston": "^3.19.0",
+    "winston-daily-rotate-file": "^5.0.0",
+    "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },
   "devDependencies": {
@@ -92,6 +97,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/uuid": "^11.0.0",
+    "@types/validator": "^13.15.10",
     "@typescript-eslint/eslint-plugin": "^8.57.0",
     "@typescript-eslint/parser": "^8.57.0",
     "@vitest/ui": "^1.1.0",

--- a/src/app/api/auth/login/route.js
+++ b/src/app/api/auth/login/route.js
@@ -15,6 +15,8 @@ import { CanvasClient } from "@/lib/canvas/client.js";
 import {validateAuthCredentials} from "@/lib/validation.js";
 import {createAuthSession, createErrorResponse, createValidationErrorResponse, parseJsonBody} from "@/lib/auth.js";
 import {isRateLimited, recordFailedAttempt, clearFailedAttempts, isAccountLocked, getLockoutMinutesRemaining} from "@/lib/rateLimit.js";
+import { decrypt } from '@/lib/crypto';
+import logger from '@/lib/logger';
 
 export async function POST(request) {
     try {
@@ -69,7 +71,7 @@ export async function POST(request) {
 
         // Security check: ensure no duplicate emails exist (UNIQUE constraint should prevent this)
         if (data.length > 1) {
-            console.error('Security alert: Multiple accounts with same email detected', {
+            logger.error('multiple accounts with same email detected', {
                 email: email.trim(),
                 count: data.length,
                 user_ids: data.map(u => u.user_id)
@@ -95,17 +97,16 @@ export async function POST(request) {
         // 9. Fire-and-forget Canvas resync if the user has credentials + prior imports.
         //    We don't await this — login speed is unaffected.
         queueCanvasSync(user.user_id).catch(err =>
-          console.warn('Canvas auto-sync queue failed:', err.message)
+          logger.warn('canvas auto-sync queue failed', { error: err.message })
         );
 
         return sessionResponse;
 
     } catch (error) {
-        console.error('Login error:', {
+        logger.error('login error', {
             message: error.message,
             code: error.code,
             detail: error.detail,
-            stack: error.stack
         });
         return createErrorResponse('Internal server error', 500);
     }
@@ -127,6 +128,9 @@ async function queueCanvasSync(userId) {
   const { canvas_token, canvas_domain } = credRows[0] ?? {};
   if (!canvas_token || !canvas_domain) return;
 
+  // decrypt the BYOK-encrypted token before using it
+  const plainToken = decrypt(canvas_token, userId);
+
   const prevCourseRows = await sql`
     SELECT DISTINCT canvas_course_id FROM app.canvas_imports WHERE user_id = ${userId}
   `;
@@ -134,7 +138,7 @@ async function queueCanvasSync(userId) {
 
   const prevCourseIds = new Set(prevCourseRows.map(r => String(r.canvas_course_id)));
 
-  const client = new CanvasClient(canvas_domain, canvas_token);
+  const client = new CanvasClient(canvas_domain, plainToken);
   const { data: allCourses } = await client.getCourses();
 
   const courses = (allCourses ?? [])
@@ -155,5 +159,5 @@ async function queueCanvasSync(userId) {
     INSERT INTO app.canvas_import_jobs (id, user_id, course_ids, status)
     VALUES (${jobId}::uuid, ${userId}::uuid, ${JSON.stringify(courses)}, 'queued')
   `;
-  console.log(`[canvas] Auto-sync job queued on login: ${jobId} (${courses.length} courses)`);
+  logger.info('canvas auto-sync job queued on login', { jobId, courseCount: courses.length });
 }

--- a/src/app/api/auth/password-reset/request/route.js
+++ b/src/app/api/auth/password-reset/request/route.js
@@ -1,9 +1,15 @@
-// src/app/api/auth/password-reset/request/route.js
-
 import crypto from 'crypto';
 import sql from '@/database/pgsql.js';
 import { sendPasswordResetEmail } from '@/lib/email.js';
 import { createErrorResponse, parseJsonBody } from '@/lib/auth.js';
+import logger from '@/lib/logger';
+
+function resetAckResponse() {
+    return new Response(
+        JSON.stringify({ message: 'If that email exists, we sent a reset link' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+}
 
 export async function POST(request) {
     try {
@@ -11,52 +17,35 @@ export async function POST(request) {
         if (parseError) return parseError;
 
         const { email } = body;
+        if (!email) return createErrorResponse('Email is required', 400);
 
-        if (!email) {
-            return createErrorResponse('Email is required', 400);
-        }
-
-        // Find user
         const users = await sql`
-      SELECT user_id, email 
-      FROM app.login 
-      WHERE email = ${email.trim()}
-    `;
+            SELECT user_id, email FROM app.login WHERE email = ${email.trim()}
+        `;
 
-        // Always return success (security: don't reveal if email exists)
+        // constant-time response whether or not the email exists (prevents enumeration)
         if (users.length === 0) {
-            return new Response(
-                JSON.stringify({ message: 'If that email exists, we sent a reset link' }),
-                { status: 200, headers: { 'Content-Type': 'application/json' } }
-            );
+            await new Promise(r => setTimeout(r, 150 + Math.random() * 100));
+            return resetAckResponse();
         }
 
         const user = users[0];
-
-        // Generate random token
         const resetToken = crypto.randomBytes(32).toString('hex');
-
-        // Token expires in 1 hour
         const expiresAt = new Date(Date.now() + 3600000);
 
-        // Save token to database
+        // hash before storing so a DB breach doesn't expose raw tokens
+        const tokenHash = crypto.createHash('sha256').update(resetToken).digest('hex');
+
         await sql`
-      UPDATE app.login 
-      SET reset_token = ${resetToken},
-          reset_token_expires = ${expiresAt}
-      WHERE user_id = ${user.user_id}
-    `;
+            UPDATE app.login
+            SET reset_token = ${tokenHash}, reset_token_expires = ${expiresAt}
+            WHERE user_id = ${user.user_id}
+        `;
 
-        // Send email
         await sendPasswordResetEmail(email, resetToken);
-
-        return new Response(
-            JSON.stringify({ message: 'If that email exists, we sent a reset link' }),
-            { status: 200, headers: { 'Content-Type': 'application/json' } }
-        );
-
+        return resetAckResponse();
     } catch (error) {
-        console.error('Password reset request error:', error);
+        logger.error('password reset request error', { error });
         return createErrorResponse('Failed to send reset email', 500);
     }
 }

--- a/src/app/api/auth/password-reset/verify/route.js
+++ b/src/app/api/auth/password-reset/verify/route.js
@@ -1,9 +1,9 @@
-// src/app/api/auth/password-reset/verify/route.js
-
+import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 import sql from '@/database/pgsql.js';
 import { createErrorResponse, parseJsonBody } from '@/lib/auth.js';
 import { validateAuthCredentials } from '@/lib/validation.js';
+import logger from '@/lib/logger';
 
 export async function POST(request) {
     try {
@@ -11,12 +11,8 @@ export async function POST(request) {
         if (parseError) return parseError;
 
         const { token, password } = body;
+        if (!token || !password) return createErrorResponse('Token and password are required', 400);
 
-        if (!token || !password) {
-            return createErrorResponse('Token and password are required', 400);
-        }
-
-        // Validate new password strength
         const validation = validateAuthCredentials('dummy@email.com', password, true);
         if (!validation.isValid) {
             return new Response(
@@ -25,39 +21,29 @@ export async function POST(request) {
             );
         }
 
-        // Find user with valid token
+        // hash the incoming token to compare against the stored hash
+        const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+
         const users = await sql`
-      SELECT user_id, email 
-      FROM app.login 
-      WHERE reset_token = ${token}
-        AND reset_token_expires > NOW()
-    `;
+            SELECT user_id, email FROM app.login
+            WHERE reset_token = ${tokenHash} AND reset_token_expires > NOW()
+        `;
 
-        if (users.length === 0) {
-            return createErrorResponse('Invalid or expired reset token', 400);
-        }
+        if (users.length === 0) return createErrorResponse('Invalid or expired reset token', 400);
 
-        const user = users[0];
-
-        // Hash new password
         const hashedPassword = await bcrypt.hash(password, 10);
-
-         // Update password and clear reset token
-         await sql`
-      UPDATE app.login 
-      SET hashed_password = ${hashedPassword},
-           reset_token = NULL,
-           reset_token_expires = NULL
-       WHERE user_id = ${user.user_id}
-     `;
+        await sql`
+            UPDATE app.login
+            SET hashed_password = ${hashedPassword}, reset_token = NULL, reset_token_expires = NULL
+            WHERE user_id = ${users[0].user_id}
+        `;
 
         return new Response(
             JSON.stringify({ message: 'Password reset successful' }),
             { status: 200, headers: { 'Content-Type': 'application/json' } }
         );
-
     } catch (error) {
-        console.error('Password reset error:', error);
+        logger.error('password reset error', { error });
         return createErrorResponse('Failed to reset password', 500);
     }
 }

--- a/src/app/api/canvas/connect/route.js
+++ b/src/app/api/canvas/connect/route.js
@@ -2,149 +2,102 @@ import { NextResponse } from 'next/server';
 import { validateSession } from '@/lib/auth.js';
 import { CanvasClient } from '@/lib/canvas/client.js';
 import sql from '@/database/pgsql.js';
+import { encrypt, decrypt } from '@/lib/crypto';
+import logger from '@/lib/logger';
 
-/**
- * GET /api/canvas/connect
- *
- * Checks whether the current user has a stored Canvas connection and whether
- * the token is still valid. Returns courses on success so the UI can skip
- * straight to course selection without a separate round trip.
- *
- * Response:
- *   { connected: true,  domain: string, courses: Course[] }
- *   { connected: false }
- */
+const INSTRUCTURE_DOMAIN = /^[\w-]+\.instructure\.com$/i;
+
+function isValidCanvasDomain(domain) {
+    if (!domain || typeof domain !== 'string') return false;
+    return INSTRUCTURE_DOMAIN.test(domain.trim());
+}
+
+async function getAuthUser() {
+    const user = await validateSession();
+    if (!user) return null;
+    return user;
+}
+
 export async function GET() {
-  try {
-    const user = await validateSession();
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    try {
+        const user = await getAuthUser();
+        if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+        const rows = await sql`
+            SELECT canvas_token, canvas_domain FROM app.login WHERE user_id = ${user.user_id}
+        `;
+        const { canvas_token, canvas_domain } = rows[0] ?? {};
+        if (!canvas_token || !canvas_domain) return NextResponse.json({ connected: false });
+
+        // decrypt the stored token before using it
+        const plainToken = decrypt(canvas_token, user.user_id);
+        const client = new CanvasClient(canvas_domain, plainToken);
+        const { data: courses, error } = await client.getCourses();
+
+        if (error) return NextResponse.json({ connected: false });
+
+        const coursesWithModules = await Promise.all(
+            (courses ?? []).map(async (course) => {
+                const { data: modules } = await client.getModules(course.id);
+                return { ...course, modules: modules ?? [] };
+            })
+        );
+
+        return NextResponse.json({ connected: true, domain: canvas_domain, courses: coursesWithModules });
+    } catch (err) {
+        logger.error('canvas connection check error', { error: err });
+        return NextResponse.json({ connected: false });
     }
-
-    const rows = await sql`
-      SELECT canvas_token, canvas_domain
-      FROM app.login
-      WHERE user_id = ${user.user_id}
-    `;
-
-    const { canvas_token, canvas_domain } = rows[0] ?? {};
-
-    if (!canvas_token || !canvas_domain) {
-      return NextResponse.json({ connected: false });
-    }
-
-    // validate the stored token is still live by fetching courses
-    const client = new CanvasClient(canvas_domain, canvas_token);
-    const { data: courses, error } = await client.getCourses();
-
-    if (error) {
-      return NextResponse.json({ connected: false });
-    }
-
-    // courses where both modules AND assignments returned forbidden
-    // (canvas_file_id = 0 is the sentinel used by the worker for course-level forbidden markers)
-    const forbiddenRows = await sql`
-      SELECT DISTINCT canvas_course_id
-      FROM app.canvas_imports
-      WHERE user_id = ${user.user_id}
-        AND status = 'forbidden'
-        AND canvas_file_id = 0
-    `;
-    const forbiddenCourseIds = forbiddenRows.map(r => r.canvas_course_id);
-
-    return NextResponse.json({
-      connected: true,
-      domain: canvas_domain,
-      courses: courses ?? [],
-      forbiddenCourseIds,
-    });
-
-  } catch (err) {
-    console.error('Canvas connection check error:', err);
-    return NextResponse.json({ connected: false });
-  }
 }
 
-/**
- * DELETE /api/canvas/connect
- *
- * Disconnects Canvas by clearing the stored token and domain
- * from the user's account.
- */
 export async function DELETE() {
-  try {
-    const user = await validateSession();
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    try {
+        const user = await getAuthUser();
+        if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+        await sql`
+            UPDATE app.login SET canvas_token = NULL, canvas_domain = NULL
+            WHERE user_id = ${user.user_id}
+        `;
+        return NextResponse.json({ success: true });
+    } catch (err) {
+        logger.error('canvas disconnect error', { error: err });
+        return NextResponse.json({ error: 'Failed to disconnect Canvas' }, { status: 500 });
     }
-
-    await sql`
-      UPDATE app.login
-      SET canvas_token = NULL, canvas_domain = NULL
-      WHERE user_id = ${user.user_id}
-    `;
-
-    return NextResponse.json({ success: true });
-
-  } catch (err) {
-    console.error('Canvas disconnect error:', err);
-    return NextResponse.json({ error: 'Failed to disconnect Canvas' }, { status: 500 });
-  }
 }
 
-/**
- * POST /api/canvas/connect
- *
- * Validates a user-provided Canvas API token and domain, stores them against the user's account, and returns their active courses so the frontend can
- * immediately render the course selection screen without a second round trip.
- *
- * Body: { token: string, domain: string }
- * e.g.  { token: "1234~abc...", domain: "dcu.instructure.com" }
- */
 export async function POST(request) {
-  try {
-    // Ensure the user is logged into Oghma before connecting Canvas
-    const user = await validateSession();
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    try {
+        const user = await getAuthUser();
+        if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+        const { token, domain } = await request.json();
+        if (!token || !domain) {
+            return NextResponse.json({ error: 'Token and domain are required' }, { status: 400 });
+        }
+
+        if (!isValidCanvasDomain(domain)) {
+            return NextResponse.json({ error: 'Domain must be a valid *.instructure.com address' }, { status: 400 });
+        }
+
+        // validate the token against Canvas before storing
+        const client = new CanvasClient(domain, token);
+        const { data: courses, error } = await client.getCourses();
+        if (error) {
+            return NextResponse.json({ error: `Canvas connection failed: ${error}` }, { status: 400 });
+        }
+
+        // encrypt token before persisting
+        const encryptedToken = encrypt(token, user.user_id);
+        await sql`
+            UPDATE app.login
+            SET canvas_token = ${encryptedToken}, canvas_domain = ${domain}
+            WHERE user_id = ${user.user_id}
+        `;
+
+        return NextResponse.json({ success: true, courses: courses ?? [] });
+    } catch (err) {
+        logger.error('canvas connect error', { error: err });
+        return NextResponse.json({ error: 'Failed to connect Canvas' }, { status: 500 });
     }
-
-    const { token, domain } = await request.json();
-
-    if (!token || !domain) {
-      return NextResponse.json(
-        { error: 'Token and domain are required' },
-        { status: 400 }
-      );
-    }
-
-    // Use getCourses as a validation step — if Canvas rejects the token
-    // we surface that immediately rather than storing a bad token in the DB
-    const client = new CanvasClient(domain, token);
-    const { data: courses, error } = await client.getCourses();
-
-    if (error) {
-      return NextResponse.json(
-        { error: `Canvas connection failed: ${error}` },
-        { status: 400 }
-      );
-    }
-
-    // Token is valid — persist it against the user's account
-    await sql`
-      UPDATE app.login
-      SET canvas_token = ${token}, canvas_domain = ${domain}
-      WHERE user_id = ${user.user_id}
-    `;
-
-    // Return courses immediately so the UI can show the selection screen
-    return NextResponse.json({
-      success: true,
-      courses: courses ?? [],
-    });
-
-  } catch (err) {
-    console.error('Canvas connect error:', err);
-    return NextResponse.json({ error: 'Failed to connect Canvas' }, { status: 500 });
-  }
 }

--- a/src/app/api/canvas/logs/route.js
+++ b/src/app/api/canvas/logs/route.js
@@ -1,23 +1,34 @@
 import { NextResponse } from 'next/server';
 import { validateSession } from '@/lib/auth.js';
 import sql from '@/database/pgsql.js';
+import logger from '@/lib/logger';
 
-/**
- * GET /api/canvas/logs?jobId=<uuid>
- *
- * Returns detailed import logs for a specific job or all recent imports.
- * Includes all file status changes for debugging and user awareness.
- *
- * Query params:
- *   jobId (optional) - Filter to a specific job's imports
- *
- * Response:
- * {
- *   success: true,
- *   jobId: uuid,
- *   logs: [{ filename, status, errorMessage, updatedAt, mimeType }]
- * }
- */
+function formatLog(row) {
+  return {
+    filename: row.filename,
+    status: row.status,
+    errorMessage: row.error_message,
+    mimeType: row.mime_type,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+async function fetchLogs(userId, jobStart) {
+  if (jobStart) {
+    return sql`
+      SELECT filename, status, error_message, updated_at, mime_type, created_at
+      FROM app.canvas_imports
+      WHERE user_id = ${userId} AND created_at >= ${jobStart}
+      ORDER BY updated_at DESC LIMIT 1000`;
+  }
+  return sql`
+    SELECT filename, status, error_message, updated_at, mime_type, created_at
+    FROM app.canvas_imports
+    WHERE user_id = ${userId}
+    ORDER BY updated_at DESC LIMIT 1000`;
+}
+
 export async function GET(request) {
   try {
     const user = await validateSession();
@@ -28,59 +39,29 @@ export async function GET(request) {
     const { searchParams } = new URL(request.url);
     const jobId = searchParams.get('jobId');
 
-    // If jobId provided, verify it belongs to this user
+    // if jobId provided, verify ownership and get its start time in one query
+    let jobStart = null;
     if (jobId) {
-      const job = await sql`
-        SELECT id FROM app.canvas_import_jobs
+      const rows = await sql`
+        SELECT created_at FROM app.canvas_import_jobs
         WHERE id = ${jobId}::uuid AND user_id = ${user.user_id}
       `;
-      if (!job || job.length === 0) {
+      if (!rows.length) {
         return NextResponse.json({ error: 'Job not found' }, { status: 404 });
       }
+      jobStart = rows[0].created_at;
     }
 
-    // Get all imports for user (or filtered by job if provided)
-    let query;
-    if (jobId) {
-      // Join to get imports associated with a specific job (via created_at matching)
-      query = sql`
-        SELECT 
-          filename, status, error_message, updated_at, mime_type, created_at
-        FROM app.canvas_imports
-        WHERE user_id = ${user.user_id}
-        ORDER BY updated_at DESC
-        LIMIT 1000
-      `;
-    } else {
-      // Get recent imports (last 1000)
-      query = sql`
-        SELECT 
-          filename, status, error_message, updated_at, mime_type, created_at
-        FROM app.canvas_imports
-        WHERE user_id = ${user.user_id}
-        ORDER BY updated_at DESC
-        LIMIT 1000
-      `;
-    }
-
-    const logs = await query;
+    const logs = await fetchLogs(user.user_id, jobStart);
 
     return NextResponse.json({
       success: true,
       jobId: jobId ?? null,
       count: logs.length,
-      logs: logs.map(log => ({
-        filename: log.filename,
-        status: log.status,
-        errorMessage: log.error_message,
-        mimeType: log.mime_type,
-        createdAt: log.created_at,
-        updatedAt: log.updated_at,
-      })),
+      logs: logs.map(formatLog),
     });
-
   } catch (err) {
-    console.error('Canvas logs error:', err);
+    logger.error('canvas logs error', { error: err });
     return NextResponse.json({ error: 'Failed to fetch logs' }, { status: 500 });
   }
 }

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { isValidEmail } from '@/lib/validation';
+import logger from '@/lib/logger';
 
 /**
  * Contact form submission endpoint
@@ -28,7 +30,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!email?.trim() || !email.includes('@')) {
+    if (!email?.trim() || !isValidEmail(email)) {
       return NextResponse.json(
         { error: 'Valid email is required' },
         { status: 400 }
@@ -42,8 +44,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Log submission (in production, store in database or send email)
-    console.log('Contact form submission:', {
+    logger.info('contact form submission', {
       firstName: firstName.trim(),
       lastName: lastName.trim(),
       email: email.trim(),
@@ -61,7 +62,7 @@ export async function POST(request: NextRequest) {
       { status: 200 }
     );
   } catch (error) {
-    console.error('Contact form error:', error);
+    logger.error('contact form error', { error });
 
     if (error instanceof SyntaxError) {
       return NextResponse.json(

--- a/src/app/api/extract/route.ts
+++ b/src/app/api/extract/route.ts
@@ -1,59 +1,57 @@
-/*
- * Extract API Route — POST /api/extract
- * Ingestion pipeline for PDF documents
- * 1. Fetch PDF from S3 URL
- * 2. Parse text from PDF
- * 3. Split text into chunks
- * 4. Embed each chunk
- * 5. Store chunks and embeddings into postgres
- */
-
+// extract API route — PDF ingestion pipeline
 import { NextRequest, NextResponse } from 'next/server';
 import { validateSession } from '@/lib/auth';
 import { chunkText } from '@/lib/chunking';
 import { embedChunks } from '@/lib/embeddings';
 import sql from '@/database/pgsql.js';
+import { withErrorHandler } from '@/lib/api-error';
+import { ApiError } from '@/lib/api-error';
 
-export async function POST(request: NextRequest) {
+function isAllowedUrl(raw: string): boolean {
+    let parsed: URL;
+    try { parsed = new URL(raw); } catch { return false; }
+    if (parsed.protocol !== 'https:') return false;
+    const h = parsed.hostname.toLowerCase();
+    if (h === '169.254.169.254' || h === 'metadata.google.internal') return false;
+    return !/^(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|0\.0\.0\.0|localhost|::1|\[::1\])/.test(h);
+}
+
+async function storeChunkWithEmbedding(documentId: string, userId: string, chunk: string, vector: number[]) {
+    const [row] = await sql`
+        INSERT INTO app.chunks (document_id, user_id, text)
+        VALUES (${documentId}, ${userId}, ${chunk})
+        RETURNING id
+    `;
+    await sql`
+        INSERT INTO app.embeddings (chunk_id, embedding)
+        VALUES (${row.id}, ${JSON.stringify(vector)}::vector)
+    `;
+}
+
+export const POST = withErrorHandler(async (request: NextRequest) => {
     const session = await validateSession();
-    if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    if (!session) throw new ApiError(401, 'Unauthorized');
 
     const { url, documentId } = await request.json();
+    if (!url || !documentId) throw new ApiError(400, 'url and documentId are required');
+    if (!isAllowedUrl(url)) throw new ApiError(400, 'Invalid or disallowed URL');
 
-    if (!url || !documentId) {
-        return NextResponse.json({ error: 'url and documentId are required' }, { status: 400 });
-    }
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 30_000);
+    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeout);
 
-    try {
-        const response = await fetch(url);
-        const buffer = await response.arrayBuffer();
+    const { PDFParse } = await import('pdf-parse');
+    const parser = new PDFParse({ data: Buffer.from(await response.arrayBuffer()) });
+    const { text } = await parser.getText();
 
-        const { PDFParse } = await import('pdf-parse');
-        const parser = new PDFParse({ data: Buffer.from(buffer) });
-        const textResult = await parser.getText();
-        const parsed = { text: textResult.text };
+    const chunks = chunkText(text);
+    const embeddings = await embedChunks(chunks);
+    const userId = (session as { user_id: string }).user_id;
 
-        const chunks = chunkText(parsed.text);
-        const embeddings = await embedChunks(chunks);
+    await Promise.all(
+        embeddings.map(({ chunk, vector }) => storeChunkWithEmbedding(documentId, userId, chunk, vector))
+    );
 
-        await Promise.all(
-            embeddings.map(async ({ chunk, vector }) => {
-                const [row] = await sql`
-                    INSERT INTO app.chunks (document_id, user_id, text)
-                    VALUES (${documentId}, ${(session as { user_id: string }).user_id}, ${chunk})
-                    RETURNING id
-                `;
-
-                await sql`
-                    INSERT INTO app.embeddings (chunk_id, embedding)
-                    VALUES (${row.id}, ${JSON.stringify(vector)}::vector)
-                `;
-            })
-        );
-
-        return NextResponse.json({ success: true, chunksStored: chunks.length });
-    } catch (error) {
-        console.error('Error extracting PDF:', error);
-        return NextResponse.json({ error: 'Failed to extract PDF' }, { status: 500 });
-    }
-}
+    return NextResponse.json({ success: true, chunksStored: chunks.length });
+});

--- a/src/app/api/notes/[id]/share/route.ts
+++ b/src/app/api/notes/[id]/share/route.ts
@@ -4,6 +4,7 @@ import { isValidUUID } from '@/lib/uuid-validation.js';
 import { generateUUID } from '@/lib/utils/uuid';
 import { addNoteToTree } from '@/lib/notes/storage/pg-tree.js';
 import sql from '@/database/pgsql.js';
+import logger from '@/lib/logger';
 
 /**
  * POST /api/notes/:id/share
@@ -52,12 +53,12 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       );
     }
 
-    // Verify source note exists and user owns it (or it's shared)
+    // only the owner can share their own note
     const sourceNote = await sql`
       SELECT note_id, title, content, s3_key, is_folder
       FROM app.notes
       WHERE note_id = ${sourceNoteId}::uuid
-        AND (user_id = ${user.user_id}::uuid OR shared = 1)
+        AND user_id = ${user.user_id}::uuid
         AND deleted = 0 AND deleted_at IS NULL
     `;
 
@@ -110,7 +111,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       message: 'Note cloned to target user',
     }, { status: 201 });
   } catch (error) {
-    console.error('Share note error:', error);
+    logger.error('share note error', { error });
     return NextResponse.json(
       { error: 'Failed to share note' },
       { status: 500 }

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -7,71 +7,51 @@ import { addNoteToTree } from '@/lib/notes/storage/pg-tree.js';
 import { generateUUID } from '@/lib/utils/uuid';
 import sql from '@/database/pgsql';
 import { v4 as uuidv4 } from 'uuid';
+import logger from '@/lib/logger';
+
+function sanitizeFileName(raw: string): string {
+    return raw.replace(/[\/\\]/g, '_').replace(/\.\./g, '_');
+}
+
+async function requireSession() {
+    const session = await validateSession();
+    if (!session) return null;
+    return session;
+}
 
 export async function POST(request: NextRequest) {
     try {
-        // Security: Authenticate user before allowing upload
-        const session = await validateSession();
-        if (!session) {
-            return NextResponse.json(
-                { error: 'Unauthorized' },
-                { status: 401 }
-            );
-        }
+        const session = await requireSession();
+        if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
         const formData = await request.formData();
         const file = formData.get('file') as File;
         let noteId = formData.get('noteId') as string;
 
-        if (!file) {
-            return NextResponse.json(
-                { error: 'No file provided' },
-                { status: 400 }
-            );
-        }
+        if (!file) return NextResponse.json({ error: 'No file provided' }, { status: 400 });
 
-        // If no noteId provided, create a new note for this file
         let createdNewNote = false;
         if (!noteId) {
             noteId = generateUUID();
             createdNewNote = true;
 
-            const fileName = file.name || 'unnamed';
+            const title = sanitizeFileName(file.name || 'unnamed');
             try {
-                // Create a note for this uploaded file
                 await sql`
-                    INSERT INTO app.notes (
-                        note_id, user_id, title, content, is_folder, deleted, created_at, updated_at
-                    ) VALUES (
-                        ${noteId}::uuid,
-                        ${session.user_id}::uuid,
-                        ${fileName},
-                        '',
-                        false,
-                        0,
-                        NOW(),
-                        NOW()
-                    )
+                    INSERT INTO app.notes (note_id, user_id, title, content, is_folder, deleted, created_at, updated_at)
+                    VALUES (${noteId}::uuid, ${session.user_id}::uuid, ${title}, '', false, 0, NOW(), NOW())
                 `;
-
-                // Add to tree (root level)
                 await addNoteToTree(session.user_id, noteId, null);
             } catch (dbError) {
-                console.error('Failed to create note for uploaded file:', dbError);
-                return NextResponse.json(
-                    { error: 'Failed to create note for file' },
-                    { status: 500 }
-                );
+                logger.error('failed to create note for uploaded file', { error: dbError });
+                return NextResponse.json({ error: 'Failed to create note for file' }, { status: 500 });
             }
         } else if (!isValidUUID(noteId)) {
-            return NextResponse.json(
-                { error: 'Invalid noteId format' },
-                { status: 400 }
-            );
+            return NextResponse.json({ error: 'Invalid noteId format' }, { status: 400 });
         }
 
         const buffer = await file.arrayBuffer();
-        const fileName = file.name || 'unnamed';
+        const fileName = sanitizeFileName(file.name || 'unnamed');
         const storagePath = `notes/${noteId}/${fileName}`;
 
         const storage = getStorageProvider();
@@ -81,102 +61,59 @@ export async function POST(request: NextRequest) {
 
         const signedUrl = await storage.getSignUrl(storagePath, 3600);
 
-        // Record attachment in database
         const attachmentId = uuidv4();
         try {
             await sql`
-                INSERT INTO app.attachments
-                (id, note_id, user_id, filename, s3_key, mime_type, file_size)
-                VALUES (
-                    ${attachmentId}::uuid,
-                    ${noteId}::uuid,
-                    ${session.user_id}::uuid,
-                    ${fileName},
-                    ${storagePath},
-                    ${file.type || 'application/octet-stream'},
-                    ${file.size}
-                )
+                INSERT INTO app.attachments (id, note_id, user_id, filename, s3_key, mime_type, file_size)
+                VALUES (${attachmentId}::uuid, ${noteId}::uuid, ${session.user_id}::uuid,
+                        ${fileName}, ${storagePath}, ${file.type || 'application/octet-stream'}, ${file.size})
             `;
         } catch (dbError) {
-            console.error('Failed to record attachment in database:', dbError);
-            // Don't fail the upload if DB insert fails, but log it
+            logger.warn('failed to record attachment in database', { error: dbError });
         }
 
-        // Update the note with the S3 key if we created it
         if (createdNewNote) {
             try {
                 await sql`
-                    UPDATE app.notes
-                    SET s3_key = ${storagePath}, updated_at = NOW()
+                    UPDATE app.notes SET s3_key = ${storagePath}, updated_at = NOW()
                     WHERE note_id = ${noteId}::uuid
                 `;
             } catch (updateError) {
-                console.error('Failed to update note with s3_key:', updateError);
+                logger.warn('failed to update note with s3_key', { error: updateError });
             }
         }
 
         return NextResponse.json({
-            success: true,
-            noteId,
-            fileName,
-            path: storagePath,
-            url: signedUrl,
-            size: file.size,
-            type: file.type,
-            attachmentId,
-            createdNewNote,
+            success: true, noteId, fileName, path: storagePath,
+            url: signedUrl, size: file.size, type: file.type, attachmentId, createdNewNote,
         });
     } catch (error) {
-        console.error('Upload error:', error);
-        return NextResponse.json(
-            { error: 'Upload failed' },
-            { status: 500 }
-        );
+        logger.error('upload error', { error });
+        return NextResponse.json({ error: 'Upload failed' }, { status: 500 });
     }
 }
 
 export async function GET(request: NextRequest) {
     try {
-        // Security: Authenticate user before allowing file retrieval
-        const session = await validateSession();
-        if (!session) {
-            return NextResponse.json(
-                { error: 'Unauthorized' },
-                { status: 401 }
-            );
-        }
+        const session = await requireSession();
+        if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
         const path = request.nextUrl.searchParams.get('path');
+        if (!path) return NextResponse.json({ error: 'path query parameter required' }, { status: 400 });
 
-        if (!path) {
-            return NextResponse.json(
-                { error: 'path query parameter required' },
-                { status: 400 }
-            );
-        }
+        // verify the requested path belongs to this user via the attachments table
+        const owned = await sql`
+            SELECT 1 FROM app.attachments
+            WHERE s3_key = ${path} AND user_id = ${session.user_id}::uuid
+            LIMIT 1
+        `;
+        if (!owned.length) return NextResponse.json({ error: 'File not found' }, { status: 404 });
 
         const storage = getStorageProvider();
-        const exists = await storage.hasObject(path);
-
-        if (!exists) {
-            return NextResponse.json(
-                { error: 'File not found' },
-                { status: 404 }
-            );
-        }
-
         const url = await storage.getSignUrl(path, 3600);
-
-        return NextResponse.json({
-            success: true,
-            path,
-            url,
-        });
+        return NextResponse.json({ success: true, path, url });
     } catch (error) {
-        console.error('Retrieve error:', error);
-        return NextResponse.json(
-            { error: error instanceof Error ? error.message : 'Retrieve failed' },
-            { status: 500 }
-        );
+        logger.error('retrieve error', { error });
+        return NextResponse.json({ error: 'Retrieve failed' }, { status: 500 });
     }
 }

--- a/src/components/editor/preview-renderer.tsx
+++ b/src/components/editor/preview-renderer.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeRaw from 'rehype-raw';
+import rehypeSanitize from 'rehype-sanitize';
 
 interface PreviewRendererProps {
   content: string;
@@ -14,7 +15,7 @@ export default function PreviewRenderer({ content }: PreviewRendererProps) {
     <div className="w-full prose prose-lg prose-invert max-w-none" dir="ltr">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeHighlight, rehypeRaw]}
+        rehypePlugins={[rehypeHighlight, rehypeRaw, rehypeSanitize]}
         components={{
           // Links rendered to open in new tabs for safety, styled with hover effects
           a: ({ node, ...props }) => (

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import logger from './logger';
+import { getTraceId, withTrace } from './trace';
+
+export class ApiError extends Error {
+  constructor(
+    public statusCode: number,
+    public userMessage: string,
+    public internalDetails?: string,
+  ) {
+    super(userMessage);
+    this.name = 'ApiError';
+  }
+}
+
+function extractErrorInfo(error: unknown) {
+  if (error instanceof ApiError) {
+    return {
+      userMessage: error.userMessage,
+      statusCode: error.statusCode,
+      logMeta: { statusCode: error.statusCode, internal: error.internalDetails },
+    };
+  }
+  const raw = error instanceof Error ? error.message : String(error);
+  return {
+    userMessage: 'Internal server error',
+    statusCode: 500,
+    logMeta: { message: raw, stack: (error as Error)?.stack },
+  };
+}
+
+export function apiErrorResponse(error: unknown): NextResponse {
+  const { userMessage, statusCode, logMeta } = extractErrorInfo(error);
+  logger.error(userMessage, logMeta);
+  return NextResponse.json({ error: userMessage, traceId: getTraceId() }, { status: statusCode });
+}
+
+type RouteHandler = (request: NextRequest, context?: any) => Promise<NextResponse>;
+
+export function withErrorHandler(handler: RouteHandler): RouteHandler {
+  return (request, context) =>
+    withTrace(async () => {
+      try { return await handler(request, context); }
+      catch (error) { return apiErrorResponse(error); }
+    });
+}

--- a/src/lib/canvas/import-worker.js
+++ b/src/lib/canvas/import-worker.js
@@ -4,37 +4,35 @@
  * Run as a separate process: node -r ./instrumentation.ts src/lib/canvas/import-worker.js
  *
  * Folder hierarchy created per import:
- *   CT101 - Introduction to Computing/
+ *   Course Name/
  *     Module Name/
  *       file.pdf
  *     Assignments/
  *       Assignment Name/
- *         Instructions (markdown note)
  *         attached-file.pdf
  */
 
 import sql from '../../database/pgsql.js';
 import { v4 as uuidv4 } from 'uuid';
+import { SQSClient, ReceiveMessageCommand, DeleteMessageCommand } from '@aws-sdk/client-sqs';
+import { ECSClient, UpdateServiceCommand } from '@aws-sdk/client-ecs';
 import { CanvasClient } from './client.js';
 import { processExtractedText } from './text-processing.js';
 import { chunkText } from '../chunking.ts';
 import { embedChunks } from '../embeddings.ts';
 import { getStorageProvider } from '../storage/init.ts';
 import { addNoteToTree } from '../notes/storage/pg-tree.js';
+import { decrypt } from '../crypto.ts';
 
-// types that get text extracted + embedded for RAG
-const RAG_TYPES = new Set(['application/pdf']);
-// types that get a visible note in the tree (expand as viewers are added)
-const VIEWABLE_TYPES = new Set(['application/pdf']);
-
-const FILE_TIMEOUT_MS = 2 * 60 * 1000;
+const PROCESSABLE_TYPES = new Set(['application/pdf']);
+const FILE_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes per file
 const FILE_CONCURRENCY = 5;
+const STUCK_JOB_THRESHOLD = "1 hour";
+const STUCK_JOB_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+// 30 empty polls × 20s long-poll = ~10 min idle before self-scale-down
+const IDLE_POLLS_BEFORE_SHUTDOWN = 30;
 
-// sentinel IDs for special Canvas structures
-const ASSIGNMENTS_PARENT_MODULE_ID = -1;
-const FORBIDDEN_SENTINEL_ID = 0;
-
-export async function pooled(tasks, limit) {
+async function pooled(tasks, limit) {
   const results = [];
   const executing = new Set();
   for (const task of tasks) {
@@ -47,138 +45,37 @@ export async function pooled(tasks, limit) {
 }
 
 function resolveMimeType(filename, canvasMimeType) {
-  if (canvasMimeType && canvasMimeType !== 'application/octet-stream') return canvasMimeType;
+  if (canvasMimeType && PROCESSABLE_TYPES.has(canvasMimeType)) return canvasMimeType;
   if (filename?.toLowerCase().endsWith('.pdf')) return 'application/pdf';
-  return canvasMimeType || 'application/octet-stream';
+  return canvasMimeType;
 }
 
-// ── Folder naming ───────────────────────────────────────────────────────────
-
-function cleanCourseName(courseCode, courseName) {
-  const codeMatch = courseCode?.match(/^(\d{4})-?(.*)/);
-  const cleanCode = codeMatch?.[2] || courseCode || '';
-  const academicYear = codeMatch?.[1] || null;
-
-  let cleanName = courseName ?? '';
-  if (courseCode && cleanName.startsWith(courseCode)) {
-    cleanName = cleanName.slice(courseCode.length).trim();
-  }
-  if (cleanCode && cleanName.startsWith(cleanCode)) {
-    cleanName = cleanName.slice(cleanCode.length).trim();
-  }
-  cleanName = cleanName.replace(/^[-—–:\s]+/, '').trim();
-
-  const title = cleanCode && cleanName
-    ? `${cleanCode} - ${cleanName}`
-    : cleanCode || cleanName || 'Untitled Course';
-
-  return { title, academicYear };
-}
-
-// ── Folder deduplication ────────────────────────────────────────────────────
-
-// builds the WHERE clause dynamically based on which canvas IDs are present
-function findCanvasFolder(userId, canvas) {
-  const { canvasCourseId, canvasModuleId, canvasAssignmentId } = canvas;
-  if (canvasAssignmentId != null) {
-    return sql`
-      SELECT note_id FROM app.notes
-      WHERE user_id = ${userId}::uuid
-        AND canvas_course_id = ${canvasCourseId}::int
-        AND canvas_assignment_id = ${canvasAssignmentId}::int
-        AND is_folder = true AND deleted = 0
-      LIMIT 1
-    `;
-  }
-  if (canvasModuleId != null) {
-    return sql`
-      SELECT note_id FROM app.notes
-      WHERE user_id = ${userId}::uuid
-        AND canvas_course_id = ${canvasCourseId}::int
-        AND canvas_module_id = ${canvasModuleId}::int
-        AND is_folder = true AND deleted = 0
-      LIMIT 1
-    `;
-  }
-  return sql`
-    SELECT note_id FROM app.notes
-    WHERE user_id = ${userId}::uuid
-      AND canvas_course_id = ${canvasCourseId}::int
-      AND canvas_module_id IS NULL AND canvas_assignment_id IS NULL
-      AND is_folder = true AND deleted = 0
-    LIMIT 1
-  `;
-}
-
-async function findOrCreateFolder(userId, title, parentId, canvas = {}) {
-  const { canvasCourseId, canvasAcademicYear } = canvas;
-
-  // try to find existing folder by canvas IDs
-  if (canvasCourseId != null) {
-    const existing = await findCanvasFolder(userId, canvas);
-    if (existing.length > 0) {
-      await addNoteToTree(userId, existing[0].note_id, parentId ?? null);
-      return existing[0].note_id;
-    }
-  }
-
+async function createNote(userId, title, parentId, { s3Key = null, isFolder = false } = {}) {
   const noteId = uuidv4();
+  await sql`
+    INSERT INTO app.notes (note_id, user_id, title, content, s3_key, is_folder, deleted, created_at, updated_at)
+    VALUES (${noteId}::uuid, ${userId}::uuid, ${title}, '', ${s3Key}, ${isFolder}, 0, NOW(), NOW())
+  `;
+  await addNoteToTree(userId, noteId, parentId ?? null);
+  return noteId;
+}
+
+async function tryCreateFolder(userId, title, parentId, fallback = null) {
   try {
-    await sql`
-      INSERT INTO app.notes (
-        note_id, user_id, title, content, is_folder, deleted,
-        canvas_course_id, canvas_module_id, canvas_assignment_id, canvas_academic_year,
-        created_at, updated_at
-      ) VALUES (
-        ${noteId}::uuid, ${userId}::uuid, ${title}, '', true, 0,
-        ${canvasCourseId ?? null}, ${canvas.canvasModuleId ?? null},
-        ${canvas.canvasAssignmentId ?? null}, ${canvasAcademicYear ?? null},
-        NOW(), NOW()
-      )
-    `;
-    await addNoteToTree(userId, noteId, parentId ?? null);
-    return noteId;
+    return await createNote(userId, title, parentId, { isFolder: true });
   } catch (err) {
-    // unique index conflict — concurrent worker created it first
-    if (err.code === '23505' && canvasCourseId != null) {
-      const winner = await findCanvasFolder(userId, canvas);
-      if (winner.length > 0) {
-        await addNoteToTree(userId, winner[0].note_id, parentId ?? null);
-        return winner[0].note_id;
-      }
-    }
     console.warn(`Failed to create folder "${title}": ${err.message}`);
-    return parentId;
+    return fallback;
   }
 }
 
-// ── Job cancellation ────────────────────────────────────────────────────────
-
-async function isJobCancelled(jobId) {
-  if (!jobId) return false;
-  const [row] = await sql`
-    SELECT status FROM app.canvas_import_jobs WHERE id = ${jobId}
-  `;
-  return row?.status === 'cancelled';
-}
-
-// ── Canvas resource fetching ────────────────────────────────────────────────
-
-async function fetchResource(fetchFn, courseId, ctx) {
-  const { userId, courseTitle, jobId } = ctx;
-  const kind = ctx.kind;
+async function fetchResource(fetchFn, courseId, userId, courseTitle, kind) {
   const { data, forbidden } = await fetchFn(courseId);
   if (forbidden) {
     console.log(`Course ${kind} restricted: ${courseTitle}`);
     await sql`
-      INSERT INTO app.canvas_imports (id, user_id, canvas_course_id, canvas_module_id, canvas_file_id, filename, mime_type, status, error_message, job_id)
-      VALUES (
-        ${uuidv4()}::uuid, ${userId}::uuid, ${courseId}::int,
-        ${FORBIDDEN_SENTINEL_ID}, ${FORBIDDEN_SENTINEL_ID},
-        ${courseTitle + ' (' + kind + ')'}, 'text/plain', 'forbidden',
-        ${'Course ' + kind + ' restricted by lecturer'},
-        ${jobId ?? null}
-      )
+      INSERT INTO app.canvas_imports (id, user_id, canvas_course_id, canvas_module_id, canvas_file_id, filename, mime_type, status, error_message)
+      VALUES (${uuidv4()}::uuid, ${userId}::uuid, ${courseId}::int, 0, 0, ${courseTitle + ' (' + kind + ')'}, 'text/plain', 'forbidden', ${'Course ' + kind + ' restricted by lecturer'})
     `;
   }
   return { data, forbidden };
@@ -194,23 +91,24 @@ async function setImportStatus(importRecordId, status, extra = {}) {
   }
 }
 
-// ── RAG pipeline ────────────────────────────────────────────────────────────
-
 async function processRagPipeline(noteId, userId, buffer) {
   try {
     const { PDFParse } = await import('pdf-parse');
     const parser = new PDFParse({ data: buffer });
     const result = await parser.getText();
+    const rawText = result.text;
 
-    const cleanedText = processExtractedText(result.text);
+    const cleanedText = processExtractedText(rawText);
     const chunks = chunkText(cleanedText);
     const embeddings = await embedChunks(chunks);
 
     await sql`
-      UPDATE app.notes SET extracted_text = ${cleanedText}, updated_at = NOW()
+      UPDATE app.notes
+      SET extracted_text = ${cleanedText}, updated_at = NOW()
       WHERE note_id = ${noteId}
     `;
 
+    // rag.ts searches app.embeddings joined with app.chunks
     for (const { chunk, vector } of embeddings) {
       const [row] = await sql`
         INSERT INTO app.chunks (document_id, user_id, text)
@@ -222,30 +120,22 @@ async function processRagPipeline(noteId, userId, buffer) {
         VALUES (${row.id}, ${JSON.stringify(vector)}::vector)
       `;
     }
+
     console.log(`RAG: ${embeddings.length} chunks embedded for note ${noteId}`);
   } catch (error) {
     console.error(`RAG pipeline error for note ${noteId}:`, error);
   }
 }
 
-// ── File import ─────────────────────────────────────────────────────────────
-
-async function createFileNote(userId, title, parentId, s3Key) {
-  const noteId = uuidv4();
-  await sql`
-    INSERT INTO app.notes (note_id, user_id, title, content, s3_key, is_folder, deleted, created_at, updated_at)
-    VALUES (${noteId}::uuid, ${userId}::uuid, ${title}, '', ${s3Key}, false, 0, NOW(), NOW())
-  `;
-  await addNoteToTree(userId, noteId, parentId ?? null);
-  return noteId;
-}
-
-async function _runFileImport(importRecordId, file, ctx) {
-  const { userId, courseId, parentFolderId, client, storage, s3Prefix, jobId } = ctx;
-  const moduleId = ctx.moduleId ?? ASSIGNMENTS_PARENT_MODULE_ID;
+async function _runFileImport(importRecordId, file, opts) {
+  const { userId, courseId, moduleId, parentFolderId, client, storage, s3Prefix } = opts;
   const resolvedMimeType = resolveMimeType(file.display_name, file.content_type);
 
-  // dedup check
+  if (!PROCESSABLE_TYPES.has(resolvedMimeType)) {
+    console.log(`Skipped (non-processable): ${file.display_name}`);
+    return { skipped: true };
+  }
+
   const existing = await sql`
     SELECT 1 FROM app.canvas_imports
     WHERE user_id = ${userId}::uuid AND canvas_file_id = ${file.id}::int AND status = 'complete'
@@ -256,9 +146,11 @@ async function _runFileImport(importRecordId, file, ctx) {
     return { skipped: true };
   }
 
+  // moduleId = -1 means "assignment file" (Canvas never issues negative module IDs)
+  const moduleIdVal = moduleId ?? -1;
   await sql`
-    INSERT INTO app.canvas_imports (id, user_id, canvas_course_id, canvas_module_id, canvas_file_id, filename, mime_type, status, job_id)
-    VALUES (${importRecordId}::uuid, ${userId}::uuid, ${courseId}::int, ${moduleId}::int, ${file.id}::int, ${file.display_name}, ${resolvedMimeType}, 'downloading', ${jobId ?? null})
+    INSERT INTO app.canvas_imports (id, user_id, canvas_course_id, canvas_module_id, canvas_file_id, filename, mime_type, status)
+    VALUES (${importRecordId}::uuid, ${userId}::uuid, ${courseId}::int, ${moduleIdVal}::int, ${file.id}::int, ${file.display_name}, ${resolvedMimeType}, 'downloading')
   `;
 
   const { buffer, forbidden: dlForbidden } = await client.downloadFile(file.url);
@@ -268,32 +160,23 @@ async function _runFileImport(importRecordId, file, ctx) {
     return;
   }
 
-  // always store to S3
   const s3Key = `${s3Prefix}/${file.filename}`;
   await storage.putObject(s3Key, buffer, { contentType: resolvedMimeType });
   await setImportStatus(importRecordId, 'processing');
 
-  // only create a tree note for viewable types
-  if (VIEWABLE_TYPES.has(resolvedMimeType)) {
-    const noteId = await createFileNote(userId, file.display_name, parentFolderId, s3Key);
-    if (RAG_TYPES.has(resolvedMimeType)) {
-      await processRagPipeline(noteId, userId, buffer);
-    }
-    await setImportStatus(importRecordId, 'complete', { noteId });
-  } else {
-    await setImportStatus(importRecordId, 'complete');
-  }
-
-  console.log(`Processed: ${file.display_name} (${resolvedMimeType})`);
+  const noteId = await createNote(userId, file.display_name, parentFolderId, { s3Key });
+  await processRagPipeline(noteId, userId, buffer);
+  await setImportStatus(importRecordId, 'complete', { noteId });
+  console.log(`Processed: ${file.display_name}`);
 }
 
-async function downloadAndStoreFile(file, ctx) {
+async function downloadAndStoreFile(file, opts) {
   const importRecordId = uuidv4();
   const timer = new Promise((_, reject) =>
     setTimeout(() => reject(new Error(`File timed out after 2 minutes: ${file.display_name}`)), FILE_TIMEOUT_MS)
   );
   try {
-    await Promise.race([_runFileImport(importRecordId, file, ctx), timer]);
+    await Promise.race([_runFileImport(importRecordId, file, opts), timer]);
   } catch (error) {
     console.error(`File processing error (${file.display_name}):`, error);
     try {
@@ -308,198 +191,72 @@ async function downloadAndStoreFile(file, ctx) {
   }
 }
 
-// ── Discovery phase ─────────────────────────────────────────────────────────
-
-async function discoverFileCount(courses, client) {
-  let total = 0;
-  for (const course of courses) {
-    const courseId = String(course.id);
-
-    const { data: modules } = await client.getModules(courseId);
-    if (modules) {
-      for (const mod of modules) {
-        const { data: items } = await client.getModuleItems(courseId, mod.id);
-        if (items) total += items.filter(item => item.type === 'File').length;
-      }
-    }
-
-    const { data: assignments } = await client.getAssignments(courseId);
-    if (assignments) {
-      for (const a of assignments) {
-        const seen = new Set();
-        for (const att of [...(a.attachments ?? []), ...(a.submission?.attachments ?? [])]) {
-          if (!seen.has(att.id)) { seen.add(att.id); total++; }
-        }
-        if (a.description?.trim()) total++;
-      }
-    }
+async function processModules(courseId, userId, courseTitle, courseFolderId, ctx) {
+  const { client, storage } = ctx;
+  const { data: modules } =
+    await fetchResource(id => client.getModules(id), courseId, userId, courseTitle, 'modules');
+  if (!modules) {
+    console.warn(`No modules (or restricted) for course ${courseId}`);
+    return;
   }
-  return total;
-}
-
-// ── Course processing ───────────────────────────────────────────────────────
-
-function stripHtmlToText(html) {
-  if (!html) return '';
-  return html
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<\/p>/gi, '\n\n')
-    .replace(/<\/li>/gi, '\n')
-    .replace(/<li[^>]*>/gi, '- ')
-    .replace(/<\/h[1-6]>/gi, '\n\n')
-    .replace(/<h[1-6][^>]*>/gi, '## ')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, ' ')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-}
-
-async function processModules(courseId, courseFolderId, ctx) {
-  const { client, storage, userId, courseTitle, jobId } = ctx;
-  if (await isJobCancelled(jobId)) return;
-
-  const { data: modules } = await fetchResource(
-    id => client.getModules(id), courseId,
-    { userId, courseTitle, jobId, kind: 'modules' },
-  );
-  if (!modules) return;
-
   await pooled(modules.map(module => async () => {
-    if (await isJobCancelled(jobId)) return;
-
     const { data: items } = await client.getModuleItems(courseId, module.id);
     if (!items) return;
     const fileItems = items.filter(item => item.type === 'File');
     if (fileItems.length === 0) return;
-
-    const folderId = await findOrCreateFolder(userId, module.name, courseFolderId, {
-      canvasCourseId: Number(courseId), canvasModuleId: module.id,
-    });
-
+    const folderId = await tryCreateFolder(userId, module.name, courseFolderId, courseFolderId);
     const metaResults = await pooled(
       fileItems.map(item => async () => {
-        const { data: file, forbidden } = await client.getFile(courseId, item.content_id);
-        if (forbidden || !file) { console.log(`File forbidden: ${item.title}`); return null; }
+        const { data: file, forbidden: fileForbidden } = await client.getFile(courseId, item.content_id);
+        if (fileForbidden || !file) { console.log(`File forbidden: ${item.title}`); return null; }
         return file;
       }),
       FILE_CONCURRENCY,
     );
-    const resolved = metaResults.filter(r => r.status === 'fulfilled' && r.value).map(r => r.value);
-
-    const fileCtx = {
+    const resolved = metaResults
+      .filter(r => r.status === 'fulfilled' && r.value)
+      .map(r => r.value);
+    const opts = {
       userId, courseId, moduleId: module.id, parentFolderId: folderId,
-      client, storage, s3Prefix: `canvas/${userId}/${courseId}/${module.id}`, jobId,
+      client, storage, s3Prefix: `canvas/${userId}/${courseId}/${module.id}`,
     };
-    await pooled(resolved.map(file => () => downloadAndStoreFile(file, fileCtx)), FILE_CONCURRENCY);
+    await pooled(resolved.map(file => () => downloadAndStoreFile(file, opts)), FILE_CONCURRENCY);
   }), FILE_CONCURRENCY);
 }
 
-async function importAssignmentInstructions(assignment, assignmentFolderId, ctx) {
-  const { userId, courseId, jobId } = ctx;
-  if (!assignment.description?.trim()) return;
+async function processAssignments(courseId, userId, courseTitle, courseFolderId, ctx) {
+  const { client, storage } = ctx;
+  const { data: assignments, forbidden } =
+    await fetchResource(id => client.getAssignments(id), courseId, userId, courseTitle, 'assignments');
+  if (forbidden || !assignments || assignments.length === 0) return;
 
-  const instrSentinel = -(assignment.id);
-  const instrExisting = await sql`
-    SELECT 1 FROM app.canvas_imports
-    WHERE user_id = ${userId}::uuid AND canvas_file_id = ${instrSentinel}::int AND status = 'complete'
-    LIMIT 1
-  `;
-  if (instrExisting.length > 0) return;
-
-  try {
-    const instrText = stripHtmlToText(assignment.description);
-    const noteId = await createFileNote(userId, 'Instructions', assignmentFolderId, null);
-    await sql`UPDATE app.notes SET content = ${instrText}, updated_at = NOW() WHERE note_id = ${noteId}::uuid`;
-    await sql`
-      INSERT INTO app.canvas_imports (id, user_id, canvas_course_id, canvas_module_id, canvas_file_id, filename, mime_type, status, note_id, job_id)
-      VALUES (${uuidv4()}::uuid, ${userId}::uuid, ${courseId}::int, ${ASSIGNMENTS_PARENT_MODULE_ID}, ${instrSentinel}::int, ${assignment.name + ' (Instructions)'}, 'text/markdown', 'complete', ${noteId}::uuid, ${jobId ?? null})
-    `;
-    console.log(`Created instructions note for: ${assignment.name}`);
-  } catch (err) {
-    console.warn(`Failed to create instructions for "${assignment.name}": ${err.message}`);
-  }
-}
-
-async function processAssignments(courseId, courseFolderId, ctx) {
-  const { client, storage, userId, courseTitle, jobId } = ctx;
-  if (await isJobCancelled(jobId)) return;
-
-  const { data: assignments, forbidden } = await fetchResource(
-    id => client.getAssignments(id), courseId,
-    { userId, courseTitle, jobId, kind: 'assignments' },
+  const assignmentsWithFiles = assignments.filter(a =>
+    (a.attachments ?? []).some(att => PROCESSABLE_TYPES.has(resolveMimeType(att.display_name, att.content_type)))
   );
-  if (forbidden || !assignments?.length) return;
+  if (assignmentsWithFiles.length === 0) return;
 
-  const relevant = assignments.filter(a => {
-    const hasFiles = (a.attachments ?? []).length > 0 || (a.submission?.attachments ?? []).length > 0;
-    return hasFiles || a.description?.trim();
-  });
-  if (relevant.length === 0) return;
-
-  const assignmentsFolderId = await findOrCreateFolder(userId, 'Assignments', courseFolderId, {
-    canvasCourseId: Number(courseId), canvasModuleId: ASSIGNMENTS_PARENT_MODULE_ID,
-  });
-
-  await pooled(relevant.map(assignment => async () => {
-    if (await isJobCancelled(jobId)) return;
-
-    const assignmentFolderId = await findOrCreateFolder(userId, assignment.name, assignmentsFolderId, {
-      canvasCourseId: Number(courseId), canvasAssignmentId: assignment.id,
-    });
-
-    await importAssignmentInstructions(assignment, assignmentFolderId, { userId, courseId, jobId });
-
-    // merge instructor + submission attachments, dedup by file ID
-    const allAtts = [];
-    const seen = new Set();
-    for (const att of [...(assignment.attachments ?? []), ...(assignment.submission?.attachments ?? [])]) {
-      if (!seen.has(att.id)) { seen.add(att.id); allAtts.push(att); }
-    }
-
-    if (allAtts.length > 0) {
-      const fileCtx = {
-        userId, courseId, parentFolderId: assignmentFolderId,
-        client, storage, s3Prefix: `canvas/${userId}/${courseId}/assignments/${assignment.id}`, jobId,
-      };
-      await pooled(allAtts.map(att => () => downloadAndStoreFile(att, fileCtx)), FILE_CONCURRENCY);
-    }
+  const assignmentsFolderId = await tryCreateFolder(userId, 'Assignments', courseFolderId, courseFolderId);
+  await pooled(assignmentsWithFiles.map(assignment => async () => {
+    const attachments = (assignment.attachments ?? []).filter(att =>
+      PROCESSABLE_TYPES.has(resolveMimeType(att.display_name, att.content_type))
+    );
+    const assignmentFolderId = await tryCreateFolder(userId, assignment.name, assignmentsFolderId, assignmentsFolderId);
+    const opts = {
+      userId, courseId, moduleId: null, parentFolderId: assignmentFolderId,
+      client, storage, s3Prefix: `canvas/${userId}/${courseId}/assignments/${assignment.id}`,
+    };
+    await pooled(attachments.map(att => () => downloadAndStoreFile(att, opts)), FILE_CONCURRENCY);
   }), FILE_CONCURRENCY);
 }
 
 async function processCourse(course, userId, ctx) {
-  const { client, storage, jobId, jobType } = ctx;
+  const { client, storage } = ctx;
   const courseId = String(course.id);
-
-  // skip fully-restricted courses on sync
-  if (jobType === 'sync') {
-    const [restricted] = await sql`
-      SELECT COUNT(DISTINCT CASE
-        WHEN filename LIKE '% (modules)' THEN 'modules'
-        WHEN filename LIKE '% (assignments)' THEN 'assignments'
-      END) AS restricted_kinds
-      FROM app.canvas_imports
-      WHERE user_id = ${userId}::uuid
-        AND canvas_course_id = ${courseId}::int
-        AND status = 'forbidden'
-        AND canvas_file_id = ${FORBIDDEN_SENTINEL_ID}
-    `;
-    if (restricted?.restricted_kinds >= 2) {
-      console.log(`Skipping fully restricted course: ${course.name}`);
-      return;
-    }
-  }
-
-  const { title: courseTitle, academicYear } = cleanCourseName(course.course_code, course.name);
+  const courseTitle = [course.course_code, course.name].filter(Boolean).join(' — ') || courseId;
   console.log(`Processing course: ${courseTitle}`);
-
-  const courseFolderId = await findOrCreateFolder(userId, courseTitle, null, {
-    canvasCourseId: Number(courseId), canvasAcademicYear: academicYear,
-  });
-
-  const courseCtx = { client, storage, userId, courseTitle, jobId };
-  await processModules(courseId, courseFolderId, courseCtx);
-  await processAssignments(courseId, courseFolderId, courseCtx);
+  const courseFolderId = await tryCreateFolder(userId, courseTitle, null);
+  await processModules(courseId, userId, courseTitle, courseFolderId, { client, storage });
+  await processAssignments(courseId, userId, courseTitle, courseFolderId, { client, storage });
 }
 
 function parseJobCourses(job) {
@@ -511,30 +268,14 @@ function parseJobCourses(job) {
   );
 }
 
-async function runJobPipeline(jobId, userId, courses, jobType) {
+async function runJobPipeline(jobId, userId, courses) {
   await sql`UPDATE app.canvas_import_jobs SET status = 'processing', started_at = NOW() WHERE id = ${jobId}`;
   const [creds] = await sql`SELECT canvas_token, canvas_domain FROM app.login WHERE user_id = ${userId}`;
   if (!creds) throw new Error('User or Canvas credentials not found');
-
-  const client = new CanvasClient(creds.canvas_domain, creds.canvas_token);
+  const plainToken = decrypt(creds.canvas_token, userId);
+  const client = new CanvasClient(creds.canvas_domain, plainToken);
   const storage = getStorageProvider();
-
-  // discovery phase: count expected files for accurate progress
-  try {
-    const expectedTotal = await discoverFileCount(courses, client);
-    await sql`UPDATE app.canvas_import_jobs SET expected_total = ${expectedTotal} WHERE id = ${jobId}`;
-    console.log(`Discovery complete: ${expectedTotal} files expected across ${courses.length} courses`);
-  } catch (err) {
-    console.warn(`Discovery phase failed (progress will use fallback): ${err.message}`);
-  }
-
-  await pooled(courses.map(course => () =>
-    processCourse(course, userId, { client, storage, jobId, jobType })
-  ), 3);
-
-  if (jobType === 'sync') {
-    await sql`UPDATE app.login SET canvas_last_sync_at = NOW() WHERE user_id = ${userId}`;
-  }
+  await pooled(courses.map(course => () => processCourse(course, userId, { client, storage })), 3);
 }
 
 // ── Job processing ────────────────────────────────────────────────────────────
@@ -544,13 +285,7 @@ export async function processImportJob(jobId) {
   try {
     const [job] = await sql`SELECT * FROM app.canvas_import_jobs WHERE id = ${jobId}`;
     if (!job) { console.error(`Job not found: ${jobId}`); return false; }
-
-    if (job.status === 'cancelled') {
-      console.log(`Job ${jobId} was cancelled, skipping`);
-      return false;
-    }
-
-    await runJobPipeline(jobId, job.user_id, parseJobCourses(job), job.job_type ?? 'import');
+    await runJobPipeline(jobId, job.user_id, parseJobCourses(job));
     await sql`UPDATE app.canvas_import_jobs SET status = 'complete', completed_at = NOW() WHERE id = ${jobId}`;
     console.log(`Job completed: ${jobId}`);
     return true;
@@ -558,5 +293,112 @@ export async function processImportJob(jobId) {
     console.error(`Job failed: ${jobId}`, error);
     await sql`UPDATE app.canvas_import_jobs SET status = 'failed', error_message = ${error.message}, updated_at = NOW() WHERE id = ${jobId}`;
     return false;
+  }
+}
+
+// ── Worker ────────────────────────────────────────────────────────────────────
+
+async function failStuckJobs() {
+  await sql`
+    UPDATE app.canvas_import_jobs
+    SET status = 'failed', error_message = 'Job timed out', updated_at = NOW()
+    WHERE status = 'processing' AND started_at < NOW() - ${STUCK_JOB_THRESHOLD}::interval
+  `;
+}
+
+// ── SQS polling ──────────────────────────────────────────────────────────────
+
+const sqsClient = new SQSClient({ region: process.env.AWS_REGION ?? 'eu-north-1' });
+const QUEUE_URL = process.env.SQS_QUEUE_URL;
+
+const MAX_CONCURRENT_JOBS = 3;
+
+// defaults to canvas-import for backwards compat
+async function processAndDelete(message) {
+  const body = JSON.parse(message.Body);
+  const type = body.type ?? 'canvas-import';
+  const ts = () => new Date().toISOString();
+
+  console.log(`[${ts()}] Received ${type}: ${body.jobId ?? body.userId ?? 'unknown'}`);
+
+  switch (type) {
+    case 'canvas-import':
+      await processImportJob(body.jobId);
+      break;
+    case 'vault-export':
+      // TODO: enable — export user's vault as zip to S3, update job row
+      console.log(`[${ts()}] vault-export not yet enabled, skipping`);
+      break;
+    case 'vault-import':
+      // TODO: enable — extract uploaded zip, create notes + RAG pipeline
+      console.log(`[${ts()}] vault-import not yet enabled, skipping`);
+      break;
+    default:
+      console.warn(`[${ts()}] Unknown job type: ${type}`);
+  }
+
+  await sqsClient.send(new DeleteMessageCommand({
+    QueueUrl: QUEUE_URL,
+    ReceiptHandle: message.ReceiptHandle,
+  }));
+  console.log(`[${ts()}] Done, message deleted`);
+}
+
+// returns true if messages were processed, false if queue was empty
+async function pollQueue() {
+  const res = await sqsClient.send(new ReceiveMessageCommand({
+    QueueUrl: QUEUE_URL,
+    MaxNumberOfMessages: MAX_CONCURRENT_JOBS,
+    WaitTimeSeconds: 20,
+    VisibilityTimeout: 3600,
+  }));
+
+  const messages = res.Messages ?? [];
+  if (messages.length === 0) return false;
+
+  const results = await Promise.allSettled(messages.map(processAndDelete));
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.error(`[${new Date().toISOString()}] Job processing error:`, result.reason?.message);
+    }
+  }
+  return true;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  console.log(`[${new Date().toISOString()}] Canvas Import Worker started (SQS mode)`);
+
+  await failStuckJobs();
+  setInterval(failStuckJobs, STUCK_JOB_CHECK_INTERVAL_MS);
+
+  let idlePolls = 0;
+
+  while (true) {
+    try {
+      const hadWork = await pollQueue();
+      if (hadWork) {
+        idlePolls = 0;
+      } else {
+        idlePolls++;
+      }
+
+      if (idlePolls >= IDLE_POLLS_BEFORE_SHUTDOWN) {
+        console.log(`[${new Date().toISOString()}] ${IDLE_POLLS_BEFORE_SHUTDOWN} idle polls (~10 min), scaling down`);
+        try {
+          const ecsClient = new ECSClient({ region: process.env.AWS_REGION ?? 'eu-north-1' });
+          await ecsClient.send(new UpdateServiceCommand({
+            cluster: process.env.ECS_CLUSTER ?? 'oghmanotes',
+            service: process.env.ECS_SERVICE ?? 'canvas-import-worker',
+            desiredCount: 0,
+          }));
+        } catch (scaleErr) {
+          console.error(`[${new Date().toISOString()}] Self scale-down failed:`, scaleErr.message);
+        }
+        process.exit(0);
+      }
+    } catch (err) {
+      console.error(`[${new Date().toISOString()}] Poll error:`, err.message);
+      await new Promise(r => setTimeout(r, 5000));
+    }
   }
 }

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,0 +1,27 @@
+import crypto from 'node:crypto';
+
+const SERVER_SECRET = process.env.SERVER_ENCRYPTION_SECRET || 'dev-secret-change-in-prod';
+
+function deriveKey(userId: string): Buffer {
+  return crypto.pbkdf2Sync(SERVER_SECRET, userId, 100_000, 32, 'sha256');
+}
+
+export function encrypt(plaintext: string, userId: string): string {
+  const key = deriveKey(userId);
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, encrypted]).toString('base64');
+}
+
+export function decrypt(ciphertext: string, userId: string): string {
+  const key = deriveKey(userId);
+  const buf = Buffer.from(ciphertext, 'base64');
+  const iv = buf.subarray(0, 12);
+  const tag = buf.subarray(12, 28);
+  const encrypted = buf.subarray(28);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  return decipher.update(encrypted).toString('utf8') + decipher.final('utf8');
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,78 @@
+import winston from 'winston';
+import 'winston-daily-rotate-file';
+import { traceFormat } from './trace';
+
+const SENSITIVE_KEYS = new Set([
+  'password',
+  'token',
+  'canvas_token',
+  'reset_token',
+  'authorization',
+  'hashed_password',
+  'secret',
+]);
+
+function redactObject(obj: unknown): unknown {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) return obj.map(redactObject);
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      result[key] = '[REDACTED]';
+    } else {
+      result[key] = typeof value === 'object' ? redactObject(value) : value;
+    }
+  }
+  return result;
+}
+
+export const redactSensitive = winston.format((info) => {
+  for (const [key, value] of Object.entries(info)) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      info[key] = '[REDACTED]';
+    } else if (typeof value === 'object' && value !== null) {
+      info[key] = redactObject(value);
+    }
+  }
+  return info;
+})();
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+const transports: winston.transport[] = [
+  new winston.transports.Console({
+    format: isProduction
+      ? winston.format.json()
+      : winston.format.combine(
+          winston.format.colorize(),
+          winston.format.simple(),
+        ),
+  }),
+];
+
+if (isProduction) {
+  transports.push(
+    new winston.transports.DailyRotateFile({
+      filename: 'logs/app-%DATE%.log',
+      datePattern: 'YYYY-MM-DD',
+      maxSize: '100m',
+      maxFiles: '14d',
+      format: winston.format.json(),
+    }),
+  );
+}
+
+const logger = winston.createLogger({
+  level: isProduction ? 'info' : 'debug',
+  defaultMeta: { service: 'oghmanotes' },
+  format: winston.format.combine(
+    traceFormat,
+    redactSensitive,
+    winston.format.timestamp(),
+  ),
+  transports,
+});
+
+export default logger;

--- a/src/lib/rateLimit.js
+++ b/src/lib/rateLimit.js
@@ -29,6 +29,7 @@ const CONFIG = {
  * @returns {boolean} True if account is locked
  */
 export function isAccountLocked(email) {
+    email = email.toLowerCase().trim();
     const state = authProtection.get(email);
     if (!state) return false;
 
@@ -49,6 +50,7 @@ export function isAccountLocked(email) {
  * @returns {boolean} True if account is currently rate-limited
  */
 export function isRateLimited(email) {
+    email = email.toLowerCase().trim();
     const state = authProtection.get(email);
     if (!state) return false;
 
@@ -69,6 +71,7 @@ export function isRateLimited(email) {
  * @param {string} email - User email address
  */
 export function recordFailedAttempt(email) {
+    email = email.toLowerCase().trim();
     const now = Date.now();
     let state = authProtection.get(email);
 
@@ -100,6 +103,7 @@ export function recordFailedAttempt(email) {
  * @param {string} email - User email address
  */
 export function clearFailedAttempts(email) {
+    email = email.toLowerCase().trim();
     authProtection.delete(email);
 }
 
@@ -111,6 +115,7 @@ export function clearFailedAttempts(email) {
  * @returns {number} Minutes remaining until unlock (0 if not locked)
  */
 export function getLockoutMinutesRemaining(email) {
+    email = email.toLowerCase().trim();
     const state = authProtection.get(email);
     if (!state || !state.lockedUntil) return 0;
 
@@ -128,6 +133,7 @@ export function getLockoutMinutesRemaining(email) {
  * @returns {number} Seconds until rate limit resets (0 if not rate limited)
  */
 export function getRateLimitResetTime(email) {
+    email = email.toLowerCase().trim();
     const state = authProtection.get(email);
     if (!state) return 0;
 

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -1,0 +1,27 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import crypto from 'node:crypto';
+import winston from 'winston';
+
+interface TraceContext {
+  traceId: string;
+}
+
+export const traceStore = new AsyncLocalStorage<TraceContext>();
+
+export function generateTraceId(): string {
+  return crypto.randomUUID().slice(0, 8);
+}
+
+export function getTraceId(): string {
+  return traceStore.getStore()?.traceId ?? 'no-trace';
+}
+
+export function withTrace<T>(fn: () => Promise<T>): Promise<T> {
+  return traceStore.run({ traceId: generateTraceId() }, fn);
+}
+
+// winston format that injects the current trace id into log info
+export const traceFormat = winston.format((info) => {
+  info.traceId = getTraceId();
+  return info;
+})();

--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -1,13 +1,13 @@
 // validation utilities for forms, inputs, and auth
+import validatorPkg from 'validator';
+const { isEmail } = validatorPkg;
 
-// email
-
+// email — uses validator.isEmail for thorough RFC validation
 export function isValidEmail(email) {
     if (!email || typeof email !== 'string') {
         return false;
     }
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email.trim());
+    return isEmail(email.trim(), { allow_ip_domain: false, require_tld: true });
 }
 
 export function validateEmail(email) {


### PR DESCRIPTION
## Summary

- **Structured logging**: Winston with JSON format, AsyncLocalStorage trace IDs, sensitive field redaction, `withErrorHandler` HOF for API routes
- **BYOK Canvas token encryption**: AES-256-GCM with PBKDF2 key derivation from userId + SERVER_ENCRYPTION_SECRET
- **SSRF prevention**: URL scheme validation, private IP/metadata blocking, 30s AbortController timeout in extract API
- **Path traversal fix**: `sanitizeFileName()` strips `/`, `\`, `..` from upload filenames
- **Upload GET ownership**: verifies s3_key belongs to authenticated user via attachments table
- **Share route authorization**: removed `OR shared = 1`, only note owner can share
- **Password reset token hashing**: SHA-256 hash stored in DB, raw token emailed, hash compared on verify
- **Email enumeration timing**: artificial delay on "email not found" path
- **XSS prevention**: added rehype-sanitize after rehypeRaw in markdown preview
- **Rate limit bypass fix**: email case normalization across all 6 exported functions
- **Canvas domain validation**: enforces `*.instructure.com` regex
- **Canvas logs bug fix**: jobId branch now filters by job's created_at
- **Security headers**: X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy
- **Email validation**: switched to validator.isEmail for RFC-compliant checking

## Test plan
- [x] 66 tests pass (vitest)
- [ ] Manual: upload file with `../` in name — should be sanitized
- [ ] Manual: extract API with `http://169.254.169.254/` — should be rejected
- [ ] Manual: share a note you don't own — should be denied
- [ ] Manual: `<script>alert(1)</script>` in note preview — should not execute
- [ ] Manual: Canvas connect with non-instructure.com domain — should be rejected