### PR TITLE
fix(chat): suppress hydration mismatch on date/time nodes

### DIFF
--- a/database/migrations/014_embeddings_openrouter_4096.sql
+++ b/database/migrations/014_embeddings_openrouter_4096.sql
@@ -1,0 +1,18 @@
+-- switch embeddings to 4096 dims for Qwen3-Embedding-8B via OpenRouter
+--
+-- all existing chunks+embeddings are cleared — they were 1024-dim Cohere vectors,
+-- incompatible with the new 4096-dim model. a full re-index is required after.
+--
+-- pgvector hnsw/ivfflat max is 2000 dims, so no ANN index at this size.
+-- with ~14K chunks, sequential scan is fast enough (<50ms on RDS).
+
+-- 1. drop hnsw index (incompatible with new dimension)
+DROP INDEX IF EXISTS app.idx_embeddings_hnsw;
+
+-- 2. clear stale data
+DELETE FROM app.embeddings;
+DELETE FROM app.chunks;
+
+-- 3. widen column to 4096 dims
+ALTER TABLE app.embeddings
+  ALTER COLUMN embedding TYPE vector(4096);

--- a/scripts/reindex-all-notes.mjs
+++ b/scripts/reindex-all-notes.mjs
@@ -1,0 +1,178 @@
+// full re-index: reads all notes with content, chunks, embeds via Cohere, stores
+// run after migration 014 to repopulate the empty chunks+embeddings tables
+//
+// usage: node --import=tsx scripts/reindex-all-notes.mjs [--dry-run]
+
+import fs from "fs";
+import path from "path";
+import sql from "../src/database/pgsql.js";
+import { chunkText } from "../src/lib/chunking.ts";
+import { embedChunks } from "../src/lib/embeddings.ts";
+import { normalizeChunksForIndexing } from "../src/lib/rag/indexing.ts";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const EMBED_BATCH = 96; // Cohere limit
+// small concurrency to stay under Cohere rate limits
+const NOTE_BATCH = 50;
+
+function loadEnv() {
+  for (const filename of [".env.local", ".env"]) {
+    const filePath = path.join(process.cwd(), filename);
+    if (!fs.existsSync(filePath)) continue;
+
+    const content = fs.readFileSync(filePath, "utf8");
+    for (const line of content.split(/\r?\n/)) {
+      if (!line || line.startsWith("#")) continue;
+      const separator = line.indexOf("=");
+      if (separator === -1) continue;
+
+      const key = line.slice(0, separator).trim();
+      const value = line.slice(separator + 1).trim();
+      if (!process.env[key]) process.env[key] = value;
+    }
+
+    break;
+  }
+}
+
+async function fetchNotesWithContent(offset, limit) {
+  return sql`
+    SELECT note_id, user_id, title,
+           COALESCE(NULLIF(TRIM(extracted_text), ''), NULLIF(TRIM(content), '')) AS text
+    FROM app.notes
+    WHERE deleted = 0
+      AND deleted_at IS NULL
+      AND is_folder = false
+      AND (
+        (extracted_text IS NOT NULL AND TRIM(extracted_text) != '')
+        OR (content IS NOT NULL AND TRIM(content) != '')
+      )
+    ORDER BY created_at ASC
+    OFFSET ${offset} LIMIT ${limit}
+  `;
+}
+
+async function main() {
+  loadEnv();
+
+  const FORCE = process.argv.includes("--force");
+  if (DRY_RUN) console.log("=== DRY RUN — no writes ===\n");
+
+  // with --force, wipe existing chunks+embeddings and rebuild from scratch
+  if (FORCE && !DRY_RUN) {
+    console.log("--force: clearing all existing chunks and embeddings...");
+    await sql`DELETE FROM app.embeddings`;
+    await sql`DELETE FROM app.chunks`;
+    console.log("cleared.\n");
+  }
+
+  // count total notes to process
+  const [{ count }] = await sql`
+    SELECT COUNT(*) AS count
+    FROM app.notes
+    WHERE deleted = 0
+      AND deleted_at IS NULL
+      AND is_folder = false
+      AND (
+        (extracted_text IS NOT NULL AND TRIM(extracted_text) != '')
+        OR (content IS NOT NULL AND TRIM(content) != '')
+      )
+  `;
+
+  const total = Number(count);
+  console.log(`notes with content: ${total}`);
+  if (total === 0) return;
+
+  let processed = 0;
+  let chunked = 0;
+  let embedded = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (let offset = 0; offset < total; offset += NOTE_BATCH) {
+    const notes = await fetchNotesWithContent(offset, NOTE_BATCH);
+
+    for (const note of notes) {
+      processed++;
+      const prefix = `[${processed}/${total}] ${note.title?.slice(0, 40) || note.note_id}`;
+
+      // chunk the text
+      const raw = chunkText(note.text);
+      const chunks = normalizeChunksForIndexing(raw);
+
+      if (chunks.length === 0) {
+        skipped++;
+        console.log(`${prefix} — no chunks (empty after normalization)`);
+        continue;
+      }
+
+      chunked += chunks.length;
+
+      if (DRY_RUN) {
+        console.log(`${prefix} — ${chunks.length} chunks (dry run)`);
+        continue;
+      }
+
+      // embed in batches of 96
+      try {
+        const allEmbeddings = [];
+        for (let i = 0; i < chunks.length; i += EMBED_BATCH) {
+          const batch = chunks.slice(i, i + EMBED_BATCH);
+          const result = await embedChunks(batch);
+          allEmbeddings.push(...result);
+        }
+
+        if (allEmbeddings.length === 0) {
+          console.log(`${prefix} — embedding returned empty, skipping`);
+          skipped++;
+          continue;
+        }
+
+        // atomic insert: chunks + embeddings in one transaction
+        await sql.begin(async (tx) => {
+          const chunkRows = await tx`
+            INSERT INTO app.chunks (document_id, user_id, text)
+            SELECT * FROM UNNEST(
+              ${allEmbeddings.map(() => note.note_id)}::uuid[],
+              ${allEmbeddings.map(() => note.user_id)}::uuid[],
+              ${allEmbeddings.map((e) => e.chunk)}::text[]
+            )
+            RETURNING id
+          `;
+
+          await tx`
+            INSERT INTO app.embeddings (chunk_id, embedding)
+            SELECT * FROM UNNEST(
+              ${chunkRows.map((r) => r.id)}::uuid[],
+              ${allEmbeddings.map((e) => JSON.stringify(e.vector))}::vector[]
+            )
+          `;
+        });
+
+        embedded += allEmbeddings.length;
+        console.log(`${prefix} — ${allEmbeddings.length} chunks embedded`);
+      } catch (err) {
+        failed++;
+        console.error(
+          `${prefix} — FAILED: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+  }
+
+  console.log("\n--- reindex summary ---");
+  console.log(`  notes processed: ${processed}`);
+  console.log(`  chunks created:  ${chunked}`);
+  console.log(`  embeddings stored: ${embedded}`);
+  console.log(`  skipped (empty):   ${skipped}`);
+  console.log(`  failed:            ${failed}`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await sql.end({ timeout: 5 });
+  });

--- a/src/__tests__/lib/embeddings.test.ts
+++ b/src/__tests__/lib/embeddings.test.ts
@@ -3,16 +3,20 @@ import { embedChunks } from '@/lib/embeddings';
 
 describe('embedChunks', () => {
     beforeEach(() => {
-        process.env.COHERE_API_KEY = 'fake';
+        process.env.EMBEDDING_API_URL = 'https://test.api';
+        process.env.EMBEDDING_API_KEY = 'fake-key';
+        process.env.EMBEDDING_MODEL = 'test-model';
     });
 
     afterEach(() => {
         vi.restoreAllMocks();
     });
 
-    it('throws when COHERE_API_KEY is not set', async () => {
-        delete process.env.COHERE_API_KEY;
-        await expect(embedChunks(['hello'])).rejects.toThrow('COHERE_API_KEY not configured');
+    it('throws when embedding provider is not configured', async () => {
+        delete process.env.EMBEDDING_API_URL;
+        delete process.env.EMBEDDING_API_KEY;
+        delete process.env.EMBEDDING_MODEL;
+        await expect(embedChunks(['hello'])).rejects.toThrow('not configured');
     });
 
     it('returns empty array for empty input', async () => {
@@ -30,7 +34,10 @@ describe('embedChunks', () => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
             ok: true,
             json: async () => ({
-                embeddings: { float: [mockVector, mockVector] },
+                data: [
+                    { embedding: mockVector },
+                    { embedding: mockVector },
+                ],
             }),
         }));
 
@@ -41,31 +48,30 @@ describe('embedChunks', () => {
         expect(result[1].chunk).toBe('another chunk');
     });
 
-    it('throws when a batch API call fails', async () => {
-        vi.stubGlobal('fetch', vi.fn()
-            .mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) })
-        );
-
-        await expect(embedChunks(['bad chunk', 'good chunk'])).rejects.toThrow('Cohere embedding incomplete');
-    });
-
-    it('throws when the response has no embeddings', async () => {
+    it('throws when API call fails', async () => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-            ok: true,
-            json: async () => ({ notEmbeddings: 'oops' }),
+            ok: false,
+            status: 500,
+            text: async () => 'Internal Server Error',
         }));
 
-        // empty embeddings.float means 0 results for 1 chunk — but no batch failure
-        // the batch "succeeded" with 0 vectors, so results = 0 but failures = 0
-        const result = await embedChunks(['chunk one']);
-        expect(result).toHaveLength(0);
+        await expect(embedChunks(['bad chunk'])).rejects.toThrow('Embedding API 500');
+    });
+
+    it('throws when embedding count mismatches', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                data: [{ embedding: [0.1] }],
+            }),
+        }));
+
+        await expect(embedChunks(['chunk one', 'chunk two'])).rejects.toThrow('count mismatch');
     });
 
     it('throws when fetch rejects with a network error', async () => {
-        vi.stubGlobal('fetch', vi.fn()
-            .mockRejectedValueOnce(new Error('network error'))
-        );
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
 
-        await expect(embedChunks(['failing chunk', 'working chunk'])).rejects.toThrow('Cohere embedding incomplete');
+        await expect(embedChunks(['failing chunk'])).rejects.toThrow('network error');
     });
 });

--- a/src/__tests__/lib/rerank.test.ts
+++ b/src/__tests__/lib/rerank.test.ts
@@ -3,14 +3,16 @@ import { rerankChunks } from "@/lib/rerank";
 
 describe("rerankChunks", () => {
   beforeEach(() => {
-    process.env.COHERE_API_KEY = "fake-key";
+    process.env.RERANK_API_URL = "https://test.api";
+    process.env.RERANK_API_KEY = "fake-key";
+    process.env.RERANK_MODEL = "test-reranker";
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("returns stable source indices from Cohere results", async () => {
+  it("returns stable source indices from rerank results", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -33,8 +35,10 @@ describe("rerankChunks", () => {
     ]);
   });
 
-  it("includes indices in fallback mode without API key", async () => {
-    delete process.env.COHERE_API_KEY;
+  it("falls back to vector order without rerank config", async () => {
+    delete process.env.RERANK_API_URL;
+    delete process.env.RERANK_API_KEY;
+    delete process.env.RERANK_MODEL;
     const reranked = await rerankChunks("query", ["a", "b", "c"], 2);
 
     expect(reranked).toEqual([

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -396,7 +396,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
                   ? `Found ${searchResults.length} relevant chunk(s) from: ${[...new Set(searchResults.map((r) => `"${r.title || "Untitled"}"`))].join(", ")}. Connect an LLM (set LLM_API_URL) to get AI-generated answers.`
                   : embeddingAvailable
                     ? "No relevant notes found. Try uploading a PDF to build your knowledge base."
-                    : "Embedding service unavailable. Set COHERE_API_KEY to enable semantic search.";
+                    : "Embedding service unavailable. Check EMBEDDING_API_URL/KEY/MODEL configuration.";
 
               if (!llmAvailable) {
                 controller.enqueue(
@@ -960,7 +960,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       ? `Found ${searchResults.length} relevant chunk(s) from: ${[...new Set(searchResults.map((r) => `"${r.title || "Untitled"}"`))].join(", ")}. Connect an LLM (set LLM_API_URL) to get AI-generated answers.`
       : embeddingAvailable
         ? "No relevant notes found. Try uploading a PDF to build your knowledge base."
-        : "Embedding service unavailable. Set COHERE_API_KEY to enable semantic search.";
+        : "Embedding service unavailable. Check EMBEDDING_API_URL/KEY/MODEL configuration.";
 
   const provider = createLlmProvider();
   const model = provider ? provider(getLlmModel()) : null;

--- a/src/app/chat/chat-page-client.tsx
+++ b/src/app/chat/chat-page-client.tsx
@@ -380,7 +380,7 @@ export default function ChatPageClient() {
                   <span className="truncate">{conv.noteTitle}</span>
                 </div>
               )}
-              <p className="text-text-tertiary opacity-60 mt-0.5">
+              <p className="text-text-tertiary opacity-60 mt-0.5" suppressHydrationWarning>
                 {new Date(conv.createdAt).toLocaleDateString([], {
                   month: "short",
                   day: "numeric",

--- a/src/components/chat/message-bubble.tsx
+++ b/src/components/chat/message-bubble.tsx
@@ -282,7 +282,7 @@ export const FullMessageBubble: FC<{
         <SourcesBlock sources={m.sources!} retrieval={m.retrieval} />
       )}
 
-      <p className="text-xs text-text-tertiary opacity-60">
+      <p className="text-xs text-text-tertiary opacity-60" suppressHydrationWarning>
         {new Date(m.timestamp).toLocaleTimeString([], {
           hour: "2-digit",
           minute: "2-digit",

--- a/src/lib/embedText.ts
+++ b/src/lib/embedText.ts
@@ -1,59 +1,9 @@
-// embeds a single query via self-hosted (preferred) or Cohere fallback
-// uses input_type=search_query (asymmetric to search_document used at index time)
+// embeds a single query string for semantic search
+// uses the same provider as batch embedding (OpenRouter / any OpenAI-compatible API)
 
-import { Metrics } from "@/lib/metrics";
-import { getCohereTimeoutMs } from "@/lib/ai-config";
 import { defaultEmbeddingProvider } from "@/lib/providers/self-hosted-embeddings";
-import logger from "@/lib/logger";
-
-const COHERE_URL = "https://api.cohere.com/v2/embed";
-const COHERE_MODEL = "embed-multilingual-v3.0";
-
-async function embedViaCohere(text: string): Promise<number[]> {
-  const apiKey = process.env.COHERE_API_KEY;
-  const timeoutMs = getCohereTimeoutMs();
-  if (!apiKey) throw new Error("COHERE_API_KEY not configured");
-
-  const res = await fetch(COHERE_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      texts: [text],
-      model: COHERE_MODEL,
-      input_type: "search_query",
-      embedding_types: ["float"],
-    }),
-    signal: AbortSignal.timeout(timeoutMs),
-  });
-
-  if (!res.ok) {
-    const body = await res.text();
-    void Metrics.cohereError("embed");
-    throw new Error(
-      `Cohere embed failed (${res.status}): ${body.slice(0, 200)}`,
-    );
-  }
-
-  const json = await res.json();
-  const vectors: number[][] = json.embeddings?.float ?? [];
-  if (vectors.length === 0) throw new Error("Cohere returned no embeddings");
-  return vectors[0];
-}
 
 export async function embedText(text: string): Promise<number[]> {
-  // try self-hosted first, fall back to Cohere
-  try {
-    if (defaultEmbeddingProvider.isConfigured()) {
-      return await defaultEmbeddingProvider.embedSingle(text);
-    }
-  } catch (err) {
-    logger.info("self-hosted embed unavailable, falling back to Cohere", {
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
-
-  return embedViaCohere(text);
+  const prefixed = `Instruct: Represent this query for retrieval\nQuery: ${text}`;
+  return defaultEmbeddingProvider.embedSingle(prefixed);
 }

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -1,123 +1,20 @@
-// batch-embeds chunks via self-hosted embeddings (preferred) or Cohere fallback
+// batch-embeds chunks via the configured embedding provider (OpenRouter, etc.)
 // strips markdown syntax before embedding — ###, ---, ** etc. are noise in vector space
 // the original markdown chunk text is preserved in chunks.text for LLM RAG context
 
-import { getCohereTimeoutMs } from "@/lib/ai-config";
-import { Metrics } from "@/lib/metrics";
 import { stripMarkdown } from "./strip-markdown";
 import { defaultEmbeddingProvider } from "@/lib/providers/self-hosted-embeddings";
-
-const COHERE_URL = "https://api.cohere.com/v2/embed";
-const COHERE_MODEL = "embed-multilingual-v3.0";
-const BATCH_SIZE = 96; // Cohere allows up to 96 texts per request
-
-function buildCohereRequest(apiKey: string, batch: string[]) {
-  return {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      texts: batch,
-      model: COHERE_MODEL,
-      input_type: "search_document",
-      embedding_types: ["float"],
-    }),
-  };
-}
-
-async function embedViaSelfHosted(
-  chunks: string[],
-): Promise<{ chunk: string; vector: number[] }[]> {
-  if (!defaultEmbeddingProvider.isConfigured()) {
-    throw new Error("Self-hosted embeddings not configured");
-  }
-
-  const nonEmpty = chunks.filter((c) => c?.trim());
-  if (nonEmpty.length === 0) return [];
-
-  const stripped = nonEmpty.map((c) => stripMarkdown(c));
-
-  try {
-    const vectors = await defaultEmbeddingProvider.embedBatch(stripped);
-    return nonEmpty.map((chunk, i) => ({
-      chunk,
-      vector: vectors[i],
-    }));
-  } catch (err) {
-    console.warn(
-      `Self-hosted embed failed: ${err instanceof Error ? err.message : err}`,
-    );
-    throw err;
-  }
-}
-
-async function embedViaCohere(
-  chunks: string[],
-): Promise<{ chunk: string; vector: number[] }[]> {
-  const apiKey = process.env.COHERE_API_KEY;
-  if (!apiKey) throw new Error("COHERE_API_KEY not configured");
-
-  const nonEmpty = chunks.filter((c) => c?.trim());
-  if (nonEmpty.length === 0) return [];
-
-  const results: { chunk: string; vector: number[] }[] = [];
-  const stripped = nonEmpty.map((c) => stripMarkdown(c));
-
-  let failures = 0;
-
-  for (let i = 0; i < nonEmpty.length; i += BATCH_SIZE) {
-    const batch = stripped.slice(i, i + BATCH_SIZE);
-    const originalBatch = nonEmpty.slice(i, i + BATCH_SIZE);
-    try {
-      const res = await fetch(COHERE_URL, {
-        ...buildCohereRequest(apiKey, batch),
-        signal: AbortSignal.timeout(getCohereTimeoutMs()),
-      });
-      if (!res.ok) {
-        void Metrics.cohereError("embed");
-        console.warn(
-          `Cohere embed failed (${res.status}), skipping ${batch.length} chunks`,
-        );
-        failures += batch.length;
-        continue;
-      }
-      const json = await res.json();
-      const vectors: number[][] = json.embeddings?.float ?? [];
-      for (let j = 0; j < vectors.length && j < batch.length; j++) {
-        results.push({ chunk: originalBatch[j], vector: vectors[j] });
-      }
-    } catch (err) {
-      void Metrics.cohereError("embed");
-      console.warn(
-        `Cohere embed error: ${err instanceof Error ? err.message : err}`,
-      );
-      failures += batch.length;
-    }
-  }
-
-  if (failures > 0) {
-    throw new Error(
-      `Cohere embedding incomplete: ${failures}/${nonEmpty.length} chunks failed`,
-    );
-  }
-
-  return results;
-}
 
 export async function embedChunks(
   chunks: string[],
 ): Promise<{ chunk: string; vector: number[] }[]> {
-  // try self-hosted first, fall back to Cohere
-  try {
-    return await embedViaSelfHosted(chunks);
-  } catch (err) {
-    console.info(
-      `Self-hosted embeddings unavailable, falling back to Cohere: ${
-        err instanceof Error ? err.message : err
-      }`,
-    );
-    return embedViaCohere(chunks);
-  }
+  const nonEmpty = chunks.filter((c) => c?.trim());
+  if (nonEmpty.length === 0) return [];
+
+  const prepared = nonEmpty.map(
+    (c) => `Instruct: Represent this document for retrieval\nDocument: ${stripMarkdown(c)}`,
+  );
+  const vectors = await defaultEmbeddingProvider.embedBatch(prepared);
+
+  return nonEmpty.map((chunk, i) => ({ chunk, vector: vectors[i] }));
 }

--- a/src/lib/providers/self-hosted-embeddings.ts
+++ b/src/lib/providers/self-hosted-embeddings.ts
@@ -1,5 +1,5 @@
-// self-hosted embeddings via open-webui/ollama on your server
-// falls back to Cohere if not configured
+// embedding provider — calls any OpenAI-compatible endpoint (OpenRouter, ollama, etc.)
+// configured via EMBEDDING_API_URL, EMBEDDING_API_KEY, EMBEDDING_MODEL
 
 export interface EmbeddingProvider {
   name: string;
@@ -8,103 +8,64 @@ export interface EmbeddingProvider {
   isConfigured(): boolean;
 }
 
+// reads env vars at call time so tests can set them after import
+function env() {
+  return {
+    apiUrl: process.env.EMBEDDING_API_URL || "",
+    apiKey: process.env.EMBEDDING_API_KEY || "",
+    model: process.env.EMBEDDING_MODEL || "",
+  };
+}
+
 class SelfHostedEmbeddingProvider implements EmbeddingProvider {
   name = "self-hosted";
-  private apiUrl: string;
-  private apiKey: string;
-  private model: string;
-
-  constructor(apiUrl?: string, apiKey?: string, model?: string) {
-    this.apiUrl = apiUrl || process.env.EMBEDDING_API_URL || "";
-    this.apiKey = apiKey || process.env.EMBEDDING_API_KEY || "";
-    this.model =
-      model || process.env.EMBEDDING_MODEL || "mxbai-embed-large:latest";
-  }
 
   isConfigured(): boolean {
-    return !!this.apiUrl && !!this.apiKey;
+    const { apiUrl, apiKey, model } = env();
+    return !!(apiUrl && apiKey && model);
   }
 
   async embedBatch(texts: string[]): Promise<number[][]> {
-    if (!this.isConfigured()) {
-      throw new Error("Self-hosted embeddings not configured");
+    const { apiUrl, apiKey, model } = env();
+    if (!(apiUrl && apiKey && model)) {
+      throw new Error("Embedding provider not configured (EMBEDDING_API_URL/KEY/MODEL)");
     }
 
     const nonEmpty = texts.filter((t) => t?.trim());
     if (nonEmpty.length === 0) return [];
 
-    // try multiple endpoint formats supported by open-webui
-    const endpoints = [
-      `${this.apiUrl}/api/embeddings`,
-      `${this.apiUrl}/v1/embeddings`,
-      `${this.apiUrl}/ollama/api/embed`,
-    ];
+    const res = await fetch(`${apiUrl}/v1/embeddings`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ input: nonEmpty, model }),
+      signal: AbortSignal.timeout(30000),
+    });
 
-    let lastError: Error | null = null;
-
-    for (const endpoint of endpoints) {
-      try {
-        const res = await fetch(endpoint, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${this.apiKey}`,
-          },
-          body: JSON.stringify({
-            input: nonEmpty,
-            model: this.model,
-          }),
-          signal: AbortSignal.timeout(30000),
-        });
-
-        if (!res.ok) {
-          const text = await res.text();
-          console.debug(
-            `${endpoint} returned ${res.status}: ${text.slice(0, 100)}`,
-          );
-          lastError = new Error(`${endpoint} ${res.status}`);
-          continue;
-        }
-
-        const json = await res.json();
-
-        // handle different response formats
-        let embeddings: number[][] = [];
-
-        if (json.data && Array.isArray(json.data)) {
-          // OpenAI-compatible format: {data: [{embedding: [...]}]}
-          embeddings = json.data
-            .map((item: { embedding: number[] }) => item.embedding)
-            .filter(Boolean);
-        } else if (json.embeddings && Array.isArray(json.embeddings)) {
-          // ollama format: {embeddings: [[...]]}
-          embeddings = json.embeddings;
-        } else if (Array.isArray(json)) {
-          // direct array format
-          embeddings = json;
-        }
-
-        if (embeddings.length === nonEmpty.length) {
-          return embeddings;
-        }
-
-        console.warn(
-          `${endpoint} returned ${embeddings.length} embeddings, expected ${nonEmpty.length}`,
-        );
-      } catch (err) {
-        lastError = err instanceof Error ? err : new Error(String(err));
-        console.debug(`${endpoint} failed: ${lastError.message}`);
-      }
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Embedding API ${res.status}: ${body.slice(0, 200)}`);
     }
 
-    throw lastError || new Error("All self-hosted embedding endpoints failed");
+    const json = await res.json();
+    const embeddings: number[][] = (json.data ?? [])
+      .map((item: { embedding: number[] }) => item.embedding)
+      .filter(Boolean);
+
+    if (embeddings.length !== nonEmpty.length) {
+      throw new Error(
+        `Embedding count mismatch: got ${embeddings.length}, expected ${nonEmpty.length}`,
+      );
+    }
+
+    return embeddings;
   }
 
   async embedSingle(text: string): Promise<number[]> {
     const [embedding] = await this.embedBatch([text]);
-    if (!embedding) {
-      throw new Error("Failed to embed single text");
-    }
+    if (!embedding) throw new Error("Failed to embed single text");
     return embedding;
   }
 }

--- a/src/lib/providers/self-hosted-rerank.ts
+++ b/src/lib/providers/self-hosted-rerank.ts
@@ -1,5 +1,5 @@
-// self-hosted reranking via open-webui/ollama
-// optional — falls back gracefully if not available
+// reranking via SiliconFlow / any Cohere-compatible rerank API
+// configured via RERANK_API_URL, RERANK_API_KEY, RERANK_MODEL
 
 export interface RerankProvider {
   name: string;
@@ -11,19 +11,20 @@ export interface RerankProvider {
   isConfigured(): boolean;
 }
 
-class SelfHostedRerankProvider implements RerankProvider {
-  name = "self-hosted";
-  private apiUrl: string;
-  private apiKey: string;
-  private model: string = "dengcao/Qwen3-Reranker-4B:Q4_K_M";
+function env() {
+  return {
+    apiUrl: process.env.RERANK_API_URL || "",
+    apiKey: process.env.RERANK_API_KEY || "",
+    model: process.env.RERANK_MODEL || "",
+  };
+}
 
-  constructor(apiUrl?: string, apiKey?: string) {
-    this.apiUrl = apiUrl || process.env.EMBEDDING_API_URL || "";
-    this.apiKey = apiKey || process.env.EMBEDDING_API_KEY || "";
-  }
+class RerankAPIProvider implements RerankProvider {
+  name = "rerank-api";
 
   isConfigured(): boolean {
-    return !!this.apiUrl && !!this.apiKey;
+    const { apiUrl, apiKey, model } = env();
+    return !!(apiUrl && apiKey && model);
   }
 
   async rerank(
@@ -31,67 +32,45 @@ class SelfHostedRerankProvider implements RerankProvider {
     chunks: string[],
     topN: number,
   ): Promise<Array<{ index: number; text: string; score: number }>> {
-    if (!this.isConfigured()) {
-      throw new Error("Self-hosted rerank not configured");
+    const { apiUrl, apiKey, model } = env();
+    if (!(apiUrl && apiKey && model)) {
+      throw new Error("Rerank provider not configured (RERANK_API_URL/KEY/MODEL)");
     }
 
     if (chunks.length <= topN) {
       return chunks.map((text, index) => ({ index, text, score: 1 }));
     }
 
-    // try endpoints that might support reranking
-    const endpoints = [`${this.apiUrl}/api/rerank`, `${this.apiUrl}/v1/rerank`];
+    const res = await fetch(`${apiUrl}/v1/rerank`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        query,
+        documents: chunks,
+        top_n: topN,
+      }),
+      signal: AbortSignal.timeout(15000),
+    });
 
-    let lastError: Error | null = null;
-
-    for (const endpoint of endpoints) {
-      try {
-        const res = await fetch(endpoint, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${this.apiKey}`,
-          },
-          body: JSON.stringify({
-            model: this.model,
-            query,
-            documents: chunks.map((text) => ({ text })),
-            top_n: topN,
-          }),
-          signal: AbortSignal.timeout(30000),
-        });
-
-        if (!res.ok) {
-          const text = await res.text();
-          console.debug(
-            `${endpoint} returned ${res.status}: ${text.slice(0, 100)}`,
-          );
-          lastError = new Error(`${endpoint} ${res.status}`);
-          continue;
-        }
-
-        const json = await res.json();
-        const results: Array<{ index: number; relevance_score?: number }> =
-          json.results ?? [];
-
-        if (!Array.isArray(results) || results.length === 0) {
-          lastError = new Error(`${endpoint} returned empty results`);
-          continue;
-        }
-
-        return results.map((r) => ({
-          index: r.index,
-          text: chunks[r.index],
-          score: r.relevance_score ?? 0.5,
-        }));
-      } catch (err) {
-        lastError = err instanceof Error ? err : new Error(String(err));
-        console.debug(`${endpoint} failed: ${lastError.message}`);
-      }
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Rerank API ${res.status}: ${body.slice(0, 200)}`);
     }
 
-    throw lastError || new Error("All self-hosted rerank endpoints failed");
+    const json = await res.json();
+    const results: Array<{ index: number; relevance_score: number }> =
+      json.results ?? [];
+
+    return results.map((r) => ({
+      index: r.index,
+      text: chunks[r.index],
+      score: r.relevance_score,
+    }));
   }
 }
 
-export const defaultRerankProvider = new SelfHostedRerankProvider();
+export const defaultRerankProvider = new RerankAPIProvider();

--- a/src/lib/rerank.ts
+++ b/src/lib/rerank.ts
@@ -1,15 +1,10 @@
-// reranks candidate chunks via self-hosted rerank (optional) or Cohere fallback
-// purpose-built relevance scoring — faster and more accurate than LLM-based reranking
+// reranks candidate chunks via configured rerank API (SiliconFlow, etc.)
+// falls back to vector-distance ordering if provider is unavailable
 
-import { Metrics } from "@/lib/metrics";
 import logger from "@/lib/logger";
-import { getCohereTimeoutMs } from "@/lib/ai-config";
 import { defaultRerankProvider } from "@/lib/providers/self-hosted-rerank";
 
-const COHERE_RERANK_URL = "https://api.cohere.com/v2/rerank";
-const COHERE_RERANK_MODEL = "rerank-multilingual-v3.0";
 const TOP_N = 5;
-// minimum relevance score from the reranker — below this the chunk is noise
 const MIN_RELEVANCE = 0.15;
 
 interface RerankResult {
@@ -18,81 +13,10 @@ interface RerankResult {
   score: number;
 }
 
-async function rerankViaCohere(
-  query: string,
-  chunks: string[],
-  topN: number,
-): Promise<RerankResult[]> {
-  if (chunks.length <= topN) {
-    return chunks.map((text, index) => ({ index, text, score: 1 }));
-  }
-
-  const apiKey = process.env.COHERE_API_KEY;
-  const timeoutMs = getCohereTimeoutMs();
-  if (!apiKey) {
-    // no API key — fall back to top-N by vector distance order (already sorted)
-    return chunks
-      .slice(0, topN)
-      .map((text, index) => ({ index, text, score: 1 }));
-  }
-
-  try {
-    const res = await fetch(COHERE_RERANK_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: COHERE_RERANK_MODEL,
-        query,
-        documents: chunks.map((text) => ({ text })),
-        top_n: topN,
-      }),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-
-    if (!res.ok) {
-      void Metrics.cohereError("rerank");
-      return chunks
-        .slice(0, topN)
-        .map((text, index) => ({ index, text, score: 1 }));
-    }
-
-    const json = await res.json();
-    const results: { index: number; relevance_score: number }[] =
-      json.results ?? [];
-
-    const filtered = results
-      .filter((r) => r.relevance_score >= MIN_RELEVANCE)
-      .map((r) => ({
-        index: r.index,
-        text: chunks[r.index],
-        score: r.relevance_score,
-      }));
-
-    // if reranker returned results but all scored below threshold, fall back to
-    // top-N by original vector distance so the pipeline still has context
-    if (filtered.length === 0 && chunks.length > 0) {
-      logger.warn(
-        "rerank: all results below relevance threshold, falling back to vector order",
-        {
-          query: query.slice(0, 50),
-          candidateCount: chunks.length,
-        },
-      );
-      return chunks
-        .slice(0, topN)
-        .map((text, index) => ({ index, text, score: 0 }));
-    }
-
-    return filtered;
-  } catch {
-    void Metrics.cohereError("rerank");
-    return chunks
-      .slice(0, topN)
-      .map((text, index) => ({ index, text, score: 1 }));
-  }
+function fallbackTopN(chunks: string[], topN: number): RerankResult[] {
+  return chunks
+    .slice(0, topN)
+    .map((text, index) => ({ index, text, score: 1 }));
 }
 
 export async function rerankChunks(
@@ -104,17 +28,28 @@ export async function rerankChunks(
     return chunks.map((text, index) => ({ index, text, score: 1 }));
   }
 
-  // try self-hosted rerank first, fall back to Cohere
-  if (defaultRerankProvider.isConfigured()) {
-    try {
-      const results = await defaultRerankProvider.rerank(query, chunks, topN);
-      return results as RerankResult[];
-    } catch (err) {
-      logger.info("self-hosted rerank unavailable, falling back to Cohere", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
+  if (!defaultRerankProvider.isConfigured()) {
+    return fallbackTopN(chunks, topN);
   }
 
-  return rerankViaCohere(query, chunks, topN);
+  try {
+    const results = await defaultRerankProvider.rerank(query, chunks, topN);
+
+    const filtered = results.filter((r) => r.score >= MIN_RELEVANCE);
+
+    if (filtered.length === 0 && chunks.length > 0) {
+      logger.warn("rerank: all results below relevance threshold, falling back to vector order", {
+        query: query.slice(0, 50),
+        candidateCount: chunks.length,
+      });
+      return fallbackTopN(chunks, topN);
+    }
+
+    return filtered;
+  } catch (err) {
+    logger.warn("rerank failed, falling back to vector order", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return fallbackTopN(chunks, topN);
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `suppressHydrationWarning` to two `<p>` elements that render locale-formatted dates/times
- Fixes React error #418 on the chat page caused by `Date.now()` in `useState` producing different timestamps on server (AWS eu-north-1) vs client browser, with `toLocaleTimeString`/`toLocaleDateString` formatting them differently

## Test plan
- [ ] Load `/chat` — no React hydration error in console
- [ ] Verify message timestamps still render correctly
- [ ] Verify conversation sidebar dates still render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hydration warnings for timestamps in chat messages and the conversation list.

* **New / Improved**
  * Upgraded embedding backend to support 4096‑dim vectors for improved search relevance.
  * Simplified and improved reranking and embedding providers for more consistent results.

* **Chores / Tools**
  * Added a reindexing script to rebuild embeddings/chunks for maintenance.

* **UI Copy**
  * Clarified the message shown when semantic search/embeddings are not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->