### PR TITLE
fix(chat): search unindexed notes

### DIFF
--- a/src/__tests__/lib/chat-chunk-search.test.ts
+++ b/src/__tests__/lib/chat-chunk-search.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/database/pgsql.js", () => {
+  const sqlMock = vi.fn();
+  sqlMock.mockResolvedValue([]);
+  return { default: sqlMock };
+});
+
+vi.mock("@/lib/embedText", () => ({
+  embedText: vi.fn(),
+}));
+
+import sql from "@/database/pgsql.js";
+import { embedText } from "@/lib/embedText";
+import { searchChatChunks } from "@/lib/chat/chunk-search";
+
+describe("searchChatChunks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sql).mockResolvedValue([]);
+    vi.mocked(embedText).mockResolvedValue([0.1, 0.2, 0.3]);
+  });
+
+  it("falls back to note text when exact chunk search finds nothing", async () => {
+    vi.mocked(sql)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          note_id: "11111111-1111-1111-1111-111111111111",
+          title: "Lecture 1",
+          snippet: "The OSI model has seven layers.",
+        },
+      ]);
+
+    const results = await searchChatChunks({
+      userId: "22222222-2222-2222-2222-222222222222",
+      query: "OSI model",
+      mode: "exact",
+      scopedNoteIds: ["11111111-1111-1111-1111-111111111111"],
+    });
+
+    expect(results).toEqual([
+      {
+        noteId: "11111111-1111-1111-1111-111111111111",
+        title: "Lecture 1",
+        chunkId: "note:11111111-1111-1111-1111-111111111111",
+        text: "The OSI model has seven layers.",
+        source: "exact-note",
+      },
+    ]);
+  });
+
+  it("applies folder scope to exact search and note fallback queries", async () => {
+    const scopedNoteIds = ["33333333-3333-3333-3333-333333333333"];
+
+    vi.mocked(sql)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          note_id: scopedNoteIds[0],
+          title: "Lecture 2",
+          snippet: "TCP/IP maps cleanly onto the lower OSI layers.",
+        },
+      ]);
+
+    await searchChatChunks({
+      userId: "44444444-4444-4444-4444-444444444444",
+      query: "TCP/IP",
+      mode: "exact",
+      scopedNoteIds,
+    });
+
+    expect(vi.mocked(sql).mock.calls).toHaveLength(2);
+    expect(vi.mocked(sql).mock.calls[0]).toContainEqual(scopedNoteIds);
+    expect(vi.mocked(sql).mock.calls[1]).toContainEqual(scopedNoteIds);
+  });
+
+  it("does not require embeddings for exact-only search", async () => {
+    vi.mocked(sql)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          note_id: "55555555-5555-5555-5555-555555555555",
+          title: "Lecture 3",
+          snippet: "Switching works at layer 2.",
+        },
+      ]);
+
+    const results = await searchChatChunks({
+      userId: "66666666-6666-6666-6666-666666666666",
+      query: "switching",
+      mode: "exact",
+    });
+
+    expect(embedText).not.toHaveBeenCalled();
+    expect(results).toHaveLength(1);
+    expect(results[0]?.source).toBe("exact-note");
+  });
+
+  it("skips note fallback duplicates when exact chunk hits already exist", async () => {
+    vi.mocked(sql)
+      .mockResolvedValueOnce([
+        {
+          note_id: "77777777-7777-7777-7777-777777777777",
+          title: "Lecture 4",
+          chunk_id: "88888888-8888-8888-8888-888888888888",
+          chunk_text: "Routers operate at layer 3.",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          note_id: "77777777-7777-7777-7777-777777777777",
+          title: "Lecture 4",
+          snippet: "Routers operate at layer 3 and forward packets.",
+        },
+      ]);
+
+    const results = await searchChatChunks({
+      userId: "99999999-9999-9999-9999-999999999999",
+      query: "routers",
+      mode: "exact",
+    });
+
+    expect(results).toEqual([
+      {
+        noteId: "77777777-7777-7777-7777-777777777777",
+        title: "Lecture 4",
+        chunkId: "88888888-8888-8888-8888-888888888888",
+        text: "Routers operate at layer 3.",
+        source: "exact",
+      },
+    ]);
+  });
+});

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -35,7 +35,7 @@ import {
   buildSystemPrompt,
   runRagPipeline,
 } from "@/lib/chat/rag-pipeline";
-import { embedText } from "@/lib/embedText";
+import { searchChatChunks } from "@/lib/chat/chunk-search";
 import {
   type ChatMessage,
   persistMessage,
@@ -424,86 +424,14 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       mode: z.enum(["semantic", "exact", "both"]).default("semantic"),
     }),
     execute: async ({ query, mode }) => {
-      type ChunkHit = {
-        noteId: string;
-        title: string;
-        chunkId: string;
-        text: string;
-        source: string;
-      };
-      const seen = new Set<string>();
-      const results: ChunkHit[] = [];
+      const results = await searchChatChunks({
+        userId,
+        query,
+        mode,
+        scopedNoteIds,
+      });
 
-      const add = (
-        noteId: string,
-        title: string,
-        chunkId: string,
-        text: string,
-        source: string,
-      ) => {
-        if (seen.has(chunkId)) return;
-        seen.add(chunkId);
-        results.push({
-          noteId,
-          title,
-          chunkId,
-          text: text.slice(0, 400),
-          source,
-        });
-      };
-
-      if (mode === "semantic" || mode === "both") {
-        try {
-          const vec = await embedText(query);
-          const vectorStr = `[${vec.join(",")}]`;
-          const scope = scopedNoteIds && scopedNoteIds.length > 0;
-          const rows: any[] = scope
-            ? await sql`
-                SELECT n.note_id, n.title, c.id AS chunk_id, c.text AS chunk_text
-                FROM app.embeddings e
-                JOIN app.chunks c ON c.id = e.chunk_id
-                JOIN app.notes n ON n.note_id = c.document_id
-                WHERE c.user_id = ${userId}::uuid
-                  AND c.document_id = ANY(${scopedNoteIds}::uuid[])
-                  AND (e.embedding <=> ${vectorStr}::vector) < 0.75
-                ORDER BY e.embedding <=> ${vectorStr}::vector
-                LIMIT 10
-              `
-            : await sql`
-                SELECT n.note_id, n.title, c.id AS chunk_id, c.text AS chunk_text
-                FROM app.embeddings e
-                JOIN app.chunks c ON c.id = e.chunk_id
-                JOIN app.notes n ON n.note_id = c.document_id
-                WHERE c.user_id = ${userId}::uuid
-                  AND (e.embedding <=> ${vectorStr}::vector) < 0.75
-                ORDER BY e.embedding <=> ${vectorStr}::vector
-                LIMIT 10
-              `;
-          for (const r of rows)
-            add(r.note_id, r.title, r.chunk_id, r.chunk_text, "semantic");
-        } catch {
-          // embedding unavailable
-        }
-      }
-
-      if (mode === "exact" || mode === "both") {
-        const safe = query.replace(/%/g, "\\%").replace(/_/g, "\\_");
-        const rows: any[] = await sql`
-          SELECT n.note_id, n.title, c.id AS chunk_id, c.text AS chunk_text
-          FROM app.chunks c
-          JOIN app.notes n ON n.note_id = c.document_id
-          WHERE c.user_id = ${userId}::uuid
-            AND n.is_folder = false
-            AND n.deleted = 0
-            AND n.deleted_at IS NULL
-            AND c.text ILIKE ${"%" + safe + "%"}
-          LIMIT 10
-        `;
-        for (const r of rows)
-          add(r.note_id, r.title, r.chunk_id, r.chunk_text, "exact");
-      }
-
-      return { results: results.slice(0, 12) };
+      return { results };
     },
   });
 

--- a/src/lib/chat/chunk-search.ts
+++ b/src/lib/chat/chunk-search.ts
@@ -1,0 +1,192 @@
+import sql from "@/database/pgsql.js";
+import { embedText } from "@/lib/embedText";
+
+const MAX_DISTANCE = 0.75;
+const MAX_RESULTS = 12;
+const QUERY_LIMIT = 10;
+
+export type ChatChunkSearchMode = "semantic" | "exact" | "both";
+
+export interface ChatChunkHit {
+  noteId: string;
+  title: string;
+  chunkId: string;
+  text: string;
+  source: string;
+}
+
+interface SearchChatChunksParams {
+  userId: string;
+  query: string;
+  mode: ChatChunkSearchMode;
+  scopedNoteIds?: string[] | null;
+}
+
+function normalizeSnippet(text: string): string {
+  return text.replace(/\s+/g, " ").trim().slice(0, 400);
+}
+
+export async function searchChatChunks({
+  userId,
+  query,
+  mode,
+  scopedNoteIds,
+}: SearchChatChunksParams): Promise<ChatChunkHit[]> {
+  const scoped = !!(scopedNoteIds && scopedNoteIds.length > 0);
+  const seenChunkIds = new Set<string>();
+  const results: ChatChunkHit[] = [];
+
+  const add = (
+    noteId: string,
+    title: string,
+    chunkId: string,
+    text: string,
+    source: string,
+  ) => {
+    if (seenChunkIds.has(chunkId)) return;
+    seenChunkIds.add(chunkId);
+    results.push({
+      noteId,
+      title,
+      chunkId,
+      text: normalizeSnippet(text),
+      source,
+    });
+  };
+
+  if (mode === "semantic" || mode === "both") {
+    try {
+      const vec = await embedText(query);
+      const vectorStr = `[${vec.join(",")}]`;
+      const rows: any[] = scoped
+        ? await sql`
+            SELECT n.note_id, n.title, c.id AS chunk_id, c.text AS chunk_text
+            FROM app.embeddings e
+            JOIN app.chunks c ON c.id = e.chunk_id
+            JOIN app.notes n ON n.note_id = c.document_id
+            WHERE c.user_id = ${userId}::uuid
+              AND c.document_id = ANY(${scopedNoteIds}::uuid[])
+              AND (e.embedding <=> ${vectorStr}::vector) < ${MAX_DISTANCE}
+            ORDER BY e.embedding <=> ${vectorStr}::vector
+            LIMIT ${QUERY_LIMIT}
+          `
+        : await sql`
+            SELECT n.note_id, n.title, c.id AS chunk_id, c.text AS chunk_text
+            FROM app.embeddings e
+            JOIN app.chunks c ON c.id = e.chunk_id
+            JOIN app.notes n ON n.note_id = c.document_id
+            WHERE c.user_id = ${userId}::uuid
+              AND (e.embedding <=> ${vectorStr}::vector) < ${MAX_DISTANCE}
+            ORDER BY e.embedding <=> ${vectorStr}::vector
+            LIMIT ${QUERY_LIMIT}
+          `;
+
+      for (const row of rows) {
+        add(row.note_id, row.title, row.chunk_id, row.chunk_text, "semantic");
+      }
+    } catch {
+      // embedding unavailable
+    }
+  }
+
+  if (mode === "exact" || mode === "both") {
+    const safe = query.replace(/%/g, "\\%").replace(/_/g, "\\_");
+    const pattern = `%${safe}%`;
+
+    const chunkRows: any[] = scoped
+      ? await sql`
+          SELECT n.note_id, n.title, c.id AS chunk_id, c.text AS chunk_text
+          FROM app.chunks c
+          JOIN app.notes n ON n.note_id = c.document_id
+          WHERE c.user_id = ${userId}::uuid
+            AND n.note_id = ANY(${scopedNoteIds}::uuid[])
+            AND n.is_folder = false
+            AND n.deleted = 0
+            AND n.deleted_at IS NULL
+            AND c.text ILIKE ${pattern}
+          LIMIT ${QUERY_LIMIT}
+        `
+      : await sql`
+          SELECT n.note_id, n.title, c.id AS chunk_id, c.text AS chunk_text
+          FROM app.chunks c
+          JOIN app.notes n ON n.note_id = c.document_id
+          WHERE c.user_id = ${userId}::uuid
+            AND n.is_folder = false
+            AND n.deleted = 0
+            AND n.deleted_at IS NULL
+            AND c.text ILIKE ${pattern}
+          LIMIT ${QUERY_LIMIT}
+        `;
+
+    for (const row of chunkRows) {
+      add(row.note_id, row.title, row.chunk_id, row.chunk_text, "exact");
+    }
+
+    const noteRows: any[] = scoped
+      ? await sql`
+          WITH matches AS (
+            SELECT
+              note_id,
+              title,
+              COALESCE(NULLIF(TRIM(extracted_text), ''), NULLIF(TRIM(content), ''), '') AS search_text
+            FROM app.notes
+            WHERE user_id = ${userId}::uuid
+              AND note_id = ANY(${scopedNoteIds}::uuid[])
+              AND is_folder = false
+              AND deleted = 0
+              AND deleted_at IS NULL
+          )
+          SELECT
+            note_id,
+            title,
+            SUBSTRING(
+              search_text
+              FROM GREATEST(POSITION(LOWER(${query}) IN LOWER(search_text)) - 80, 1)
+              FOR 400
+            ) AS snippet
+          FROM matches
+          WHERE search_text ILIKE ${pattern}
+          LIMIT ${QUERY_LIMIT}
+        `
+      : await sql`
+          WITH matches AS (
+            SELECT
+              note_id,
+              title,
+              COALESCE(NULLIF(TRIM(extracted_text), ''), NULLIF(TRIM(content), ''), '') AS search_text
+            FROM app.notes
+            WHERE user_id = ${userId}::uuid
+              AND is_folder = false
+              AND deleted = 0
+              AND deleted_at IS NULL
+          )
+          SELECT
+            note_id,
+            title,
+            SUBSTRING(
+              search_text
+              FROM GREATEST(POSITION(LOWER(${query}) IN LOWER(search_text)) - 80, 1)
+              FOR 400
+            ) AS snippet
+          FROM matches
+          WHERE search_text ILIKE ${pattern}
+          LIMIT ${QUERY_LIMIT}
+        `;
+
+    const noteIdsWithChunkHits = new Set(
+      results.map((result) => result.noteId),
+    );
+    for (const row of noteRows) {
+      if (noteIdsWithChunkHits.has(row.note_id)) continue;
+      add(
+        row.note_id,
+        row.title,
+        `note:${row.note_id}`,
+        row.snippet,
+        "exact-note",
+      );
+    }
+  }
+
+  return results.slice(0, MAX_RESULTS);
+}


### PR DESCRIPTION
## Summary
- fix chat exact search so it respects scoped note IDs
- add fallback exact search against note content and extracted text when chunk rows are missing
- extract the chat chunk search helper and cover the fix with regression tests

## Test Plan
- [x] npm test -- src/__tests__/lib/chat-chunk-search.test.ts
- [x] npm run test:ci
- [x] npm exec eslint src/lib/chat/chunk-search.ts src/app/api/chat/route.ts src/__tests__/lib/chat-chunk-search.test.ts
- [x] npm run build
- [x] smoke-test the built app: GET /api/health -> 200, unauthenticated /chat and /api/chat -> 307 /login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced chat search with semantic, exact, and hybrid search modes
  * Improved result deduplication and ranking
  * Search results can be scoped to specific notes

* **Tests**
  * Added comprehensive test coverage for search functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->