### PR TITLE
perf: replace img tags with next/image for lighthouse optimization

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,16 @@ const nextConfig = {
     // standalone output generates NFT trace files required by Amplify SSR
     output: 'standalone',
 
+    images: {
+        formats: ['image/avif', 'image/webp'],
+        remotePatterns: [
+            {
+                protocol: 'https',
+                hostname: 'images.unsplash.com',
+            },
+        ],
+    },
+
     async headers() {
         return [
             {

--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import Header from "@/components/header";
 import { aboutBlogCards, authors } from "@/lib/blog-data";
@@ -196,9 +197,11 @@ export default function About() {
                 <div className="mt-14 flex justify-end gap-8 sm:-mt-44 sm:justify-start sm:pl-20 lg:mt-0 lg:pl-0">
                   <div className="ml-auto w-44 flex-none space-y-8 pt-32 sm:ml-0 sm:pt-80 lg:order-last lg:pt-36 xl:order-0 xl:pt-80">
                     <div className="relative">
-                      <img
+                      <Image
                         alt=""
-                        src="https://images.unsplash.com/photo-1523240795612-9a054b0db644?auto=format&fit=crop&h=528&q=80"
+                        src="https://images.unsplash.com/photo-1523240795612-9a054b0db644?auto=format&fit=crop&w=352&h=528&q=80"
+                        width={352}
+                        height={528}
                         className="aspect-2/3 w-full rounded-xl bg-gray-700/5 object-cover shadow-lg"
                       />
                       <div className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-white/10 ring-inset" />
@@ -206,17 +209,21 @@ export default function About() {
                   </div>
                   <div className="mr-auto w-44 flex-none space-y-8 sm:mr-0 sm:pt-52 lg:pt-36">
                     <div className="relative">
-                      <img
+                      <Image
                         alt=""
-                        src="https://images.unsplash.com/photo-1524178232363-1fb2b075b655?auto=format&fit=crop&h=528&q=80"
+                        src="https://images.unsplash.com/photo-1524178232363-1fb2b075b655?auto=format&fit=crop&w=352&h=528&q=80"
+                        width={352}
+                        height={528}
                         className="aspect-2/3 w-full rounded-xl bg-gray-700/5 object-cover shadow-lg"
                       />
                       <div className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-white/10 ring-inset" />
                     </div>
                     <div className="relative">
-                      <img
+                      <Image
                         alt=""
-                        src="https://images.unsplash.com/photo-1509062522246-3755977927d7?auto=format&fit=crop&w=396&h=528&q=80"
+                        src="https://images.unsplash.com/photo-1509062522246-3755977927d7?auto=format&fit=crop&w=352&h=528&q=80"
+                        width={352}
+                        height={528}
                         className="aspect-2/3 w-full rounded-xl bg-gray-700/5 object-cover shadow-lg"
                       />
                       <div className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-white/10 ring-inset" />
@@ -224,17 +231,21 @@ export default function About() {
                   </div>
                   <div className="w-44 flex-none space-y-8 pt-32 sm:pt-0">
                     <div className="relative">
-                      <img
+                      <Image
                         alt=""
-                        src="https://images.unsplash.com/photo-1517486808906-6ca8b3f04846?auto=format&fit=crop&w=400&h=528&q=80"
+                        src="https://images.unsplash.com/photo-1517486808906-6ca8b3f04846?auto=format&fit=crop&w=352&h=528&q=80"
+                        width={352}
+                        height={528}
                         className="aspect-2/3 w-full rounded-xl bg-gray-700/5 object-cover shadow-lg"
                       />
                       <div className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-white/10 ring-inset" />
                     </div>
                     <div className="relative">
-                      <img
+                      <Image
                         alt=""
-                        src="https://images.unsplash.com/photo-1541339907198-e08756dedf3f?auto=format&fit=crop&h=528&q=80"
+                        src="https://images.unsplash.com/photo-1541339907198-e08756dedf3f?auto=format&fit=crop&w=352&h=528&q=80"
+                        width={352}
+                        height={528}
                         className="aspect-2/3 w-full rounded-xl bg-gray-700/5 object-cover shadow-lg"
                       />
                       <div className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-white/10 ring-inset" />
@@ -288,9 +299,11 @@ export default function About() {
 
         {/* Image section */}
         <div className="mt-32 sm:mt-40 xl:mx-auto xl:max-w-7xl xl:px-8">
-          <img
+          <Image
             alt=""
-            src="https://images.unsplash.com/photo-1497633762265-9d179a990aa6?auto=format&fit=crop&w=2832&q=80"
+            src="https://images.unsplash.com/photo-1497633762265-9d179a990aa6?auto=format&fit=crop&w=1400&q=80"
+            width={1400}
+            height={560}
             className="aspect-5/2 w-full object-cover outline-1 -outline-offset-1 outline-white/10 xl:rounded-3xl"
           />
         </div>
@@ -418,9 +431,11 @@ export default function About() {
                   key={img.name}
                   className="col-span-1 overflow-hidden rounded-xl"
                 >
-                  <img
+                  <Image
                     alt={img.name}
                     src={img.src}
+                    width={600}
+                    height={400}
                     className="aspect-3/2 w-full object-cover"
                   />
                 </div>
@@ -457,9 +472,11 @@ export default function About() {
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    <img
+                    <Image
                       alt={person.name}
                       src={person.imageUrl}
+                      width={224}
+                      height={224}
                       className="mx-auto size-48 rounded-full outline-1 -outline-offset-1 outline-white/10 md:size-56"
                     />
                   </a>
@@ -550,10 +567,12 @@ export default function About() {
                 key={post.slug}
                 className="relative isolate flex flex-col justify-end overflow-hidden rounded-2xl bg-surface px-8 pt-80 pb-8 sm:pt-48 lg:pt-80"
               >
-                <img
+                <Image
                   alt=""
                   src={post.imageUrl}
-                  className="absolute inset-0 -z-10 size-full object-cover"
+                  fill
+                  sizes="(max-width: 1024px) 100vw, 33vw"
+                  className="absolute inset-0 -z-10 object-cover"
                 />
                 <div className="absolute inset-0 -z-10 bg-linear-to-t from-black/80 via-black/40" />
                 <div className="absolute inset-0 -z-10 rounded-2xl inset-ring inset-ring-white/10" />
@@ -575,9 +594,11 @@ export default function About() {
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      <img
+                      <Image
                         alt={post.author.name}
                         src={post.author.imageUrl}
+                        width={24}
+                        height={24}
                         className="size-6 flex-none rounded-full bg-gray-800/10"
                       />
                       <span>{post.author.name}</span>

--- a/src/app/blog/[slug]/page.jsx
+++ b/src/app/blog/[slug]/page.jsx
@@ -5,6 +5,7 @@ import {
   CheckCircleIcon,
   InformationCircleIcon,
 } from "@heroicons/react/20/solid";
+import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import Header from "@/components/header";
@@ -59,9 +60,11 @@ export default function BlogPost({ params }) {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <img
+                <Image
                   alt={post.author.name}
                   src={post.author.imageUrl}
+                  width={32}
+                  height={32}
                   className="size-8 rounded-full bg-gray-800"
                 />
                 <div>
@@ -108,9 +111,11 @@ export default function BlogPost({ params }) {
                 <p>"{t(post.testimonial.quote)}"</p>
               </blockquote>
               <figcaption className="mt-6 flex gap-x-4">
-                <img
+                <Image
                   alt=""
                   src={post.testimonial.image}
+                  width={24}
+                  height={24}
                   className="size-6 flex-none rounded-full bg-gray-800"
                 />
                 <div className="text-sm/6">
@@ -126,9 +131,11 @@ export default function BlogPost({ params }) {
           </div>
 
           <figure className="mt-16">
-            <img
+            <Image
               alt=""
               src={post.imageUrl}
+              width={800}
+              height={450}
               className="aspect-video rounded-xl bg-gray-800 object-cover"
             />
             <figcaption className="mt-4 flex gap-x-2 text-sm/6 text-gray-400">

--- a/src/app/blog/page.jsx
+++ b/src/app/blog/page.jsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import Header from "@/components/header";
 import Footer from "@/components/footer";
@@ -43,9 +44,11 @@ export default function BlogPage() {
                 className="flex flex-col items-start justify-between"
               >
                 <div className="relative w-full">
-                  <img
+                  <Image
                     src={post.imageUrl}
                     alt=""
+                    width={800}
+                    height={450}
                     className="aspect-video w-full rounded-2xl bg-gray-100 object-cover sm:aspect-square lg:aspect-video"
                   />
                   <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-gray-900/10" />
@@ -80,9 +83,11 @@ export default function BlogPage() {
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      <img
+                      <Image
                         alt={post.author.name}
                         src={post.author.imageUrl}
+                        width={40}
+                        height={40}
                         className="h-10 w-10 rounded-full bg-gray-800"
                       />
                       <div>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -11,6 +11,7 @@ import {
   EnvelopeIcon,
   PhoneIcon,
 } from "@heroicons/react/24/outline";
+import Image from "next/image";
 import { motion } from "motion/react";
 import Header from "@/components/header";
 import Footer from "@/components/footer";
@@ -38,10 +39,13 @@ function FadeIn({ children, delay = 0, className }) {
 function HeroMockup() {
   return (
     <div className="relative mt-16 sm:mt-24 rounded-3xl ring-1 ring-white/10 shadow-2xl overflow-hidden">
-      <img
+      <Image
         src="/notes-screenshot.png"
         alt="OghmaNotes editor with file tree, rich text editing, and AI chat"
+        width={1440}
+        height={900}
         className="w-full h-auto block"
+        priority
       />
       {/* smooth fade-out blending into the page */}
       <div

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import useI18n from "@/lib/notes/hooks/use-i18n";
 import { configLocale } from "@/locales";
 
@@ -69,10 +70,11 @@ export default function Footer() {
         <div className="xl:grid xl:grid-cols-3 xl:gap-8">
           <div className="space-y-8">
             <div className="font-serif text-2xl font-bold text-white flex items-center gap-2">
-              <img
+              <Image
                 src="/oghmanotes.svg"
                 alt="OghmaNotes Logo"
-                className="w-8 h-8"
+                width={32}
+                height={32}
               />
               {t("OghmaNotes")}
             </div>

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import { Dialog, DialogPanel } from "@headlessui/react";
 import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
@@ -35,10 +36,11 @@ export default function Header() {
         <div className="flex lg:flex-1">
           <Link href="/" className="-m-1.5 p-1.5 flex items-center gap-2">
             <span className="sr-only">{t("OghmaNotes")}</span>
-            <img
+            <Image
               src="/oghmanotes.svg"
               alt={t("OghmaNotes")}
-              className="w-8 h-8"
+              width={32}
+              height={32}
             />
             <span className="font-serif text-lg font-semibold text-white hidden sm:block">
               {t("OghmaNotes")}
@@ -82,10 +84,11 @@ export default function Header() {
           <div className="flex items-center justify-between">
             <Link href="/" className="-m-1.5 p-1.5 flex items-center gap-2">
               <span className="sr-only">{t("OghmaNotes")}</span>
-              <img
+              <Image
                 src="/oghmanotes.svg"
                 alt={t("OghmaNotes")}
-                className="w-8 h-8"
+                width={32}
+                height={32}
               />
               <span className="font-serif text-lg font-semibold text-white">
                 {t("OghmaNotes")}

--- a/src/lib/blog-data.js
+++ b/src/lib/blog-data.js
@@ -25,7 +25,7 @@ const blogPosts = [
     excerpt: 'Learn how to structure your notes using the Cornell Method and leverage OghmaNotes AI to automatically generate summaries and study guides from your notes.',
     date: 'Jan 15, 2025',
     datetime: '2025-01-15',
-    imageUrl: 'https://images.unsplash.com/photo-1434030216411-0b793f4b4173?auto=format&fit=crop&w=3603&q=80',
+    imageUrl: 'https://images.unsplash.com/photo-1434030216411-0b793f4b4173?auto=format&fit=crop&w=800&q=80',
     intro: 'Learn how to structure your notes using the Cornell Method and leverage OghmaNotes AI to automatically generate summaries and study guides from your notes.',
     content: `The Cornell Method is one of the most effective note-taking systems ever developed. Combined with OghmaNotes AI, you can take your studying to the next level.
 
@@ -78,7 +78,7 @@ The platform is designed specifically for students who want to maximize their le
     excerpt: 'Discover how to connect OghmaNotes to Canvas and never miss an assignment deadline again with automatic syncing.',
     date: 'Jan 10, 2025',
     datetime: '2025-01-10',
-    imageUrl: 'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=3270&q=80',
+    imageUrl: 'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=800&q=80',
     intro: 'Discover how to connect OghmaNotes to Canvas and never miss an assignment deadline again with automatic syncing.',
     content: `Manual assignment tracking across multiple courses is exhausting. With OghmaNotes Canvas integration, all your assignments, deadlines, and course materials sync automatically.
 
@@ -126,7 +126,7 @@ Never switch between apps again. Everything you need is in OghmaNotes.`,
     excerpt: 'Real students share their strategies for using OghmaNotes to improve grades, stay organized, and reduce study time by 40%.',
     date: 'Jan 5, 2025',
     datetime: '2025-01-05',
-    imageUrl: 'https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=3270&q=80',
+    imageUrl: 'https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=800&q=80',
     intro: 'Real students share their strategies for using OghmaNotes to improve grades, stay organized, and reduce study time by 40%.',
     content: `Top-performing students don't study harder—they study smarter. Here are the strategies that successful students are using with OghmaNotes.
 


### PR DESCRIPTION
## Summary
- Replace all raw `<img>` tags with `next/image` on public pages (homepage, blog, about, header, footer)
- Configure `next.config.mjs` with AVIF/WebP formats and Unsplash remote patterns
- Add `priority` prop to LCP hero image on homepage
- Downsize Unsplash URL params from w=3603 to w=800

## Expected impact
- Homepage LCP: 6,060ms → significant reduction (hero image now priority + optimized)
- Blog LCP: 11,300ms → significant reduction (3,208 KiB image savings)
- All pages: automatic WebP/AVIF conversion, responsive sizing, lazy loading

## Test plan
- [x] All 542 tests pass
- [x] Lint passes (0 errors)
- [ ] Verify pages render correctly on dev.oghmanotes.ie
- [ ] Re-run Unlighthouse after deploy to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled advanced image format support (AVIF, WebP) for better performance and faster loading.
  * Added support for loading remote images from external sources.

* **Performance**
  * Optimized image rendering and sizing throughout the application for improved load times and visual quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->