### PR TITLE
fix: prompt injection, redis rate limiting, RDS SSL, input validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,12 @@ STORAGE_SECRET_KEY=your-secret
 MAX_FILE_SIZE=104857600
 PRESIGNED_URL_EXPIRY=3600
 
+# Redis (ElastiCache / local)
+REDIS_HOST=localhost
+REDIS_PORT=6379
+# set REDIS_TLS=true for ElastiCache cluster mode
+REDIS_TLS=false
+
 # Runtime
 NODE_ENV=development
 PORT=3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@lexical/rich-text": "^0.41.0",
         "@radix-ui/react-context-menu": "2.2.16",
         "allotment": "^1.20.5",
+        "aws-ssl-profiles": "^1.1.2",
         "bcryptjs": "^3.0.3",
         "better-auth": "^1.4.18",
         "clsx": "^2.1.1",
@@ -7951,6 +7952,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/aws4": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@lexical/rich-text": "^0.41.0",
     "@radix-ui/react-context-menu": "2.2.16",
     "allotment": "^1.20.5",
+    "aws-ssl-profiles": "^1.1.2",
     "bcryptjs": "^3.0.3",
     "better-auth": "^1.4.18",
     "clsx": "^2.1.1",

--- a/src/__tests__/lib/rateLimit.test.js
+++ b/src/__tests__/lib/rateLimit.test.js
@@ -1,4 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// mock redis module so tests use the in-memory fallback without
+// attempting a real connection
+vi.mock('@/lib/redis', () => ({
+    redis: {},
+    redisReady: false,
+}));
+
+// mock logger to avoid winston init side effects in tests
+vi.mock('@/lib/logger', () => ({
+    default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
 import {
     isAccountLocked,
     isRateLimited,
@@ -10,9 +23,9 @@ import {
 
 const EMAIL = 'test@example.com';
 
-beforeEach(() => {
+beforeEach(async () => {
     vi.useFakeTimers();
-    clearFailedAttempts(EMAIL);
+    await clearFailedAttempts(EMAIL);
 });
 
 afterEach(() => {
@@ -20,90 +33,90 @@ afterEach(() => {
 });
 
 describe('recordFailedAttempt + isRateLimited', () => {
-    it('is not rate limited with zero attempts', () => {
-        expect(isRateLimited(EMAIL)).toBe(false);
+    it('is not rate limited with zero attempts', async () => {
+        expect(await isRateLimited(EMAIL)).toBe(false);
     });
 
-    it('is not rate limited below threshold (4 attempts)', () => {
-        for (let i = 0; i < 4; i++) recordFailedAttempt(EMAIL);
-        expect(isRateLimited(EMAIL)).toBe(false);
+    it('is not rate limited below threshold (4 attempts)', async () => {
+        for (let i = 0; i < 4; i++) await recordFailedAttempt(EMAIL);
+        expect(await isRateLimited(EMAIL)).toBe(false);
     });
 
-    it('is rate limited at exactly 5 attempts', () => {
-        for (let i = 0; i < 5; i++) recordFailedAttempt(EMAIL);
-        expect(isRateLimited(EMAIL)).toBe(true);
+    it('is rate limited at exactly 5 attempts', async () => {
+        for (let i = 0; i < 5; i++) await recordFailedAttempt(EMAIL);
+        expect(await isRateLimited(EMAIL)).toBe(true);
     });
 
-    it('resets after the 15-minute window expires', () => {
-        for (let i = 0; i < 5; i++) recordFailedAttempt(EMAIL);
-        expect(isRateLimited(EMAIL)).toBe(true);
+    it('resets after the 15-minute window expires', async () => {
+        for (let i = 0; i < 5; i++) await recordFailedAttempt(EMAIL);
+        expect(await isRateLimited(EMAIL)).toBe(true);
 
         // advance past the 15-minute window
         vi.advanceTimersByTime(15 * 60 * 1000 + 1);
-        expect(isRateLimited(EMAIL)).toBe(false);
+        expect(await isRateLimited(EMAIL)).toBe(false);
     });
 });
 
 describe('isAccountLocked', () => {
-    it('is not locked with no attempts', () => {
-        expect(isAccountLocked(EMAIL)).toBe(false);
+    it('is not locked with no attempts', async () => {
+        expect(await isAccountLocked(EMAIL)).toBe(false);
     });
 
-    it('locks account after 5 failed attempts', () => {
-        for (let i = 0; i < 5; i++) recordFailedAttempt(EMAIL);
-        expect(isAccountLocked(EMAIL)).toBe(true);
+    it('locks account after 5 failed attempts', async () => {
+        for (let i = 0; i < 5; i++) await recordFailedAttempt(EMAIL);
+        expect(await isAccountLocked(EMAIL)).toBe(true);
     });
 
-    it('unlocks after 30-minute lockout duration', () => {
-        for (let i = 0; i < 5; i++) recordFailedAttempt(EMAIL);
-        expect(isAccountLocked(EMAIL)).toBe(true);
+    it('unlocks after 30-minute lockout duration', async () => {
+        for (let i = 0; i < 5; i++) await recordFailedAttempt(EMAIL);
+        expect(await isAccountLocked(EMAIL)).toBe(true);
 
         vi.advanceTimersByTime(30 * 60 * 1000);
-        expect(isAccountLocked(EMAIL)).toBe(false);
+        expect(await isAccountLocked(EMAIL)).toBe(false);
     });
 });
 
 describe('clearFailedAttempts', () => {
-    it('resets rate limit and lockout state', () => {
-        for (let i = 0; i < 5; i++) recordFailedAttempt(EMAIL);
-        expect(isRateLimited(EMAIL)).toBe(true);
-        expect(isAccountLocked(EMAIL)).toBe(true);
+    it('resets rate limit and lockout state', async () => {
+        for (let i = 0; i < 5; i++) await recordFailedAttempt(EMAIL);
+        expect(await isRateLimited(EMAIL)).toBe(true);
+        expect(await isAccountLocked(EMAIL)).toBe(true);
 
-        clearFailedAttempts(EMAIL);
-        expect(isRateLimited(EMAIL)).toBe(false);
-        expect(isAccountLocked(EMAIL)).toBe(false);
+        await clearFailedAttempts(EMAIL);
+        expect(await isRateLimited(EMAIL)).toBe(false);
+        expect(await isAccountLocked(EMAIL)).toBe(false);
     });
 });
 
 describe('getLockoutMinutesRemaining', () => {
-    it('returns 0 when not locked', () => {
-        expect(getLockoutMinutesRemaining(EMAIL)).toBe(0);
+    it('returns 0 when not locked', async () => {
+        expect(await getLockoutMinutesRemaining(EMAIL)).toBe(0);
     });
 
-    it('returns ~30 minutes immediately after lockout', () => {
-        for (let i = 0; i < 5; i++) recordFailedAttempt(EMAIL);
-        const mins = getLockoutMinutesRemaining(EMAIL);
+    it('returns ~30 minutes immediately after lockout', async () => {
+        for (let i = 0; i < 5; i++) await recordFailedAttempt(EMAIL);
+        const mins = await getLockoutMinutesRemaining(EMAIL);
         expect(mins).toBeGreaterThanOrEqual(29);
         expect(mins).toBeLessThanOrEqual(30);
     });
 
-    it('decreases over time', () => {
-        for (let i = 0; i < 5; i++) recordFailedAttempt(EMAIL);
+    it('decreases over time', async () => {
+        for (let i = 0; i < 5; i++) await recordFailedAttempt(EMAIL);
         vi.advanceTimersByTime(10 * 60 * 1000); // 10 min
-        const mins = getLockoutMinutesRemaining(EMAIL);
+        const mins = await getLockoutMinutesRemaining(EMAIL);
         expect(mins).toBeGreaterThanOrEqual(19);
         expect(mins).toBeLessThanOrEqual(20);
     });
 });
 
 describe('getRateLimitResetTime', () => {
-    it('returns 0 when no attempts recorded', () => {
-        expect(getRateLimitResetTime(EMAIL)).toBe(0);
+    it('returns 0 when no attempts recorded', async () => {
+        expect(await getRateLimitResetTime(EMAIL)).toBe(0);
     });
 
-    it('returns seconds until window reset', () => {
-        recordFailedAttempt(EMAIL);
-        const seconds = getRateLimitResetTime(EMAIL);
+    it('returns seconds until window reset', async () => {
+        await recordFailedAttempt(EMAIL);
+        const seconds = await getRateLimitResetTime(EMAIL);
         // should be close to 15 minutes in seconds
         expect(seconds).toBeGreaterThan(14 * 60);
         expect(seconds).toBeLessThanOrEqual(15 * 60);
@@ -111,9 +124,20 @@ describe('getRateLimitResetTime', () => {
 });
 
 describe('isolation between emails', () => {
-    it('does not affect a different email', () => {
-        for (let i = 0; i < 5; i++) recordFailedAttempt(EMAIL);
-        expect(isRateLimited(EMAIL)).toBe(true);
-        expect(isRateLimited('other@example.com')).toBe(false);
+    it('does not affect a different email', async () => {
+        for (let i = 0; i < 5; i++) await recordFailedAttempt(EMAIL);
+        expect(await isRateLimited(EMAIL)).toBe(true);
+        expect(await isRateLimited('other@example.com')).toBe(false);
+    });
+});
+
+describe('email normalization', () => {
+    it('treats different cases of the same email as identical', async () => {
+        await recordFailedAttempt('User@Example.COM');
+        await recordFailedAttempt('user@example.com');
+        await recordFailedAttempt('USER@EXAMPLE.COM');
+        await recordFailedAttempt('  user@example.com  ');
+        await recordFailedAttempt('user@example.com');
+        expect(await isRateLimited('USER@Example.com')).toBe(true);
     });
 });

--- a/src/app/api/auth/login/route.js
+++ b/src/app/api/auth/login/route.js
@@ -33,8 +33,8 @@ export async function POST(request) {
         }
 
         // 3. Check if account is locked due to too many failed attempts
-        if (isAccountLocked(email)) {
-            const minutesRemaining = getLockoutMinutesRemaining(email);
+        if (await isAccountLocked(email)) {
+            const minutesRemaining = await getLockoutMinutesRemaining(email);
             return createErrorResponse(
                 `Account temporarily locked. Try again in ${minutesRemaining} minute${minutesRemaining !== 1 ? 's' : ''}.`,
                 429
@@ -42,7 +42,7 @@ export async function POST(request) {
         }
 
         // 4. Check rate limit (prevents brute force even with multiple accounts)
-        if (isRateLimited(email)) {
+        if (await isRateLimited(email)) {
             return createErrorResponse(
                 'Too many login attempts. Please try again later.',
                 429
@@ -60,7 +60,7 @@ export async function POST(request) {
 
         if (!user) {
             // Record failed attempt for security tracking
-            recordFailedAttempt(email);
+            await recordFailedAttempt(email);
             return createErrorResponse('Invalid email or password', 401);
         }
 
@@ -84,12 +84,12 @@ export async function POST(request) {
 
         if (!matchingPassword) {
             // Record failed attempt for security tracking
-            recordFailedAttempt(email);
+            await recordFailedAttempt(email);
             return createErrorResponse('Invalid email or password', 401);
         }
 
         // 7. Successful login - clear failed attempt counters
-        clearFailedAttempts(email);
+        await clearFailedAttempts(email);
 
         // 8. Create auth session (generates JWT, sets cookie, returns response)
         const sessionResponse = await createAuthSession(user, 1);

--- a/src/app/api/notes/[id]/route.js
+++ b/src/app/api/notes/[id]/route.js
@@ -8,6 +8,9 @@ import { mapNoteFromDB } from '@/lib/notes/utils/map-note';
 import sql from '@/database/pgsql.js';
 import logger from '@/lib/logger';
 
+const MAX_TITLE_LENGTH = 500;
+const MAX_CONTENT_LENGTH = 5 * 1024 * 1024; // 5MB
+
 export async function GET(request, { params }) {
   try {
     // Get authenticated user
@@ -86,6 +89,22 @@ export async function PUT(request, { params }) {
     }
 
     const body = await request.json();
+
+    // validate input lengths
+    if (body.title && body.title.length > MAX_TITLE_LENGTH) {
+      logger.warn('note title exceeds max length', { length: body.title.length, noteId });
+      return NextResponse.json(
+        { error: `Title must be ${MAX_TITLE_LENGTH} characters or fewer` },
+        { status: 400 }
+      );
+    }
+    if (body.content && body.content.length > MAX_CONTENT_LENGTH) {
+      logger.warn('note content exceeds max length', { length: body.content.length, noteId });
+      return NextResponse.json(
+        { error: `Content must be ${MAX_CONTENT_LENGTH} bytes or fewer` },
+        { status: 400 }
+      );
+    }
 
     // Get existing note (verify ownership)
     const result = await sql`

--- a/src/app/api/notes/route.js
+++ b/src/app/api/notes/route.js
@@ -11,6 +11,8 @@ import logger from '@/lib/logger';
 const NOTE_DELETED = { NORMAL: 0, DELETED: 1 };
 const NOTE_PINNED = { UNPINNED: 0, PINNED: 1 };
 const NOTE_SHARED = { PRIVATE: 0, SHARED: 1 };
+const MAX_TITLE_LENGTH = 500;
+const MAX_CONTENT_LENGTH = 5 * 1024 * 1024; // 5MB
 
 export async function GET(request) {
   try {
@@ -77,7 +79,23 @@ export async function POST(request) {
     }
 
     const body = await request.json();
-    
+
+    // validate input lengths
+    if (body.title && body.title.length > MAX_TITLE_LENGTH) {
+      logger.warn('note title exceeds max length', { length: body.title.length });
+      return NextResponse.json(
+        { error: `Title must be ${MAX_TITLE_LENGTH} characters or fewer` },
+        { status: 400 }
+      );
+    }
+    if (body.content && body.content.length > MAX_CONTENT_LENGTH) {
+      logger.warn('note content exceeds max length', { length: body.content.length });
+      return NextResponse.json(
+        { error: `Content must be ${MAX_CONTENT_LENGTH} bytes or fewer` },
+        { status: 400 }
+      );
+    }
+
     // Generate UUID v7 for note
     const noteId = generateUUID();
     

--- a/src/database/pgsql.js
+++ b/src/database/pgsql.js
@@ -1,4 +1,5 @@
 import postgres from 'postgres';
+import { rds } from 'aws-ssl-profiles';
 
 // lazy connection - only created on first use, not at module load
 // this ensures runtime env vars are available (not build-time values)
@@ -14,11 +15,9 @@ function getSQL() {
             );
         }
         const requiresSSL = url.includes('sslmode=require');
-        // RDS uses Amazon's own CA which isn't in Node's default trust store.
-        // rejectUnauthorized: false is safe here — we connect to a known RDS
-        // endpoint over AWS networking, not an arbitrary server.
+        // use the bundled AWS RDS CA certificates for proper TLS verification
         sql = postgres(url, {
-            ssl: requiresSSL ? { rejectUnauthorized: false } : false,
+            ssl: requiresSSL ? { ca: rds.ca } : false,
             // Connection timeout settings (in milliseconds)
             idle_in_transaction_session_timeout: 30000, // 30s - max time for transaction
             statement_timeout: 30000, // 30s - max time for a single query

--- a/src/lib/rateLimit.js
+++ b/src/lib/rateLimit.js
@@ -5,11 +5,15 @@
  * - Rate limiting: Tracks failed login attempts in a sliding window (15 min)
  * - Account lockout: Locks account after exceeding max attempts (30 min)
  *
- * Implementation: In-memory store (per-process); resets on server restart.
- * TODO: Scale to multiple servers using Redis for persistent lockout state.
+ * Implementation: Redis-backed (shared across instances) with in-memory
+ * fallback when Redis is unavailable (local dev, connection failure).
+ * Email keys are normalized with toLowerCase().trim() to prevent bypass.
  */
 
-// Single in-memory storage for all auth protection: { "email": { count, lockedUntil, ... } }
+import { redis, redisReady } from '@/lib/redis';
+import logger from '@/lib/logger';
+
+// in-memory fallback for when redis is unavailable
 const authProtection = new Map();
 
 /**
@@ -18,77 +22,151 @@ const authProtection = new Map();
 const CONFIG = {
     MAX_ATTEMPTS: 5,
     WINDOW_MS: 15 * 60 * 1000,      // 15 min sliding window for rate limiting
-    LOCK_DURATION_MS: 30 * 60 * 1000 // 30 min account lockout duration
+    LOCK_DURATION_MS: 30 * 60 * 1000, // 30 min account lockout duration
+    WINDOW_SECS: 15 * 60,            // 15 min in seconds (for redis TTL)
+    LOCK_SECS: 30 * 60,              // 30 min in seconds (for redis TTL)
 };
 
-/**
- * Checks if an account is currently locked due to too many failed attempts.
- * Automatically clears lock if duration has expired.
- *
- * @param {string} email - User email address
- * @returns {boolean} True if account is locked
- */
-export function isAccountLocked(email) {
-    email = email.toLowerCase().trim();
+// redis key prefixes
+const KEY = {
+    attempts: (email) => `ratelimit:attempts:${email}`,
+    window:   (email) => `ratelimit:window:${email}`,
+    lockout:  (email) => `ratelimit:lockout:${email}`,
+};
+
+function normalize(email) {
+    return email.toLowerCase().trim();
+}
+
+function useRedis() {
+    return redisReady;
+}
+
+// ── Redis-backed implementations ────────────────────────────────────────────
+
+async function redisIsAccountLocked(email) {
+    const lockUntil = await redis.get(KEY.lockout(email));
+    if (!lockUntil) return false;
+
+    const now = Date.now();
+    if (now >= parseInt(lockUntil, 10)) {
+        // lock expired, clean up
+        await redis.del(KEY.lockout(email));
+        return false;
+    }
+    return true;
+}
+
+async function redisIsRateLimited(email) {
+    const [countStr, windowResetStr] = await redis.mget(
+        KEY.attempts(email),
+        KEY.window(email),
+    );
+    if (!countStr) return false;
+
+    const now = Date.now();
+    if (windowResetStr && now > parseInt(windowResetStr, 10)) {
+        // window expired, clean up
+        await redis.del(KEY.attempts(email), KEY.window(email));
+        return false;
+    }
+
+    return parseInt(countStr, 10) >= CONFIG.MAX_ATTEMPTS;
+}
+
+async function redisRecordFailedAttempt(email) {
+    const now = Date.now();
+    const windowResetStr = await redis.get(KEY.window(email));
+
+    // reset if window expired or no window exists
+    if (!windowResetStr || now > parseInt(windowResetStr, 10)) {
+        const windowReset = now + CONFIG.WINDOW_MS;
+        // set count to 1 and window reset time atomically with pipeline
+        const pipeline = redis.pipeline();
+        pipeline.set(KEY.attempts(email), '1', 'EX', CONFIG.WINDOW_SECS);
+        pipeline.set(KEY.window(email), String(windowReset), 'EX', CONFIG.WINDOW_SECS);
+        await pipeline.exec();
+
+        // first attempt can never trigger lockout (need MAX_ATTEMPTS)
+        return;
+    }
+
+    // increment within existing window
+    const newCount = await redis.incr(KEY.attempts(email));
+
+    // lock account if threshold exceeded
+    if (newCount >= CONFIG.MAX_ATTEMPTS) {
+        const lockUntil = now + CONFIG.LOCK_DURATION_MS;
+        await redis.set(KEY.lockout(email), String(lockUntil), 'EX', CONFIG.LOCK_SECS);
+    }
+}
+
+async function redisClearFailedAttempts(email) {
+    await redis.del(
+        KEY.attempts(email),
+        KEY.window(email),
+        KEY.lockout(email),
+    );
+}
+
+async function redisGetLockoutMinutesRemaining(email) {
+    const lockUntil = await redis.get(KEY.lockout(email));
+    if (!lockUntil) return 0;
+
+    const remainingMs = parseInt(lockUntil, 10) - Date.now();
+    return Math.max(0, Math.ceil(remainingMs / 1000 / 60));
+}
+
+async function redisGetRateLimitResetTime(email) {
+    const windowReset = await redis.get(KEY.window(email));
+    if (!windowReset) return 0;
+
+    const remainingMs = parseInt(windowReset, 10) - Date.now();
+    return Math.max(0, Math.ceil(remainingMs / 1000));
+}
+
+// ── In-memory fallback implementations ──────────────────────────────────────
+
+function memIsAccountLocked(email) {
     const state = authProtection.get(email);
     if (!state) return false;
 
     const now = Date.now();
-    // Lock period expired - auto-clear
     if (now >= state.lockedUntil) {
         authProtection.delete(email);
         return false;
     }
-
     return true;
 }
 
-/**
- * Checks if an email has exceeded rate limit attempts in the current window.
- *
- * @param {string} email - User email address
- * @returns {boolean} True if account is currently rate-limited
- */
-export function isRateLimited(email) {
-    email = email.toLowerCase().trim();
+function memIsRateLimited(email) {
     const state = authProtection.get(email);
     if (!state) return false;
 
     const now = Date.now();
-    // Window expired - reset
     if (now > state.windowResetTime) {
         authProtection.delete(email);
         return false;
     }
-
     return state.count >= CONFIG.MAX_ATTEMPTS;
 }
 
-/**
- * Records a failed login attempt for an account.
- * Locks the account if MAX_ATTEMPTS is exceeded.
- *
- * @param {string} email - User email address
- */
-export function recordFailedAttempt(email) {
-    email = email.toLowerCase().trim();
+function memRecordFailedAttempt(email) {
     const now = Date.now();
     let state = authProtection.get(email);
 
-    // Initialize or reset if window expired
     if (!state || now > state.windowResetTime) {
         state = {
             count: 0,
             windowResetTime: now + CONFIG.WINDOW_MS,
             lockedUntil: 0,
-            lastAttempt: now
+            lastAttempt: now,
         };
     }
 
     state.count++;
     state.lastAttempt = now;
 
-    // Lock account if threshold exceeded
     if (state.count >= CONFIG.MAX_ATTEMPTS) {
         state.lockedUntil = now + CONFIG.LOCK_DURATION_MS;
     }
@@ -96,49 +174,129 @@ export function recordFailedAttempt(email) {
     authProtection.set(email, state);
 }
 
+function memClearFailedAttempts(email) {
+    authProtection.delete(email);
+}
+
+function memGetLockoutMinutesRemaining(email) {
+    const state = authProtection.get(email);
+    if (!state || !state.lockedUntil) return 0;
+
+    const remainingMs = state.lockedUntil - Date.now();
+    return Math.max(0, Math.ceil(remainingMs / 1000 / 60));
+}
+
+function memGetRateLimitResetTime(email) {
+    const state = authProtection.get(email);
+    if (!state) return 0;
+
+    const remainingMs = state.windowResetTime - Date.now();
+    return Math.max(0, Math.ceil(remainingMs / 1000));
+}
+
+// ── Public API (async, redis-first with fallback) ───────────────────────────
+
+/**
+ * Checks if an account is currently locked due to too many failed attempts.
+ * @param {string} email
+ * @returns {Promise<boolean>}
+ */
+export async function isAccountLocked(email) {
+    email = normalize(email);
+    if (useRedis()) {
+        try {
+            return await redisIsAccountLocked(email);
+        } catch (err) {
+            logger.warn('redis rate-limit read failed, falling back to memory', { fn: 'isAccountLocked', message: err.message });
+        }
+    }
+    return memIsAccountLocked(email);
+}
+
+/**
+ * Checks if an email has exceeded rate limit attempts in the current window.
+ * @param {string} email
+ * @returns {Promise<boolean>}
+ */
+export async function isRateLimited(email) {
+    email = normalize(email);
+    if (useRedis()) {
+        try {
+            return await redisIsRateLimited(email);
+        } catch (err) {
+            logger.warn('redis rate-limit read failed, falling back to memory', { fn: 'isRateLimited', message: err.message });
+        }
+    }
+    return memIsRateLimited(email);
+}
+
+/**
+ * Records a failed login attempt for an account.
+ * Locks the account if MAX_ATTEMPTS is exceeded.
+ * @param {string} email
+ * @returns {Promise<void>}
+ */
+export async function recordFailedAttempt(email) {
+    email = normalize(email);
+    if (useRedis()) {
+        try {
+            await redisRecordFailedAttempt(email);
+            return;
+        } catch (err) {
+            logger.warn('redis rate-limit write failed, falling back to memory', { fn: 'recordFailedAttempt', message: err.message });
+        }
+    }
+    memRecordFailedAttempt(email);
+}
+
 /**
  * Clears failed attempt count for an email (called after successful login).
- * Resets both rate limit and lockout state.
- *
- * @param {string} email - User email address
+ * @param {string} email
+ * @returns {Promise<void>}
  */
-export function clearFailedAttempts(email) {
-    email = email.toLowerCase().trim();
-    authProtection.delete(email);
+export async function clearFailedAttempts(email) {
+    email = normalize(email);
+    if (useRedis()) {
+        try {
+            await redisClearFailedAttempts(email);
+            return;
+        } catch (err) {
+            logger.warn('redis rate-limit write failed, falling back to memory', { fn: 'clearFailedAttempts', message: err.message });
+        }
+    }
+    memClearFailedAttempts(email);
 }
 
 /**
  * Gets the remaining time (in minutes) until the account unlock.
- * Useful for error messages: "Account locked for X more minutes"
- *
- * @param {string} email - User email address
- * @returns {number} Minutes remaining until unlock (0 if not locked)
+ * @param {string} email
+ * @returns {Promise<number>} Minutes remaining until unlock (0 if not locked)
  */
-export function getLockoutMinutesRemaining(email) {
-    email = email.toLowerCase().trim();
-    const state = authProtection.get(email);
-    if (!state || !state.lockedUntil) return 0;
-
-    const now = Date.now();
-    const remainingMs = state.lockedUntil - now;
-
-    return Math.max(0, Math.ceil(remainingMs / 1000 / 60));
+export async function getLockoutMinutesRemaining(email) {
+    email = normalize(email);
+    if (useRedis()) {
+        try {
+            return await redisGetLockoutMinutesRemaining(email);
+        } catch (err) {
+            logger.warn('redis rate-limit read failed, falling back to memory', { fn: 'getLockoutMinutesRemaining', message: err.message });
+        }
+    }
+    return memGetLockoutMinutesRemaining(email);
 }
 
 /**
  * Gets the remaining time (in seconds) until the rate limit resets.
- * Useful for error messages: "Try again in X minutes"
- *
- * @param {string} email - User email address
- * @returns {number} Seconds until rate limit resets (0 if not rate limited)
+ * @param {string} email
+ * @returns {Promise<number>} Seconds until rate limit resets (0 if not rate limited)
  */
-export function getRateLimitResetTime(email) {
-    email = email.toLowerCase().trim();
-    const state = authProtection.get(email);
-    if (!state) return 0;
-
-    const now = Date.now();
-    const remainingMs = state.windowResetTime - now;
-
-    return Math.max(0, Math.ceil(remainingMs / 1000));
+export async function getRateLimitResetTime(email) {
+    email = normalize(email);
+    if (useRedis()) {
+        try {
+            return await redisGetRateLimitResetTime(email);
+        } catch (err) {
+            logger.warn('redis rate-limit read failed, falling back to memory', { fn: 'getRateLimitResetTime', message: err.message });
+        }
+    }
+    return memGetRateLimitResetTime(email);
 }

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,4 +1,5 @@
 import Redis, { Cluster } from 'ioredis';
+import logger from '@/lib/logger';
 
 const host = process.env.REDIS_HOST ?? 'localhost';
 const port = parseInt(process.env.REDIS_PORT ?? '6379', 10);
@@ -20,6 +21,19 @@ export const redis: Cluster | Redis = tls
     })
   : new Redis({ host, port, ...redisOptions, retryStrategy: (times) => Math.min(times * 100, 3000) });
 
+// track connection state for consumers that need to know if redis is available
+export let redisReady = false;
+
+redis.on('ready', () => {
+  redisReady = true;
+  logger.info('redis connection established');
+});
+
 redis.on('error', (err) => {
-  console.error('[redis] connection error:', err.message);
+  redisReady = false;
+  logger.error('redis connection error', { message: err.message });
+});
+
+redis.on('close', () => {
+  redisReady = false;
 });

--- a/src/lib/rerank.ts
+++ b/src/lib/rerank.ts
@@ -10,19 +10,52 @@
  */
 
 import { getOpenWebUIToken, invalidateToken } from './openwebuiAuth';
+import logger from '@/lib/logger';
 
 const LLM_URL = process.env.LLM_API_URL;
 const LLM_MODEL = process.env.LLM_MODEL ?? 'qwen3:8b';
 const TOP_N = 3;
+const MAX_QUERY_LENGTH = 500;
+
+// patterns that look like prompt injection attempts
+const INJECTION_PATTERNS = /^(ignore|system:|assistant:|human:|user:|<\|.*?\|>|###)/im;
+
+/**
+ * sanitize user query before embedding in the reranker prompt.
+ * strips control chars, truncates, and removes instruction-like lines.
+ */
+function sanitizeQuery(raw: string): string {
+    // strip control characters (keep spaces 0x20, newlines 0x0a, tabs 0x09)
+    let cleaned = raw.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
+
+    // truncate to max length
+    if (cleaned.length > MAX_QUERY_LENGTH) {
+        cleaned = cleaned.slice(0, MAX_QUERY_LENGTH);
+        logger.warn('reranker: query truncated to %d chars', MAX_QUERY_LENGTH);
+    }
+
+    // remove lines that look like injection attempts
+    const lines = cleaned.split('\n');
+    const safe = lines.filter(line => !INJECTION_PATTERNS.test(line.trim()));
+    if (safe.length < lines.length) {
+        logger.warn('reranker: stripped %d injection-like lines from query', lines.length - safe.length);
+    }
+    cleaned = safe.join('\n').trim();
+
+    return cleaned || 'empty query';
+}
 
 export async function rerankChunks(query: string, chunks: string[]): Promise<string[]> {
     if (chunks.length <= TOP_N) return chunks;
 
+    const safeQuery = sanitizeQuery(query);
     const numbered = chunks.map((c, i) => `[${i + 1}] ${c.slice(0, 300)}`).join('\n\n');
 
     const prompt = `You are a relevance ranker. Given a query and a list of passages, return only the indices of the ${TOP_N} most relevant passages in order of relevance, as a comma-separated list like: 3,1,7
 
-Query: ${query}
+<user_query>
+${safeQuery}
+</user_query>
 
 Passages:
 ${numbered}


### PR DESCRIPTION
## Summary
- **Prompt injection (#9)**: `sanitizeQuery()` in reranker strips control chars, truncates to 500 chars, removes injection patterns, wraps user input in `<user_query>` XML delimiters
- **Redis rate limiting (#10+#11)**: Replaces in-memory `Map` with ioredis-backed storage using atomic `INCR`/`EXPIRE`. Falls back to in-memory if Redis unavailable. Email keys normalized with `.toLowerCase().trim()` to prevent bypass via case variations
- **RDS SSL (#13)**: Replaces `rejectUnauthorized: false` with `aws-ssl-profiles` CA bundle for proper TLS cert verification
- **Input validation (#16)**: Note titles capped at 500 chars, content at 5MB, with 400 responses on violation

## Test plan
- [x] 144 vitest tests pass (12 suites)
- [x] New test for email normalization in rate limiter
- [x] Rate limiter gracefully falls back to in-memory when Redis unavailable
- [x] Login route updated to await all async rate limit calls