### PR TITLE
fix(tree): eliminate N+1 note fetches on tree load

### DIFF
--- a/src/app/api/tree/children/route.ts
+++ b/src/app/api/tree/children/route.ts
@@ -40,7 +40,8 @@ export const GET = withErrorHandler(async (request) => {
             n.title,
             n.is_folder as "isFolder",
             ti.is_expanded as "isExpanded",
-            n.s3_key as "s3Key"
+            n.s3_key as "s3Key",
+            n.pinned
           FROM app.tree_items ti
           JOIN app.notes n ON ti.note_id = n.note_id
           WHERE ti.user_id = ${user.user_id}::uuid
@@ -55,7 +56,8 @@ export const GET = withErrorHandler(async (request) => {
             n.title,
             n.is_folder as "isFolder",
             ti.is_expanded as "isExpanded",
-            n.s3_key as "s3Key"
+            n.s3_key as "s3Key",
+            n.pinned
           FROM app.tree_items ti
           JOIN app.notes n ON ti.note_id = n.note_id
           WHERE ti.user_id = ${user.user_id}::uuid
@@ -67,12 +69,13 @@ export const GET = withErrorHandler(async (request) => {
 
     const body = {
       parentId: parentId || 'root',
-      items: rows.map((row: { id: string; title: string; isFolder: boolean; isExpanded: boolean; s3Key: string | null }) => ({
+      items: rows.map((row: { id: string; title: string; isFolder: boolean; isExpanded: boolean; s3Key: string | null; pinned: number }) => ({
         id: row.id,
         title: row.title,
         isFolder: row.isFolder,
         isExpanded: row.isExpanded,
         s3Key: row.s3Key || null,
+        pinned: row.pinned ?? 0,
       })),
     };
 

--- a/src/lib/notes/api/tree.ts
+++ b/src/lib/notes/api/tree.ts
@@ -11,6 +11,8 @@ interface TreeItem {
   title: string;
   isFolder: boolean;
   isExpanded: boolean;
+  s3Key: string | null;
+  pinned: number;
 }
 
 interface FetchChildrenResponse {

--- a/src/lib/notes/state/tree.ts
+++ b/src/lib/notes/state/tree.ts
@@ -9,7 +9,7 @@ import TreeActions, {
   TreeModel,
 } from "@/lib/notes/types/tree";
 import noteCache from "../cache/note";
-import { NOTE_DELETED } from "@/lib/notes/types/meta";
+import { NOTE_DELETED, NOTE_SHARED, NOTE_PINNED } from "@/lib/notes/types/meta";
 import { NoteModel } from "@/lib/notes/types/note";
 import { uiCache } from "../cache";
 
@@ -163,32 +163,23 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
           isExpanded: item.isExpanded ?? false,
           isChildrenLoading: false,
           isFolder: item.isFolder ?? false,
+          // use the title + metadata already returned by the tree children API
+          // so the sidebar renders instantly without N individual note fetches
+          data: {
+            id: item.id,
+            title: item.title ?? "Untitled",
+            isFolder: item.isFolder ?? false,
+            s3Key: item.s3Key ?? undefined,
+            deleted: NOTE_DELETED.NORMAL,
+            shared: NOTE_SHARED.PRIVATE,
+            pinned: item.pinned ?? NOTE_PINNED.UNPINNED,
+          },
         };
         newTree.items[item.id] = treeItem;
         rootChildren.push(item.id);
       }
 
       newTree.items[ROOT_ID].children = rootChildren;
-
-      if (items.length > 0) {
-        // Fetch note data for all root items in parallel
-        const noteResults = await Promise.all(
-          items.map((item: any) =>
-            noteAPI
-              .fetch(item.id)
-              .then((noteData: NoteModel) => ({ id: item.id, data: noteData }))
-              .catch((e: any) => {
-                console.error(`Failed to fetch note ${item.id}:`, e);
-                return null;
-              }),
-          ),
-        );
-        for (const result of noteResults) {
-          if (result && newTree.items[result.id]) {
-            newTree.items[result.id].data = result.data;
-          }
-        }
-      }
 
       set({ tree: newTree, initLoaded: true });
 
@@ -245,6 +236,16 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
             isExpanded: item.isExpanded ?? false,
             isChildrenLoading: false,
             isFolder: item.isFolder ?? false,
+            // use the title + metadata already returned by the tree children API
+            data: {
+              id: item.id,
+              title: item.title ?? "Untitled",
+              isFolder: item.isFolder ?? false,
+              s3Key: item.s3Key ?? undefined,
+              deleted: NOTE_DELETED.NORMAL,
+              shared: NOTE_SHARED.PRIVATE,
+              pinned: item.pinned ?? NOTE_PINNED.UNPINNED,
+            },
           };
           newTree.items[item.id] = treeItem;
           childIds.push(item.id);
@@ -257,27 +258,6 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
             children: childIds,
             childrenLoaded: true,
           };
-        }
-
-        // Fetch note data for children
-        const notePromises = childrenResponse.items.map((item: any) =>
-          noteAPI
-            .fetch(item.id)
-            .then((noteData: NoteModel) => ({
-              id: item.id,
-              data: noteData,
-            }))
-            .catch((e: any) => {
-              console.error(`Failed to fetch note ${item.id}:`, e);
-              return null;
-            }),
-        );
-
-        const noteResults = await Promise.all(notePromises);
-        for (const result of noteResults) {
-          if (result && newTree.items[result.id]) {
-            newTree.items[result.id].data = result.data;
-          }
         }
 
         set({ tree: newTree });


### PR DESCRIPTION
## Summary
- Tree sidebar was showing all notes as "Untitled" after clearing browser data because `initTree` and `loadChildren` discarded titles from the `/api/tree/children` response and re-fetched each note individually — those individual fetches silently failed (401)
- Now uses data from the single tree children API response directly, eliminating the N+1 fetch pattern
- Added `pinned` to the tree children SQL query and response so pin indicators work without a separate fetch

## Test plan
- [x] 545/545 tests pass
- [x] 0 lint errors
- [x] Type check clean on changed files
- [x] Pre-existing build failure (MCP module) confirmed unrelated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tree items now support a pinned status indicator, allowing users to identify pinned items at a glance.

* **Performance Improvements**
  * Streamlined data initialization for tree views by consolidating data retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->