### PR TITLE
feat(ai): add secure Canvas MCP chat access

### DIFF
--- a/infra/chat-lambda/handler.ts
+++ b/infra/chat-lambda/handler.ts
@@ -29,6 +29,8 @@ import { chunkText } from "@/lib/chunking";
 import { replaceNoteEmbeddings } from "@/lib/rag/indexing";
 import { processExtractedText } from "@/lib/canvas/text-processing.js";
 import { cacheInvalidate, cacheKeys } from "@/lib/cache";
+import { resolveAppOrigin } from "@/lib/chat/canvas-mcp-client";
+import { getOptionalCanvasTooling } from "@/lib/chat/canvas-tooling";
 
 import {
   normalizeUuidList,
@@ -427,6 +429,19 @@ export const handler = awslambda.streamifyResponse(
           `\nLast folder used for note creation: "${effectiveSessionContext.lastFolder.title}" ` +
           `(id: ${effectiveSessionContext.lastFolder.id}). Use that parentID directly when it fits.`;
 
+      const appOrigin = resolveAppOrigin({
+        requestOrigin: event.headers?.origin,
+        referer: event.headers?.referer,
+      });
+      const {
+        client: canvasMcpClient,
+        tools: canvasTools,
+        instruction: canvasInstruction,
+      } = await getOptionalCanvasTooling({
+        userId,
+        appOrigin,
+      });
+
       const toolInstruction =
         "Tools available:\n" +
         "- getChunks({ query, mode?, scope? }) — search notes for relevant chunks. mode: 'semantic' (default, conceptual match), 'exact' (literal phrase/term), 'both'. scope: 'session' (default, stay in current scope) or 'all' (search across all notes). Returns chunk text + noteId per hit.\n" +
@@ -434,7 +449,8 @@ export const handler = awslambda.streamifyResponse(
         "- findFolder({ query }) — search for a folder/course directory by name. Use when parent folder is not already known.\n" +
         "- makeMDNote({ text, parentID?, title? }) — create a markdown note. Set parentID to place it in the right folder.\n" +
         "When the user asks to create/save/write a note: if you already know the parentID (from context below), call makeMDNote directly. Otherwise call findFolder first. Prefer session scope first. Only use scope='all' when the user asks to search beyond the current scope or when scoped search clearly isn't enough." +
-        scopedParentHint;
+        scopedParentHint +
+        (canvasInstruction ? `\n\n${canvasInstruction}` : "");
 
       // ── tool definitions ────────────────────────────────────────────────
 
@@ -537,19 +553,29 @@ export const handler = awslambda.streamifyResponse(
         maxOutputTokens: getLlmMaxTokens(),
         ...(thinkingMode !== "off" && { temperature: 1 }),
         stopWhen: stepCountIs(50),
-        tools: { getChunks, readNote, findFolder, makeMDNote },
+        tools: {
+          getChunks,
+          readNote,
+          findFolder,
+          makeMDNote,
+          ...canvasTools,
+        },
         providerOptions: { moonshotai: moonshotOptions },
       });
 
-      for await (const part of result.fullStream) {
-        if (part.type === "reasoning-delta") {
-          sse.event("thinking", { text: part.text });
-        } else if (part.type === "text-delta") {
-          reply += part.text;
-          sse.event("token", { text: part.text });
-        } else if (part.type === "tool-call") {
-          sse.event("tool-call", { toolName: part.toolName });
+      try {
+        for await (const part of result.fullStream) {
+          if (part.type === "reasoning-delta") {
+            sse.event("thinking", { text: part.text });
+          } else if (part.type === "text-delta") {
+            reply += part.text;
+            sse.event("token", { text: part.text });
+          } else if (part.type === "tool-call") {
+            sse.event("tool-call", { toolName: part.toolName });
+          }
         }
+      } finally {
+        await canvasMcpClient?.close().catch(() => {});
       }
       void Metrics.llmLatency(Date.now() - t0);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "oghmanotes",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/mcp": "^1.0.36",
         "@ai-sdk/moonshotai": "^2.0.16",
         "@ai-sdk/openai": "^3.0.51",
         "@aws-sdk/client-auto-scaling": "^3.1021.0",
@@ -24,6 +25,7 @@
         "@codemirror/theme-one-dark": "^6.1.3",
         "@headlessui/react": "^2.2.9",
         "@heroicons/react": "^2.2.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "ai": "^6.0.149",
         "aws-ssl-profiles": "^1.1.2",
         "aws-xray-sdk-core": "^3.12.0",
@@ -127,6 +129,23 @@
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.23",
         "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.36.tgz",
+      "integrity": "sha512-THQKwlknp7OU2ViLPfIU7W01XvDRM2eqH+4UULQgP64AopnwI9mGqqJeGIx2l/pxUu9yIDQtW9YtYM8kHm2CQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "pkce-challenge": "^5.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -3193,6 +3212,18 @@
         "react": ">= 16 || ^19.0.0-rc"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3948,6 +3979,68 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/@napi-rs/canvas": {
@@ -7387,6 +7480,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -7444,6 +7550,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -7878,6 +8023,46 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -7954,6 +8139,15 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -7977,7 +8171,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7991,7 +8184,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8323,12 +8515,69 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/crelt": {
       "version": "1.0.6",
@@ -8340,7 +8589,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -8581,6 +8829,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -8707,7 +8964,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -8726,6 +8982,12 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -8748,6 +9010,15 @@
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
@@ -8861,7 +9132,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8871,7 +9141,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8917,7 +9186,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -9036,6 +9304,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -9620,6 +9894,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/eventsource-parser": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
@@ -9639,6 +9934,67 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -9649,7 +10005,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -9701,6 +10056,22 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
@@ -9794,6 +10165,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -9854,6 +10246,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -9895,6 +10296,15 @@
         }
       }
     },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -9914,7 +10324,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9975,7 +10384,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -10000,7 +10408,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -10088,7 +10495,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10159,7 +10565,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10188,7 +10593,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -10459,6 +10863,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -10537,6 +10950,26 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/husky": {
@@ -10669,6 +11102,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-alphabetical": {
@@ -10991,6 +11442,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -11147,7 +11604,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -11364,6 +11820,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -12027,7 +12489,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12342,6 +12803,27 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-refs": {
       "version": "2.0.0",
@@ -12966,6 +13448,31 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -13105,6 +13612,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/next": {
       "version": "16.2.1",
@@ -13363,7 +13879,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13373,7 +13888,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13492,6 +14006,27 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/one-time": {
       "version": "1.0.0",
@@ -13657,6 +14192,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -13686,7 +14230,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13698,6 +14241,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -13755,6 +14308,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -13886,6 +14448,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -13909,6 +14484,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/qss": {
@@ -13940,6 +14530,46 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -14308,7 +14938,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14411,6 +15040,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/run-parallel": {
@@ -14558,6 +15203,51 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -14606,6 +15296,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -14656,7 +15352,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -14669,7 +15364,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14685,7 +15379,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14705,7 +15398,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14722,7 +15414,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14741,7 +15432,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14842,6 +15532,15 @@
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.0.0",
@@ -15293,6 +15992,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -15443,6 +16151,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -15855,6 +16577,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -15978,6 +16709,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
@@ -16297,7 +17037,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -16547,6 +17286,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -16591,6 +17336,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "i18n:extract": "node scripts/extract-i18n.js"
   },
   "dependencies": {
+    "@ai-sdk/mcp": "^1.0.36",
     "@ai-sdk/moonshotai": "^2.0.16",
     "@ai-sdk/openai": "^3.0.51",
     "@aws-sdk/client-auto-scaling": "^3.1021.0",
@@ -37,6 +38,7 @@
     "@codemirror/theme-one-dark": "^6.1.3",
     "@headlessui/react": "^2.2.9",
     "@heroicons/react": "^2.2.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "ai": "^6.0.149",
     "aws-ssl-profiles": "^1.1.2",
     "aws-xray-sdk-core": "^3.12.0",

--- a/src/__tests__/api/settings.test.ts
+++ b/src/__tests__/api/settings.test.ts
@@ -62,4 +62,26 @@ describe("POST /api/settings", () => {
       editorsize: "small",
     });
   });
+
+  it("persists the Canvas AI access flag", async () => {
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ai_canvas_access: true,
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(saveSettingsToS3).toHaveBeenCalledWith("user-123", {
+      locale: "en",
+      ai_canvas_access: true,
+    });
+    expect(body).toMatchObject({
+      ai_canvas_access: true,
+    });
+  });
 });

--- a/src/__tests__/lib/internal-mcp-auth.test.ts
+++ b/src/__tests__/lib/internal-mcp-auth.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInternalMcpToken,
+  verifyInternalMcpToken,
+} from "@/lib/mcp/internal-auth";
+
+describe("internal MCP auth", () => {
+  it("round-trips a short-lived token", () => {
+    const token = createInternalMcpToken("user-123");
+    expect(verifyInternalMcpToken(token)).toEqual({ userId: "user-123" });
+  });
+
+  it("rejects an invalid token", () => {
+    expect(() => verifyInternalMcpToken("not-a-token")).toThrow();
+  });
+});

--- a/src/app/api/assignments/sync/route.js
+++ b/src/app/api/assignments/sync/route.js
@@ -3,8 +3,7 @@ import { withErrorHandler, requireAuth } from "@/lib/api-error";
 import { CanvasClient } from "@/lib/canvas/client.js";
 import { syncAssignmentMetadata } from "@/lib/canvas/sync-assignments.js";
 import { cleanCourseName } from "@/lib/canvas/canvas-folders.js";
-import sql from "@/database/pgsql.js";
-import { decrypt } from "@/lib/crypto";
+import { loadCanvasCredentials } from "@/lib/canvas/credentials";
 
 /**
  * POST /api/assignments/sync
@@ -15,22 +14,15 @@ import { decrypt } from "@/lib/crypto";
 export const POST = withErrorHandler(async () => {
   const user = await requireAuth();
 
-  const credRows = await sql`
-    SELECT canvas_token, canvas_domain
-    FROM app.login
-    WHERE user_id = ${user.user_id}
-  `;
-  const { canvas_token, canvas_domain } = credRows[0] ?? {};
-
-  if (!canvas_token || !canvas_domain) {
+  const credentials = await loadCanvasCredentials(user.user_id);
+  if (!credentials) {
     return NextResponse.json({
       synced: false,
       reason: "No Canvas account connected",
     });
   }
 
-  const plainToken = decrypt(canvas_token, user.user_id);
-  const client = new CanvasClient(canvas_domain, plainToken);
+  const client = new CanvasClient(credentials.domain, credentials.token);
 
   const { data: allCourses, error } = await client.getCourses();
   if (error || !allCourses) {

--- a/src/app/api/auth/login/route.js
+++ b/src/app/api/auth/login/route.js
@@ -26,13 +26,13 @@ import {
   isAccountLocked,
   getLockoutMinutesRemaining,
 } from "@/lib/loginLockout.js";
-import { decrypt } from "@/lib/crypto";
 import { sqsClient, getCanvasImportQueueUrl } from "@/lib/sqs";
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { ensureWorkerRunning } from "@/lib/ecs";
 import logger from "@/lib/logger";
 import { withErrorHandler } from "@/lib/api-error";
 import { loginSchema, validateBody } from "@/lib/validations/schemas";
+import { loadCanvasCredentials } from "@/lib/canvas/credentials";
 
 export const POST = withErrorHandler(async (request) => {
   // 1. Parse and validate request body
@@ -154,14 +154,8 @@ export const POST = withErrorHandler(async (request) => {
  * Called fire-and-forget after login — never throws to the caller.
  */
 async function queueCanvasSync(userId) {
-  const credRows = await sql`
-    SELECT canvas_token, canvas_domain FROM app.login WHERE user_id = ${userId}
-  `;
-  const { canvas_token, canvas_domain } = credRows[0] ?? {};
-  if (!canvas_token || !canvas_domain) return;
-
-  // decrypt the BYOK-encrypted token before using it
-  const plainToken = decrypt(canvas_token, userId);
+  const credentials = await loadCanvasCredentials(userId);
+  if (!credentials) return;
 
   const prevCourseRows = await sql`
     SELECT DISTINCT canvas_course_id FROM app.canvas_imports WHERE user_id = ${userId}
@@ -172,7 +166,7 @@ async function queueCanvasSync(userId) {
     prevCourseRows.map((r) => String(r.canvas_course_id)),
   );
 
-  const client = new CanvasClient(canvas_domain, plainToken);
+  const client = new CanvasClient(credentials.domain, credentials.token);
   const { data: allCourses } = await client.getCourses();
 
   const courses = (allCourses ?? [])

--- a/src/app/api/canvas/connect/route.js
+++ b/src/app/api/canvas/connect/route.js
@@ -2,32 +2,35 @@ import { NextResponse } from "next/server";
 import { withErrorHandler, requireAuth, ApiError } from "@/lib/api-error";
 import { CanvasClient } from "@/lib/canvas/client.js";
 import sql from "@/database/pgsql.js";
-import { encrypt, decrypt } from "@/lib/crypto";
+import { encrypt } from "@/lib/crypto";
 import { preWarmMarker } from "@/lib/marker-ec2";
+import { checkRateLimit } from "@/lib/rateLimiter";
+import { loadCanvasCredentials } from "@/lib/canvas/credentials";
 
 const INSTRUCTURE_DOMAIN = /^[\w-]+\.instructure\.com$/i;
+const CANVAS_TOKEN_MAX_LENGTH = 4096;
 
 function isValidCanvasDomain(domain) {
   if (!domain || typeof domain !== "string") return false;
   return INSTRUCTURE_DOMAIN.test(domain.trim());
 }
 
+function noStoreJson(body, init) {
+  const response = NextResponse.json(body, init);
+  response.headers.set("Cache-Control", "no-store");
+  return response;
+}
+
 export const GET = withErrorHandler(async () => {
   const user = await requireAuth();
 
-  const rows = await sql`
-          SELECT canvas_token, canvas_domain FROM app.login WHERE user_id = ${user.user_id}
-      `;
-  const { canvas_token, canvas_domain } = rows[0] ?? {};
-  if (!canvas_token || !canvas_domain)
-    return NextResponse.json({ connected: false });
+  const credentials = await loadCanvasCredentials(user.user_id);
+  if (!credentials) return noStoreJson({ connected: false });
 
-  // decrypt the stored token before using it
-  const plainToken = decrypt(canvas_token, user.user_id);
-  const client = new CanvasClient(canvas_domain, plainToken);
+  const client = new CanvasClient(credentials.domain, credentials.token);
   const { data: courses, error } = await client.getCourses();
 
-  if (error) return NextResponse.json({ connected: false });
+  if (error) return noStoreJson({ connected: false });
 
   const coursesWithModules = await Promise.all(
     (courses ?? []).map(async (course) => {
@@ -36,9 +39,9 @@ export const GET = withErrorHandler(async () => {
     }),
   );
 
-  return NextResponse.json({
+  return noStoreJson({
     connected: true,
-    domain: canvas_domain,
+    domain: credentials.domain,
     courses: coursesWithModules,
   });
 });
@@ -55,28 +58,38 @@ export const DELETE = withErrorHandler(async () => {
 
 export const POST = withErrorHandler(async (request) => {
   const user = await requireAuth();
+  const limited = await checkRateLimit("canvas-connect", user.user_id);
+  if (limited) return limited;
 
   const { token, domain } = await request.json();
-  if (!token || !domain) {
+  const normalizedToken = typeof token === "string" ? token.trim() : "";
+  const normalizedDomain =
+    typeof domain === "string" ? domain.trim().toLowerCase() : "";
+
+  if (!normalizedToken || !normalizedDomain) {
     throw new ApiError(400, "Token and domain are required");
   }
 
-  if (!isValidCanvasDomain(domain)) {
+  if (normalizedToken.length > CANVAS_TOKEN_MAX_LENGTH) {
+    throw new ApiError(400, "Canvas token is too long");
+  }
+
+  if (!isValidCanvasDomain(normalizedDomain)) {
     throw new ApiError(400, "Domain must be a valid *.instructure.com address");
   }
 
   // validate the token against Canvas before storing
-  const client = new CanvasClient(domain, token);
+  const client = new CanvasClient(normalizedDomain, normalizedToken);
   const { data: courses, error } = await client.getCourses();
   if (error) {
     throw new ApiError(400, `Canvas connection failed: ${error}`);
   }
 
   // encrypt token before persisting
-  const encryptedToken = encrypt(token, user.user_id);
+  const encryptedToken = encrypt(normalizedToken, user.user_id);
   await sql`
           UPDATE app.login
-          SET canvas_token = ${encryptedToken}, canvas_domain = ${domain}
+          SET canvas_token = ${encryptedToken}, canvas_domain = ${normalizedDomain}
           WHERE user_id = ${user.user_id}
       `;
 
@@ -84,5 +97,5 @@ export const POST = withErrorHandler(async (request) => {
   // fire-and-forget, never throws, gives ~90s head start before first import
   preWarmMarker();
 
-  return NextResponse.json({ success: true, courses: courses ?? [] });
+  return noStoreJson({ success: true, courses: courses ?? [] });
 });

--- a/src/app/api/canvas/courses/route.js
+++ b/src/app/api/canvas/courses/route.js
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
 import { withErrorHandler, requireAuth, ApiError } from '@/lib/api-error';
 import { CanvasClient } from '@/lib/canvas/client.js';
-import sql from '@/database/pgsql.js';
-import { decrypt } from '@/lib/crypto';
+import { loadCanvasCredentials } from '@/lib/canvas/credentials';
 
 /**
  * GET /api/canvas/courses
@@ -16,20 +15,12 @@ export const GET = withErrorHandler(async () => {
   const user = await requireAuth();
 
   // Retrieve stored Canvas credentials for this user
-  const rows = await sql`
-    SELECT canvas_token, canvas_domain
-    FROM app.login
-    WHERE user_id = ${user.user_id}
-  `;
-
-  const { canvas_token, canvas_domain } = rows[0] ?? {};
-
-  if (!canvas_token || !canvas_domain) {
+  const credentials = await loadCanvasCredentials(user.user_id);
+  if (!credentials) {
     throw new ApiError(400, 'No Canvas account connected. Please add your API token in Settings.');
   }
 
-  const plainToken = decrypt(canvas_token, user.user_id);
-  const client = new CanvasClient(canvas_domain, plainToken);
+  const client = new CanvasClient(credentials.domain, credentials.token);
 
   // Fetch all active courses the user is enrolled in as a student
   const { data: courses, error: coursesError } = await client.getCourses();

--- a/src/app/api/canvas/import/route.js
+++ b/src/app/api/canvas/import/route.js
@@ -5,8 +5,8 @@ import sql from "@/database/pgsql.js";
 import { sqsClient, getCanvasImportQueueUrl } from "@/lib/sqs";
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { ensureWorkerRunning } from "@/lib/ecs";
-import { decrypt } from "@/lib/crypto";
 import logger from "@/lib/logger";
+import { loadCanvasCredentials } from "@/lib/canvas/credentials";
 
 /**
  * POST /api/canvas/import
@@ -27,23 +27,13 @@ export const POST = withErrorHandler(async (request) => {
     throw new ApiError(400, "courseIds array is required");
   }
 
-  const rows = await sql`
-    SELECT canvas_token, canvas_domain
-    FROM app.login
-    WHERE user_id = ${user.user_id}
-  `;
-
-  const { canvas_token, canvas_domain } = rows[0] ?? {};
-
-  if (!canvas_token || !canvas_domain) {
+  const credentials = await loadCanvasCredentials(user.user_id);
+  if (!credentials) {
     throw new ApiError(400, "No Canvas account connected");
   }
 
-  // decrypt the stored token before using it
-  const plainToken = decrypt(canvas_token, user.user_id);
-
   // Validate the token is still live before queuing
-  const client = new CanvasClient(canvas_domain, plainToken);
+  const client = new CanvasClient(credentials.domain, credentials.token);
   const { data: courses, error: coursesError } = await client.getCourses();
   if (!courses && coursesError) {
     throw new ApiError(401, "Canvas token is invalid or expired");

--- a/src/app/api/canvas/sync/route.js
+++ b/src/app/api/canvas/sync/route.js
@@ -5,8 +5,8 @@ import sql from "@/database/pgsql.js";
 import { sqsClient, getCanvasImportQueueUrl } from "@/lib/sqs";
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { ensureWorkerRunning } from "@/lib/ecs";
-import { decrypt } from "@/lib/crypto";
 import logger from "@/lib/logger";
+import { loadCanvasCredentials } from "@/lib/canvas/credentials";
 
 /**
  * POST /api/canvas/sync
@@ -21,21 +21,13 @@ import logger from "@/lib/logger";
 export const POST = withErrorHandler(async () => {
   const user = await requireAuth();
 
-  const credRows = await sql`
-    SELECT canvas_token, canvas_domain
-    FROM app.login
-    WHERE user_id = ${user.user_id}
-  `;
-  const { canvas_token, canvas_domain } = credRows[0] ?? {};
-
-  if (!canvas_token || !canvas_domain) {
+  const credentials = await loadCanvasCredentials(user.user_id);
+  if (!credentials) {
     return NextResponse.json({
       queued: false,
       reason: "No Canvas account connected",
     });
   }
-
-  const plainToken = decrypt(canvas_token, user.user_id);
 
   // Derive the set of course IDs previously imported by this user
   const prevCourseRows = await sql`
@@ -56,7 +48,7 @@ export const POST = withErrorHandler(async () => {
   );
 
   // Fetch current course list from Canvas to get up-to-date name / course_code
-  const client = new CanvasClient(canvas_domain, plainToken);
+  const client = new CanvasClient(credentials.domain, credentials.token);
   const { data: allCourses } = await client.getCourses();
 
   const courses = (allCourses ?? [])
@@ -125,8 +117,8 @@ export const POST = withErrorHandler(async () => {
 export const GET = withErrorHandler(async () => {
   const user = await requireAuth();
 
-  const [credRows, prevCourseRows, activeJobRows] = await Promise.all([
-    sql`SELECT canvas_token, canvas_domain FROM app.login WHERE user_id = ${user.user_id}`,
+  const [credentials, prevCourseRows, activeJobRows] = await Promise.all([
+    loadCanvasCredentials(user.user_id),
     sql`SELECT COUNT(DISTINCT canvas_course_id)::int AS count FROM app.canvas_imports WHERE user_id = ${user.user_id}`,
     sql`
       SELECT id, status, created_at FROM app.canvas_import_jobs
@@ -134,12 +126,10 @@ export const GET = withErrorHandler(async () => {
       ORDER BY created_at DESC LIMIT 1
     `,
   ]);
-
-  const { canvas_token } = credRows[0] ?? {};
   const courseCount = prevCourseRows[0]?.count ?? 0;
 
   return NextResponse.json({
-    available: !!(canvas_token && courseCount > 0),
+    available: !!(credentials && courseCount > 0),
     courseCount,
     activeJob: activeJobRows[0] ?? null,
   });

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -26,6 +26,8 @@ import { chunkText } from "@/lib/chunking";
 import { replaceNoteEmbeddings } from "@/lib/rag/indexing";
 import { processExtractedText } from "@/lib/canvas/text-processing.js";
 import { cacheInvalidate, cacheKeys } from "@/lib/cache";
+import { resolveAppOrigin } from "@/lib/chat/canvas-mcp-client";
+import { getOptionalCanvasTooling } from "@/lib/chat/canvas-tooling";
 
 import {
   normalizeUuidList,
@@ -444,6 +446,19 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
                   `(id: ${effectiveSessionContext.lastFolder.id}). Use that parentID directly when it fits.`;
               }
 
+              const appOrigin = resolveAppOrigin({
+                requestOrigin: request.nextUrl.origin,
+                referer: request.headers.get("referer"),
+              });
+              const {
+                client: canvasMcpClient,
+                tools: canvasTools,
+                instruction: canvasInstruction,
+              } = await getOptionalCanvasTooling({
+                userId,
+                appOrigin,
+              });
+
               const toolInstruction =
                 "Tools available:\n" +
                 "- getChunks({ query, mode?, scope? }) — search notes for relevant chunks. mode: 'semantic' (default, conceptual match), 'exact' (literal phrase/term), 'both'. scope: 'session' (default, stay in current scope) or 'all' (search across all notes). Returns chunk text + noteId per hit.\n" +
@@ -451,7 +466,8 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
                 "- findFolder({ query }) — search for a folder/course directory by name. Use when parent folder is not already known.\n" +
                 "- makeMDNote({ text, parentID?, title? }) — create a markdown note. Set parentID to place it in the right folder.\n" +
                 "When the user asks to create/save/write a note: if you already know the parentID (from context below), call makeMDNote directly. Otherwise call findFolder first. Prefer session scope first. Only use scope='all' when the user asks to search beyond the current scope or when scoped search clearly isn't enough." +
-                scopedParentHint;
+                scopedParentHint +
+                (canvasInstruction ? `\n\n${canvasInstruction}` : "");
 
               // ── tool definitions ──────────────────────────────────────────
               const makeMDNote = tool({
@@ -700,31 +716,43 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
                 maxOutputTokens: getLlmMaxTokens(),
                 ...(thinkingMode !== "off" && { temperature: 1 }),
                 stopWhen: stepCountIs(50),
-                tools: { getChunks, readNote, findFolder, makeMDNote },
+                tools: {
+                  getChunks,
+                  readNote,
+                  findFolder,
+                  makeMDNote,
+                  ...canvasTools,
+                },
                 providerOptions: { moonshotai: moonshotOptions },
               };
 
               // ── stream LLM ────────────────────────────────────────────────
               const t0 = Date.now();
               let reply = "";
-              const result = streamText({ model: model!, ...llmCallOptions });
-              for await (const part of result.fullStream) {
-                if (part.type === "reasoning-delta") {
-                  controller.enqueue(
-                    encoder.encode(toSseEvent("thinking", { text: part.text })),
-                  );
-                } else if (part.type === "text-delta") {
-                  reply += part.text;
-                  controller.enqueue(
-                    encoder.encode(toSseEvent("token", { text: part.text })),
-                  );
-                } else if (part.type === "tool-call") {
-                  controller.enqueue(
-                    encoder.encode(
-                      toSseEvent("tool-call", { toolName: part.toolName }),
-                    ),
-                  );
+              try {
+                const result = streamText({ model: model!, ...llmCallOptions });
+                for await (const part of result.fullStream) {
+                  if (part.type === "reasoning-delta") {
+                    controller.enqueue(
+                      encoder.encode(
+                        toSseEvent("thinking", { text: part.text }),
+                      ),
+                    );
+                  } else if (part.type === "text-delta") {
+                    reply += part.text;
+                    controller.enqueue(
+                      encoder.encode(toSseEvent("token", { text: part.text })),
+                    );
+                  } else if (part.type === "tool-call") {
+                    controller.enqueue(
+                      encoder.encode(
+                        toSseEvent("tool-call", { toolName: part.toolName }),
+                      ),
+                    );
+                  }
                 }
+              } finally {
+                await canvasMcpClient?.close().catch(() => {});
               }
               void Metrics.llmLatency(Date.now() - t0);
 
@@ -993,6 +1021,19 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       `(id: ${effectiveSessionContext.lastFolder.id}). Use that parentID directly when it fits.`;
   }
 
+  const appOrigin = resolveAppOrigin({
+    requestOrigin: request.nextUrl.origin,
+    referer: request.headers.get("referer"),
+  });
+  const {
+    client: canvasMcpClient,
+    tools: canvasTools,
+    instruction: canvasInstruction,
+  } = await getOptionalCanvasTooling({
+    userId,
+    appOrigin,
+  });
+
   const toolInstruction =
     "Tools available:\n" +
     "- getChunks({ query, mode?, scope? }) — search notes for relevant chunks. mode: 'semantic' (default, conceptual match), 'exact' (literal phrase/term), 'both'. scope: 'session' (default, stay in current scope) or 'all' (search across all notes). Returns chunk text + noteId per hit.\n" +
@@ -1000,7 +1041,8 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     "- findFolder({ query }) — search for a folder/course directory by name. Use when parent folder is not already known.\n" +
     "- makeMDNote({ text, parentID?, title? }) — create a markdown note. Set parentID to place it in the right folder.\n" +
     "When the user asks to create/save/write a note: if you already know the parentID (from context below), call makeMDNote directly. Otherwise call findFolder first. Prefer session scope first. Only use scope='all' when the user asks to search beyond the current scope or when scoped search clearly isn't enough." +
-    scopedParentHint;
+    scopedParentHint +
+    (canvasInstruction ? `\n\n${canvasInstruction}` : "");
 
   const chatMessages: ChatMessage[] = [
     {
@@ -1233,11 +1275,18 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     maxOutputTokens: getLlmMaxTokens(),
     ...(thinkingMode !== "off" && { temperature: 1 }),
     stopWhen: stepCountIs(50),
-    tools: { getChunks, readNote, findFolder, makeMDNote },
+    tools: {
+      getChunks,
+      readNote,
+      findFolder,
+      makeMDNote,
+      ...canvasTools,
+    },
     providerOptions: { moonshotai: moonshotOptions },
   };
 
   if (!model) {
+    await canvasMcpClient?.close().catch(() => {});
     await persistMessage(sessionId, "assistant", fallbackReply, uniqueSources);
     return NextResponse.json({
       reply: fallbackReply,
@@ -1259,10 +1308,16 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
 
   try {
     const t0 = Date.now();
-    const { text: reply, reasoningText } = await generateText({
-      model,
-      ...llmCallOptions,
-    });
+    const { text: reply, reasoningText } = await (async () => {
+      try {
+        return await generateText({
+          model,
+          ...llmCallOptions,
+        });
+      } finally {
+        await canvasMcpClient?.close().catch(() => {});
+      }
+    })();
     void Metrics.llmLatency(Date.now() - t0);
 
     await persistMessage(sessionId, "assistant", reply, uniqueSources);

--- a/src/app/api/mcp/canvas/route.ts
+++ b/src/app/api/mcp/canvas/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import logger from "@/lib/logger";
+import { CanvasClient } from "@/lib/canvas/client.js";
+import { loadCanvasCredentials } from "@/lib/canvas/credentials";
+import { createCanvasMcpServer } from "@/lib/canvas/mcp";
+import { verifyInternalMcpToken } from "@/lib/mcp/internal-auth";
+
+export const dynamic = "force-dynamic";
+
+function unauthorizedResponse(message: string, status = 401) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+function extractBearerToken(request: NextRequest): string | null {
+  const header = request.headers.get("authorization");
+  if (!header?.startsWith("Bearer ")) return null;
+  return header.slice(7).trim() || null;
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const token = extractBearerToken(request);
+  if (!token) {
+    return unauthorizedResponse("Missing internal MCP token");
+  }
+
+  let userId: string;
+  try {
+    userId = verifyInternalMcpToken(token).userId;
+  } catch {
+    return unauthorizedResponse("Invalid internal MCP token");
+  }
+
+  const credentials = await loadCanvasCredentials(userId);
+  if (!credentials) {
+    return unauthorizedResponse("Canvas account not connected", 403);
+  }
+
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+  });
+  const client = new CanvasClient(credentials.domain, credentials.token);
+  const server = createCanvasMcpServer(client);
+
+  try {
+    await server.connect(transport);
+    return await transport.handleRequest(request);
+  } catch (error) {
+    logger.error("Canvas MCP request failed", {
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json({ error: "Canvas MCP request failed" }, { status: 500 });
+  } finally {
+    await transport.close().catch(() => {});
+    await server.close().catch(() => {});
+  }
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -34,6 +34,7 @@ export const POST = withErrorHandler(async (request) => {
       "lastName",
       "timezone",
       "editorsize",
+      "ai_canvas_access",
     ]);
     const sanitized: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(body)) {

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -498,6 +498,11 @@ const ChatInterface: FC<ChatInterfaceProps> = ({
                 readNote: "Reading note",
                 findFolder: "Looking up folder",
                 makeMDNote: "Creating note",
+                canvas_list_courses: "Reading Canvas courses",
+                canvas_list_modules: "Reading Canvas modules",
+                canvas_list_assignments: "Reading Canvas assignments",
+                canvas_list_module_items: "Reading Canvas module items",
+                canvas_get_file: "Reading Canvas file metadata",
               };
               const label = labels[toolName] ?? toolName;
               setMessages((prev) =>

--- a/src/components/settings/ai-section.jsx
+++ b/src/components/settings/ai-section.jsx
@@ -1,10 +1,36 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import useI18n from "@/lib/notes/hooks/use-i18n";
-import { inputClass } from "./settings-utils";
+import { useSettingsStore } from "@/lib/notes/state/ui/settings";
+import { Checkbox, CheckboxField } from "@/components/catalyst/checkbox";
+import { inputClass, saveBtnClass } from "./settings-utils";
 
 export default function AISection() {
   const { t } = useI18n();
+  const settings = useSettingsStore((state) => state.settings);
+  const updateSettings = useSettingsStore((state) => state.updateSettings);
+  const [canvasAccessEnabled, setCanvasAccessEnabled] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setCanvasAccessEnabled(Boolean(settings?.ai_canvas_access));
+  }, [settings?.ai_canvas_access]);
+
+  const handleSave = async (event) => {
+    event.preventDefault();
+    setSaving(true);
+    try {
+      await updateSettings({ ai_canvas_access: canvasAccessEnabled });
+      toast.success(t("AI settings saved"));
+    } catch (error) {
+      console.error("Failed to save AI settings:", error);
+      toast.error(t("Failed to save settings"));
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <div
@@ -20,47 +46,82 @@ export default function AISection() {
         </p>
       </div>
 
-      <div className="md:col-span-2">
-        <div className="space-y-8">
-          {/* model selector */}
-          <div>
-            <label
-              htmlFor="ai-model"
-              className="block text-sm/6 font-medium text-text"
+      <form className="md:col-span-2 space-y-8" onSubmit={handleSave}>
+        <div>
+          <label
+            htmlFor="ai-model"
+            className="block text-sm/6 font-medium text-text"
+          >
+            {t("Model")}
+          </label>
+          <p className="mt-1 text-sm text-text-tertiary">
+            {t("Powers chat, search, and study features.")}
+          </p>
+          <div className="mt-2 sm:max-w-xs">
+            <select
+              id="ai-model"
+              className={`${inputClass} appearance-auto`}
+              defaultValue="kimi-k2.5"
+              disabled
             >
-              {t("Model")}
-            </label>
-            <p className="mt-1 text-sm text-text-tertiary">
-              {t("Powers chat, search, and study features.")}
-            </p>
-            <div className="mt-2 sm:max-w-xs">
-              <select
-                id="ai-model"
-                className={`${inputClass} appearance-auto`}
-                defaultValue="kimi-k2.5"
-                disabled
-              >
-                <option value="kimi-k2.5">Kimi K2.5</option>
-              </select>
-            </div>
-          </div>
-
-          {/* BYOK status */}
-          <div className="border-t border-border pt-6">
-            <div className="flex items-center gap-2">
-              <h3 className="text-sm/6 font-medium text-text">
-                {t("Bring Your Own Key")}
-              </h3>
-              <span className="inline-flex items-center rounded-md bg-primary-500/10 px-2 py-0.5 text-xs font-medium text-primary-400 ring-1 ring-inset ring-primary-500/20">
-                {t("Beta")}
-              </span>
-            </div>
-            <p className="mt-1 text-sm text-text-tertiary">
-              {t("Bring Your Own Key is not available yet for beta users.")}
-            </p>
+              <option value="kimi-k2.5">Kimi K2.5</option>
+            </select>
           </div>
         </div>
-      </div>
+
+        <div className="border-t border-border pt-6">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm/6 font-medium text-text">
+              {t("Bring Your Own Key")}
+            </h3>
+            <span className="inline-flex items-center rounded-md bg-primary-500/10 px-2 py-0.5 text-xs font-medium text-primary-400 ring-1 ring-inset ring-primary-500/20">
+              {t("Beta")}
+            </span>
+          </div>
+          <p className="mt-1 text-sm text-text-tertiary">
+            {t("Bring Your Own Key is not available yet for beta users.")}
+          </p>
+        </div>
+
+        <div className="border-t border-border pt-6">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm/6 font-medium text-text">
+              {t("Canvas In Chat")}
+            </h3>
+            <span className="inline-flex items-center rounded-md bg-primary-500/10 px-2 py-0.5 text-xs font-medium text-primary-400 ring-1 ring-inset ring-primary-500/20">
+              {t("Beta")}
+            </span>
+          </div>
+          <p className="mt-1 text-sm text-text-tertiary">
+            {t(
+              "Allow AI chat to read your connected Canvas courses, modules, assignments, and file metadata through server-side tools.",
+            )}
+          </p>
+          <div className="mt-4 rounded-radius-lg border border-border-subtle bg-surface/70 p-4">
+            <CheckboxField>
+              <Checkbox
+                color="indigo"
+                checked={canvasAccessEnabled}
+                onChange={setCanvasAccessEnabled}
+              />
+              <label data-slot="label" className="text-sm text-text">
+                {t("Enable Canvas access in AI chat")}
+              </label>
+              <p data-slot="description" className="text-xs text-text-tertiary">
+                {t(
+                  "Canvas tokens stay server-side. Chat only gets filtered Canvas results, never your raw API key.",
+                )}
+              </p>
+            </CheckboxField>
+          </div>
+        </div>
+
+        <div className="flex">
+          <button type="submit" disabled={saving} className={saveBtnClass}>
+            {saving ? t("Saving...") : t("Save changes")}
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/src/components/settings/canvas-integration.jsx
+++ b/src/components/settings/canvas-integration.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
 import useI18n from "@/lib/notes/hooks/use-i18n";
 import {
@@ -29,9 +29,9 @@ export default function CanvasIntegration() {
 
   // Connection form state
   const [domain, setDomain] = useState("");
-  const [token, setToken] = useState("");
   const [isConnecting, setIsConnecting] = useState(false);
   const [connectionError, setConnectionError] = useState(null);
+  const tokenInputRef = useRef(null);
 
   // Post-connection state
   const [isConnected, setIsConnected] = useState(false);
@@ -200,12 +200,18 @@ export default function CanvasIntegration() {
   }, [selectedCourseIds]);
 
   const handleConnect = async () => {
-    if (!domain || !token) return;
+    const rawToken = tokenInputRef.current?.value?.trim() ?? "";
+    if (!domain || !rawToken) return;
 
     setIsConnecting(true);
     setConnectionError(null);
 
     try {
+      const token = rawToken;
+      if (tokenInputRef.current) {
+        tokenInputRef.current.value = "";
+      }
+
       const res = await fetch("/api/canvas/connect", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -247,7 +253,9 @@ export default function CanvasIntegration() {
       setRecentLogs([]);
       setMarkerColdStarting(false);
       setDomain("");
-      setToken("");
+      if (tokenInputRef.current) {
+        tokenInputRef.current.value = "";
+      }
       localStorage.removeItem(LS_SELECTED);
       localStorage.removeItem(LS_ERRORS);
       localStorage.removeItem(LS_ACTIVE_JOB);
@@ -324,8 +332,7 @@ export default function CanvasIntegration() {
         <CanvasConnectionForm
           domain={domain}
           setDomain={setDomain}
-          token={token}
-          setToken={setToken}
+          tokenInputRef={tokenInputRef}
           isConnecting={isConnecting}
           connectionError={connectionError}
           connectionWarning={connectionWarning}

--- a/src/components/settings/canvas/canvas-connection-form.jsx
+++ b/src/components/settings/canvas/canvas-connection-form.jsx
@@ -6,8 +6,7 @@ import useI18n from "@/lib/notes/hooks/use-i18n";
 export default function CanvasConnectionForm({
   domain,
   setDomain,
-  token,
-  setToken,
+  tokenInputRef,
   isConnecting,
   connectionError,
   connectionWarning,
@@ -107,11 +106,13 @@ export default function CanvasConnectionForm({
         </label>
         <div className="mt-2">
           <input
+            ref={tokenInputRef}
             id="canvas-token"
             type="password"
+            autoComplete="off"
+            autoCapitalize="none"
+            spellCheck={false}
             placeholder={t("Paste your Canvas API token here")}
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
             className="block w-full rounded-radius-md bg-surface border border-border-subtle px-3 py-1.5 text-sm text-text placeholder:text-text-tertiary focus:ring-1 focus:ring-primary-500/50 focus:border-primary-500/50 focus:outline-none"
           />
         </div>
@@ -126,7 +127,7 @@ export default function CanvasConnectionForm({
 
       <button
         type="button"
-        disabled={!domain || !token || isConnecting}
+        disabled={!domain || isConnecting}
         onClick={onConnect}
         className="rounded-md bg-primary-500 px-3 py-2 text-sm font-semibold text-white hover:bg-primary-400 disabled:opacity-50 disabled:cursor-not-allowed"
       >

--- a/src/lib/canvas/credentials.ts
+++ b/src/lib/canvas/credentials.ts
@@ -1,0 +1,27 @@
+import sql from "@/database/pgsql.js";
+import { decrypt } from "@/lib/crypto";
+
+export interface CanvasCredentials {
+  domain: string;
+  token: string;
+}
+
+export async function loadCanvasCredentials(
+  userId: string,
+): Promise<CanvasCredentials | null> {
+  const [row] = await sql`
+    SELECT canvas_token, canvas_domain
+    FROM app.login
+    WHERE user_id = ${userId}::uuid
+    LIMIT 1
+  `;
+
+  if (!row?.canvas_token || !row?.canvas_domain) {
+    return null;
+  }
+
+  return {
+    domain: row.canvas_domain,
+    token: decrypt(row.canvas_token, userId),
+  };
+}

--- a/src/lib/canvas/mcp.ts
+++ b/src/lib/canvas/mcp.ts
@@ -1,0 +1,335 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CanvasClient } from "@/lib/canvas/client.js";
+
+const MAX_RETURNED_ITEMS = 25;
+const MAX_TEXT_LENGTH = 500;
+
+function trimText(value: unknown, fallback = ""): string {
+  if (typeof value !== "string") return fallback;
+  return value.trim().slice(0, MAX_TEXT_LENGTH);
+}
+
+function clampItems<T>(items: T[], limit = MAX_RETURNED_ITEMS): T[] {
+  return items.slice(0, limit);
+}
+
+export function createCanvasMcpServer(client: CanvasClient) {
+  const server = new McpServer({
+    name: "oghmanotes-canvas",
+    version: "1.0.0",
+  });
+
+  server.registerTool(
+    "canvas_list_courses",
+    {
+      description:
+        "List the user's active Canvas courses. Read-only. Use first when you need a course ID.",
+      inputSchema: {
+        limit: z.number().int().min(1).max(MAX_RETURNED_ITEMS).optional(),
+      },
+      outputSchema: {
+        courses: z.array(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+            courseCode: z.string(),
+            term: z.string(),
+          }),
+        ),
+      },
+    },
+    async ({ limit }) => {
+      const { data, error } = await client.getCourses();
+      if (error) {
+        throw new Error(error);
+      }
+
+      const courses = clampItems(data ?? [], limit).map((course) => ({
+        id: String(course.id),
+        name: trimText(course.name, String(course.id)),
+        courseCode: trimText(course.course_code),
+        term: trimText(course?.term?.name),
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify({ courses }, null, 2) }],
+        structuredContent: { courses },
+      };
+    },
+  );
+
+  server.registerTool(
+    "canvas_list_modules",
+    {
+      description:
+        "List modules in a Canvas course. Read-only. Use after selecting a course.",
+      inputSchema: {
+        courseId: z.string().min(1),
+        limit: z.number().int().min(1).max(MAX_RETURNED_ITEMS).optional(),
+      },
+      outputSchema: {
+        modules: z.array(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+            itemCount: z.number().int().nonnegative(),
+            unlockAt: z.string().nullable(),
+          }),
+        ),
+      },
+    },
+    async ({ courseId, limit }) => {
+      const { data, error } = await client.getModules(courseId);
+      if (error) {
+        throw new Error(error);
+      }
+
+      const modules = clampItems(data ?? [], limit).map((module) => ({
+        id: String(module.id),
+        name: trimText(module.name, String(module.id)),
+        itemCount: Number(module.items_count ?? 0),
+        unlockAt:
+          typeof module.unlock_at === "string" ? module.unlock_at : null,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify({ modules }, null, 2) }],
+        structuredContent: { modules },
+      };
+    },
+  );
+
+  server.registerTool(
+    "canvas_list_assignments",
+    {
+      description:
+        "List assignments in a Canvas course. Read-only. Includes due dates and submission status when available.",
+      inputSchema: {
+        courseId: z.string().min(1),
+        limit: z.number().int().min(1).max(MAX_RETURNED_ITEMS).optional(),
+      },
+      outputSchema: {
+        assignments: z.array(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+            dueAt: z.string().nullable(),
+            htmlUrl: z.string().nullable(),
+            submissionState: z.string().nullable(),
+          }),
+        ),
+      },
+    },
+    async ({ courseId, limit }) => {
+      const { data, error } = await client.getAssignments(courseId);
+      if (error) {
+        throw new Error(error);
+      }
+
+      const assignments = clampItems(data ?? [], limit).map((assignment) => ({
+        id: String(assignment.id),
+        name: trimText(assignment.name, String(assignment.id)),
+        dueAt:
+          typeof assignment.due_at === "string" ? assignment.due_at : null,
+        htmlUrl:
+          typeof assignment.html_url === "string"
+            ? assignment.html_url
+            : null,
+        submissionState:
+          typeof assignment?.submission?.workflow_state === "string"
+            ? assignment.submission.workflow_state
+            : null,
+      }));
+
+      return {
+        content: [
+          { type: "text", text: JSON.stringify({ assignments }, null, 2) },
+        ],
+        structuredContent: { assignments },
+      };
+    },
+  );
+
+  server.registerTool(
+    "canvas_list_module_items",
+    {
+      description:
+        "List items inside a Canvas module. Read-only. Helpful for finding files, pages, and assignments inside a module.",
+      inputSchema: {
+        courseId: z.string().min(1),
+        moduleId: z.string().min(1),
+        limit: z.number().int().min(1).max(MAX_RETURNED_ITEMS).optional(),
+      },
+      outputSchema: {
+        items: z.array(
+          z.object({
+            id: z.string(),
+            title: z.string(),
+            type: z.string(),
+            contentId: z.string().nullable(),
+            htmlUrl: z.string().nullable(),
+          }),
+        ),
+      },
+    },
+    async ({ courseId, moduleId, limit }) => {
+      const { data, error } = await client.getModuleItems(courseId, moduleId);
+      if (error) {
+        throw new Error(error);
+      }
+
+      const items = clampItems(data ?? [], limit).map((item) => ({
+        id: String(item.id),
+        title: trimText(item.title, String(item.id)),
+        type: trimText(item.type, "unknown"),
+        contentId:
+          item.content_id === null || item.content_id === undefined
+            ? null
+            : String(item.content_id),
+        htmlUrl:
+          typeof item.html_url === "string" ? item.html_url.slice(0, 1000) : null,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify({ items }, null, 2) }],
+        structuredContent: { items },
+      };
+    },
+  );
+
+  server.registerTool(
+    "canvas_get_file",
+    {
+      description:
+        "Get metadata for one Canvas file by course ID and file ID. Read-only. Returns filename, content type, and download URL metadata only.",
+      inputSchema: {
+        courseId: z.string().min(1),
+        fileId: z.string().min(1),
+      },
+      outputSchema: {
+        file: z.object({
+          id: z.string(),
+          displayName: z.string(),
+          contentType: z.string().nullable(),
+          size: z.number().int().nonnegative().nullable(),
+          url: z.string().nullable(),
+          updatedAt: z.string().nullable(),
+        }),
+      },
+    },
+    async ({ courseId, fileId }) => {
+      const { data, error } = await client.getFile(courseId, fileId);
+      if (error) {
+        throw new Error(error);
+      }
+      if (!data) {
+        throw new Error("File not found");
+      }
+
+      const file = {
+        id: String(data.id),
+        displayName: trimText(data.display_name, String(data.id)),
+        contentType:
+          typeof data["content-type"] === "string"
+            ? data["content-type"]
+            : null,
+        size: Number.isFinite(data.size) ? Number(data.size) : null,
+        url: typeof data.url === "string" ? data.url.slice(0, 1000) : null,
+        updatedAt: typeof data.updated_at === "string" ? data.updated_at : null,
+      };
+
+      return {
+        content: [{ type: "text", text: JSON.stringify({ file }, null, 2) }],
+        structuredContent: { file },
+      };
+    },
+  );
+
+  return server;
+}
+
+export const canvasMcpToolSchemas = {
+  canvas_list_courses: {
+    inputSchema: z.object({
+      limit: z.number().int().min(1).max(MAX_RETURNED_ITEMS).optional(),
+    }),
+    outputSchema: z.object({
+      courses: z.array(
+        z.object({
+          id: z.string(),
+          name: z.string(),
+          courseCode: z.string(),
+          term: z.string(),
+        }),
+      ),
+    }),
+  },
+  canvas_list_modules: {
+    inputSchema: z.object({
+      courseId: z.string().min(1),
+      limit: z.number().int().min(1).max(MAX_RETURNED_ITEMS).optional(),
+    }),
+    outputSchema: z.object({
+      modules: z.array(
+        z.object({
+          id: z.string(),
+          name: z.string(),
+          itemCount: z.number().int().nonnegative(),
+          unlockAt: z.string().nullable(),
+        }),
+      ),
+    }),
+  },
+  canvas_list_assignments: {
+    inputSchema: z.object({
+      courseId: z.string().min(1),
+      limit: z.number().int().min(1).max(MAX_RETURNED_ITEMS).optional(),
+    }),
+    outputSchema: z.object({
+      assignments: z.array(
+        z.object({
+          id: z.string(),
+          name: z.string(),
+          dueAt: z.string().nullable(),
+          htmlUrl: z.string().nullable(),
+          submissionState: z.string().nullable(),
+        }),
+      ),
+    }),
+  },
+  canvas_list_module_items: {
+    inputSchema: z.object({
+      courseId: z.string().min(1),
+      moduleId: z.string().min(1),
+      limit: z.number().int().min(1).max(MAX_RETURNED_ITEMS).optional(),
+    }),
+    outputSchema: z.object({
+      items: z.array(
+        z.object({
+          id: z.string(),
+          title: z.string(),
+          type: z.string(),
+          contentId: z.string().nullable(),
+          htmlUrl: z.string().nullable(),
+        }),
+      ),
+    }),
+  },
+  canvas_get_file: {
+    inputSchema: z.object({
+      courseId: z.string().min(1),
+      fileId: z.string().min(1),
+    }),
+    outputSchema: z.object({
+      file: z.object({
+        id: z.string(),
+        displayName: z.string(),
+        contentType: z.string().nullable(),
+        size: z.number().int().nonnegative().nullable(),
+        url: z.string().nullable(),
+        updatedAt: z.string().nullable(),
+      }),
+    }),
+  },
+} as const;

--- a/src/lib/chat/canvas-mcp-client.ts
+++ b/src/lib/chat/canvas-mcp-client.ts
@@ -1,0 +1,67 @@
+import { createMCPClient, type MCPClient } from "@ai-sdk/mcp";
+import type { ToolSet } from "ai";
+import { canvasMcpToolSchemas } from "@/lib/canvas/mcp";
+import { createInternalMcpToken } from "@/lib/mcp/internal-auth";
+import logger from "@/lib/logger";
+
+function normalizeOrigin(value: string | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveAppOrigin(input: {
+  requestOrigin?: string | null;
+  referer?: string | null;
+}): string | null {
+  return (
+    normalizeOrigin(input.requestOrigin) ||
+    normalizeOrigin(input.referer) ||
+    normalizeOrigin(process.env.APP_BASE_URL) ||
+    normalizeOrigin(process.env.NEXTAUTH_URL)
+  );
+}
+
+export const canvasToolInstruction =
+  "Canvas tools available when course data is needed:\n" +
+  "- canvas_list_courses({ limit? }) — list active Canvas courses to find course IDs.\n" +
+  "- canvas_list_modules({ courseId, limit? }) — list modules in a Canvas course.\n" +
+  "- canvas_list_assignments({ courseId, limit? }) — list assignments with due dates and submission state.\n" +
+  "- canvas_list_module_items({ courseId, moduleId, limit? }) — inspect items inside a module.\n" +
+  "- canvas_get_file({ courseId, fileId }) — fetch Canvas file metadata only.\n" +
+  "Use Canvas tools only when the user asks about Canvas course content, assignments, modules, or files. Prefer note tools first when the answer likely exists in imported notes.";
+
+export async function createCanvasMcpTools(args: {
+  userId: string;
+  appOrigin: string | null;
+}): Promise<{
+  client: MCPClient | null;
+  tools: ToolSet;
+}> {
+  if (!args.appOrigin) {
+    logger.warn("Canvas MCP disabled: app origin unavailable", {
+      userId: args.userId,
+    });
+    return { client: null, tools: {} };
+  }
+
+  const client = await createMCPClient({
+    transport: {
+      type: "http",
+      url: `${args.appOrigin}/api/mcp/canvas`,
+      headers: {
+        Authorization: `Bearer ${createInternalMcpToken(args.userId)}`,
+      },
+      redirect: "error",
+    },
+  });
+
+  const tools = await client.tools({
+    schemas: canvasMcpToolSchemas,
+  });
+
+  return { client, tools };
+}

--- a/src/lib/chat/canvas-tooling.ts
+++ b/src/lib/chat/canvas-tooling.ts
@@ -1,0 +1,37 @@
+import type { MCPClient } from "@ai-sdk/mcp";
+import type { ToolSet } from "ai";
+import { getSettingsFromS3 } from "@/lib/notes/storage/s3-storage";
+import logger from "@/lib/logger";
+import {
+  canvasToolInstruction,
+  createCanvasMcpTools,
+} from "@/lib/chat/canvas-mcp-client";
+
+export async function getOptionalCanvasTooling(args: {
+  userId: string;
+  appOrigin: string | null;
+}): Promise<{
+  client: MCPClient | null;
+  tools: ToolSet;
+  instruction: string;
+}> {
+  const settings = await getSettingsFromS3(args.userId);
+  if (!settings?.ai_canvas_access) {
+    return { client: null, tools: {}, instruction: "" };
+  }
+
+  try {
+    const { client, tools } = await createCanvasMcpTools(args);
+    return {
+      client,
+      tools,
+      instruction: client ? canvasToolInstruction : "",
+    };
+  } catch (error) {
+    logger.warn("Canvas MCP tooling unavailable", {
+      userId: args.userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { client: null, tools: {}, instruction: "" };
+  }
+}

--- a/src/lib/mcp/internal-auth.ts
+++ b/src/lib/mcp/internal-auth.ts
@@ -1,0 +1,47 @@
+import jwt from "jsonwebtoken";
+
+const INTERNAL_MCP_AUDIENCE = "internal-mcp";
+const INTERNAL_MCP_SCOPE = "canvas";
+const INTERNAL_MCP_EXPIRY_SECONDS = 60;
+
+interface InternalMcpClaims {
+  sub: string;
+  aud: string;
+  scope: string;
+}
+
+function getInternalMcpSecret(): string {
+  if (process.env.MCP_INTERNAL_AUTH_SECRET?.trim()) {
+    return process.env.MCP_INTERNAL_AUTH_SECRET.trim();
+  }
+  if (process.env.JWT_SECRET?.trim()) {
+    return process.env.JWT_SECRET.trim();
+  }
+  throw new Error(
+    "JWT_SECRET or MCP_INTERNAL_AUTH_SECRET must be set for internal MCP auth",
+  );
+}
+
+export function createInternalMcpToken(userId: string): string {
+  return jwt.sign(
+    {
+      sub: userId,
+      aud: INTERNAL_MCP_AUDIENCE,
+      scope: INTERNAL_MCP_SCOPE,
+    } satisfies InternalMcpClaims,
+    getInternalMcpSecret(),
+    { expiresIn: INTERNAL_MCP_EXPIRY_SECONDS },
+  );
+}
+
+export function verifyInternalMcpToken(token: string): { userId: string } {
+  const payload = jwt.verify(token, getInternalMcpSecret(), {
+    audience: INTERNAL_MCP_AUDIENCE,
+  }) as InternalMcpClaims;
+
+  if (payload.scope !== INTERNAL_MCP_SCOPE || !payload.sub) {
+    throw new Error("Invalid internal MCP token");
+  }
+
+  return { userId: payload.sub };
+}

--- a/src/lib/notes/types/settings.ts
+++ b/src/lib/notes/types/settings.ts
@@ -11,6 +11,7 @@ export interface Settings {
   lastName?: string;
   timezone?: string;
   editorsize?: "small" | "large";
+  ai_canvas_access?: boolean;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -18,4 +19,5 @@ export const DEFAULT_SETTINGS: Settings = {
   split_sizes: [200, 800],
   locale: Locale.EN,
   theme: "system",
+  ai_canvas_access: false,
 };

--- a/src/lib/rateLimitConfig.ts
+++ b/src/lib/rateLimitConfig.ts
@@ -11,6 +11,7 @@ export const RATE_LIMITS: Record<string, RateLimitRule> = {
   // tier 1 — expensive external API calls
   'chat':           { limit: 120, windowSeconds: 3600,  keyType: 'userId' },
   'extract':        { limit: 10,  windowSeconds: 3600,  keyType: 'userId' },
+  'canvas-connect': { limit: 10,  windowSeconds: 3600,  keyType: 'userId' },
 
   // tier 2 — auth security (public endpoints)
   'register':       { limit: 5,   windowSeconds: 3600,  keyType: 'ip' },


### PR DESCRIPTION
## Summary
- add server-side Canvas MCP tools for AI chat
- harden Canvas token handling and internal auth flow
- add per-user Canvas-in-chat setting and tests

## Verification
- npm run test:ci -- src/__tests__/api/settings.test.ts src/__tests__/lib/crypto.test.ts src/__tests__/lib/internal-mcp-auth.test.ts
- npx tsc -p tsconfig.json --noEmit
- npm run lint -- src/components/settings/ai-section.jsx src/components/settings/canvas-integration.jsx src/components/settings/canvas/canvas-connection-form.jsx src/app/api/chat/route.ts src/app/api/mcp/canvas/route.ts src/lib/canvas/credentials.ts src/lib/canvas/mcp.ts src/lib/chat/canvas-mcp-client.ts src/lib/chat/canvas-tooling.ts src/lib/mcp/internal-auth.ts infra/chat-lambda/handler.ts src/app/api/canvas/connect/route.js src/app/api/canvas/courses/route.js src/app/api/canvas/import/route.js src/app/api/canvas/sync/route.js src/app/api/assignments/sync/route.js src/app/api/auth/login/route.js src/__tests__/api/settings.test.ts src/__tests__/lib/internal-mcp-auth.test.ts