### PR TITLE
fix: add missing useI18n() hook call in CanvasImportToast

### DIFF
--- a/src/components/CanvasImportToast.jsx
+++ b/src/components/CanvasImportToast.jsx
@@ -14,6 +14,7 @@ export default function CanvasImportToast({
   progress,
   onViewLogs,
 }) {
+  const { t } = useI18n();
   const {
     total = 0,
     completed = 0,


### PR DESCRIPTION
## Summary
- Agent added `import useI18n` but never called `const { t } = useI18n()` in the component body
- Caused `ReferenceError: t is not defined` at runtime whenever Canvas import toast rendered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed translation initialization in the canvas import dialog to ensure text displays correctly in the user's selected language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->