### PR TITLE
fix: guard logged_hours against null before .toFixed()

### DIFF
--- a/src/components/panels/assignment-tracker.tsx
+++ b/src/components/panels/assignment-tracker.tsx
@@ -330,12 +330,13 @@ export default function AssignmentTracker() {
                     <div
                       className="h-full rounded-full bg-primary-500/60 transition-all"
                       style={{
-                        width: `${Math.min(100, (a.logged_hours / a.estimated_hours) * 100)}%`,
+                        width: `${Math.min(100, ((Number(a.logged_hours) || 0) / a.estimated_hours) * 100)}%`,
                       }}
                     />
                   </div>
                   <p className="mt-0.5 text-[9px] text-text-tertiary">
-                    {a.logged_hours.toFixed(1)}/{a.estimated_hours}h
+                    {(Number(a.logged_hours) || 0).toFixed(1)}/
+                    {a.estimated_hours}h
                   </p>
                 </div>
               )}


### PR DESCRIPTION
logged_hours can be null or a string from the DB, causing toFixed is not a function at runtime in assignment-tracker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed logging hours display in the assignment tracker to properly handle numeric values and prevent calculation errors. Logged hours now display with one decimal place and include an improved layout for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->