### PR TITLE
fix: unset empty-string env vars to fix Amplify build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,13 @@
 ## Critical Rules
 
 ### 1. Development Server
+
 - **Assume** `npm run dev` is always running in background
 - **Never restart or modify** the dev server unless explicitly instructed
 - Check `/tmp/dev.pid` for current process status if needed
 
 ### 2. Git Safety Protocol
+
 - **Never execute destructive git operations** without verified backup strategy
 - All staged changes must be committed or stashed before any risky operations
 - Verify `git status` shows clean working tree or all files are staged before:
@@ -18,16 +20,21 @@
 - For complex operations, create temporary commit first, then amend/squash if needed
 
 ### 3. Package Manager
+
 - **Use `npm` only** — do not use `pnpm` or `yarn`
 - All install/run commands must use `npm install`, `npm run`, etc.
 
 ### 4. Branch & Deploy Strategy
+
 - **`main`** is the production branch — deployed to oghmanotes.ie via AWS Amplify
 - **`dev`** is the development branch — deployed to dev.oghmanotes.ie
 - deploy flow: `dev` → `main` (via PR)
 - never push directly to `main` — always go through PR with required status checks
+- **Amplify app**: `d22kmou82nb1c5` in `eu-north-1`, auto-builds on push to `main` and `dev`
+- **Build env**: runtime-only env vars (DATABASE_URL, NEXTAUTH_URL, etc.) are unset before `npm run build` to prevent empty-string values from crashing SSR prerendering — they are written to `.env.production` for runtime use only
 
 ### 5. Code Changes
+
 - Never silently drop uncommitted work
 - Always verify file staging status before operations that affect the working tree
 - If unsure about data safety, create a backup branch or stash first

--- a/amplify.yml
+++ b/amplify.yml
@@ -45,27 +45,35 @@ frontend:
         - npm ci --include=dev --legacy-peer-deps
     build:
       commands:
-        # write runtime env vars without exposing values in build logs
+        # write runtime env vars to .env.production for SSR runtime,
+        # then UNSET them so empty-string values don't break the build.
+        # next-auth crashes with new URL("") if NEXTAUTH_URL is "" at import time.
         - |
-          for var in DATABASE_URL JWT_SECRET STORAGE_BUCKET STORAGE_ACCESS_KEY \
+          RUNTIME_VARS="DATABASE_URL JWT_SECRET STORAGE_BUCKET STORAGE_ACCESS_KEY \
             STORAGE_SECRET_KEY STORAGE_REGION STORAGE_ENDPOINT STORAGE_PREFIX \
-            NEXT_PUBLIC_API_URL REDIS_HOST REDIS_PORT REDIS_TLS \
+            REDIS_HOST REDIS_PORT REDIS_TLS \
             LLM_API_URL LLM_API_KEY LLM_MODEL EMBEDDING_API_URL EMBEDDING_MODEL \
             SQS_QUEUE_URL SQS_EXTRACT_RETRY_QUEUE_URL \
             MARKER_EC2_INSTANCE_ID MARKER_API_URL DATALAB_API_KEY \
-            NEXTAUTH_SECRET NEXT_PUBLIC_APP_URL \
+            NEXTAUTH_SECRET NEXTAUTH_URL \
             GOOGLE_ID GOOGLE_SECRET GITHUB_ID GITHUB_SECRET \
             ENABLE_CREDENTIALS_AUTH SERVER_ENCRYPTION_SECRET COHERE_API_KEY \
-            NEXTAUTH_URL \
-            SES_REGION SES_ACCESS_KEY_ID SES_SECRET_ACCESS_KEY SES_FROM_EMAIL; do
+            SES_REGION SES_ACCESS_KEY_ID SES_SECRET_ACCESS_KEY SES_FROM_EMAIL"
+          ALL_VARS="$RUNTIME_VARS NEXT_PUBLIC_API_URL NEXT_PUBLIC_APP_URL"
+          for var in $ALL_VARS; do
             [ -n "${!var}" ] && echo "${var}=${!var}" >> .env.production || true
+          done
+          # unset runtime-only vars so next build doesn't see "" as the value
+          # (NEXT_PUBLIC_* must stay — they're inlined into the client bundle)
+          for var in $RUNTIME_VARS; do
+            unset "$var"
           done
         - npm run build
   artifacts:
     baseDirectory: .next
     files:
-      - '**/*'
-      - '../.env.production'
+      - "**/*"
+      - "../.env.production"
   cache:
     paths:
       - node_modules/**/*

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,10 +4,7 @@ const nextConfig = {
     serverExternalPackages: ['postgres', 'winston-cloudwatch'],
     // standalone output generates NFT trace files required by Amplify SSR
     output: 'standalone',
-    // Use webpack bundler instead of Turbopack for builds
-    experimental: {
-        turbo: undefined,
-    },
+
     async headers() {
         return [
             {


### PR DESCRIPTION
## Summary

- Fixes the Amplify build failure on both `main` and `dev` (all 7 builds on main and 11 on dev were failing)
- Root cause: `next-auth/utils/parse-url.js` uses nullish coalescing, so `NEXTAUTH_URL=""` passes through to `new URL("")` which throws `TypeError: Invalid URL` during `/login` page prerendering
- The `amplify.yml` `env.variables` section sets all vars (including `NEXTAUTH_URL`) to `$VAR_NAME` references — when these aren't configured in the Amplify console, they resolve to empty string `""` instead of `undefined`

## Changes

- **amplify.yml**: After writing env vars to `.env.production` for runtime, `unset` all runtime-only vars so `next build` sees `undefined` (safe fallback) instead of `""` (crash). `NEXT_PUBLIC_*` vars are kept since they're inlined into the client bundle at build time.
- **next.config.mjs**: Remove dead `experimental.turbo: undefined` config that Next.js 16 warns about
- **AGENTS.md**: Document Amplify app ID and build env strategy

## Verification

- Reproduced locally: `NEXTAUTH_URL="" npm run build` → crash on `/login`
- Verified fix: `npm run build` (without NEXTAUTH_URL) → all 56 pages generated successfully
- Amplify dev build #37: **SUCCEED**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build stability by preventing potential server-side rendering failures related to environment variable handling.

* **Chores**
  * Updated AWS deployment configuration with auto-build settings.
  * Refined build process configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->