### PR TITLE
test(quiz): stop assuming shuffled option order

### DIFF
--- a/src/__tests__/lib/quiz/normalize-question.test.ts
+++ b/src/__tests__/lib/quiz/normalize-question.test.ts
@@ -33,7 +33,12 @@ describe("normalizeQuizOptions", () => {
     ]);
     const result = normalizeQuizOptions(raw);
     expect(result).toHaveLength(2);
-    expect(result![0]).toEqual({ text: "A", is_correct: true });
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { text: "A", is_correct: true },
+        { text: "B", is_correct: false },
+      ]),
+    );
   });
 
   it("returns null for an empty JSON array string", () => {
@@ -53,7 +58,12 @@ describe("normalizeQuizOptions", () => {
     };
     const result = normalizeQuizOptions(input);
     expect(result).toHaveLength(2);
-    expect(result![1]).toEqual({ text: "Y", is_correct: true });
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { text: "X", is_correct: false },
+        { text: "Y", is_correct: true },
+      ]),
+    );
   });
 
   it("unwraps options from a JSON string of wrapped object", () => {
@@ -96,10 +106,7 @@ describe("normalizeQuizOptions", () => {
   });
 
   it("returns null when all entries are invalid", () => {
-    const input = [
-      { text: 1, is_correct: "no" },
-      null,
-    ];
+    const input = [{ text: 1, is_correct: "no" }, null];
     expect(normalizeQuizOptions(input)).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- make quiz option normalization tests order-insensitive
- match existing behavior that shuffles non-True/False options

## Test Plan
- [x] `npm run test:ci -- src/__tests__/lib/quiz/normalize-question.test.ts`
- [x] `npm run test:ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertions for quiz option normalization validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->