### PR TITLE
fix(import): prevent duplicate root-level notes on Canvas re-import

### DIFF
--- a/database/migrations/015_dedup_root_notes.sql
+++ b/database/migrations/015_dedup_root_notes.sql
@@ -1,0 +1,38 @@
+-- Migration 015: deduplicate root-level notes created by Canvas import bug
+--
+-- Context: findOrCreateNote used `parent_id = $1::uuid` which evaluates to
+-- unknown when parent_id is NULL (root level). This meant re-imports never
+-- found existing root notes and created duplicates each time.
+--
+-- Strategy: for each (user_id, title) group at root level with duplicates,
+-- keep the oldest note (MIN created_at) and soft-delete the rest.
+-- Safe to re-run — only touches notes not already deleted.
+
+WITH duplicates AS (
+  SELECT
+    n.user_id,
+    n.title,
+    MIN(n.created_at) AS keep_created_at
+  FROM app.notes n
+  JOIN app.tree_items t ON t.note_id = n.note_id AND t.user_id = n.user_id
+  WHERE t.parent_id IS NULL
+    AND n.is_folder = false
+    AND n.deleted = 0
+    AND n.deleted_at IS NULL
+  GROUP BY n.user_id, n.title
+  HAVING COUNT(*) > 1
+),
+to_delete AS (
+  SELECT n.note_id
+  FROM app.notes n
+  JOIN app.tree_items t ON t.note_id = n.note_id AND t.user_id = n.user_id
+  JOIN duplicates d ON d.user_id = n.user_id AND d.title = n.title
+  WHERE t.parent_id IS NULL
+    AND n.is_folder = false
+    AND n.deleted = 0
+    AND n.deleted_at IS NULL
+    AND n.created_at > d.keep_created_at
+)
+UPDATE app.notes
+SET deleted = 1, deleted_at = NOW()
+WHERE note_id IN (SELECT note_id FROM to_delete);

--- a/src/lib/canvas/import-worker.js
+++ b/src/lib/canvas/import-worker.js
@@ -206,17 +206,30 @@ async function createNote(userId, title, parentId, opts = {}) {
 // find an existing note by title under a parent, or create a new one
 // handles concurrent inserts by catching unique-violation and re-fetching
 async function findOrCreateNote(userId, title, parentId, opts = {}) {
-  const existing = await sql`
-    SELECT n.note_id FROM app.notes n
-    JOIN app.tree_items t ON t.note_id = n.note_id
-    WHERE n.user_id = ${userId}::uuid
-      AND t.user_id = ${userId}::uuid
-      AND n.title = ${title}
-      AND n.is_folder = false
-      AND n.deleted = 0
-      AND t.parent_id = ${parentId}::uuid
-    LIMIT 1
-  `;
+  // SQL `= NULL` is always unknown — split query for null vs non-null parent
+  const existing = parentId
+    ? await sql`
+        SELECT n.note_id FROM app.notes n
+        JOIN app.tree_items t ON t.note_id = n.note_id
+        WHERE n.user_id = ${userId}::uuid
+          AND t.user_id = ${userId}::uuid
+          AND n.title = ${title}
+          AND n.is_folder = false
+          AND n.deleted = 0
+          AND t.parent_id = ${parentId}::uuid
+        LIMIT 1
+      `
+    : await sql`
+        SELECT n.note_id FROM app.notes n
+        JOIN app.tree_items t ON t.note_id = n.note_id
+        WHERE n.user_id = ${userId}::uuid
+          AND t.user_id = ${userId}::uuid
+          AND n.title = ${title}
+          AND n.is_folder = false
+          AND n.deleted = 0
+          AND t.parent_id IS NULL
+        LIMIT 1
+      `;
   if (existing.length > 0) {
     const noteId = existing[0].note_id;
     // backfill canvas metadata on re-import if not already set
@@ -238,17 +251,29 @@ async function findOrCreateNote(userId, title, parentId, opts = {}) {
   } catch (err) {
     // concurrent insert won the race — re-fetch the winner
     if (err.code === "23505") {
-      const [row] = await sql`
-        SELECT n.note_id FROM app.notes n
-        JOIN app.tree_items t ON t.note_id = n.note_id
-        WHERE n.user_id = ${userId}::uuid
-          AND t.user_id = ${userId}::uuid
-          AND n.title = ${title}
-          AND n.is_folder = false
-          AND n.deleted = 0
-          AND t.parent_id = ${parentId}::uuid
-        LIMIT 1
-      `;
+      const [row] = parentId
+        ? await sql`
+            SELECT n.note_id FROM app.notes n
+            JOIN app.tree_items t ON t.note_id = n.note_id
+            WHERE n.user_id = ${userId}::uuid
+              AND t.user_id = ${userId}::uuid
+              AND n.title = ${title}
+              AND n.is_folder = false
+              AND n.deleted = 0
+              AND t.parent_id = ${parentId}::uuid
+            LIMIT 1
+          `
+        : await sql`
+            SELECT n.note_id FROM app.notes n
+            JOIN app.tree_items t ON t.note_id = n.note_id
+            WHERE n.user_id = ${userId}::uuid
+              AND t.user_id = ${userId}::uuid
+              AND n.title = ${title}
+              AND n.is_folder = false
+              AND n.deleted = 0
+              AND t.parent_id IS NULL
+            LIMIT 1
+          `;
       if (row) return { noteId: row.note_id, created: false };
     }
     throw err;


### PR DESCRIPTION
## Summary
- `findOrCreateNote` used `parent_id = $1::uuid` which silently fails when parent is NULL (root level) — SQL `= NULL` is always unknown, so root-level notes were never found by the dedup check
- Every Canvas re-import created fresh copies of root-level files instead of reusing existing ones
- Split the query into `IS NULL` vs `= $1::uuid` branches, matching the pattern used in tree children route
- Includes migration 015 to soft-delete the duplicate root notes (keeps oldest copy per user+title)

## Test plan
- [x] 545/545 tests pass
- [x] 0 lint errors
- [ ] Run migration 015 against production database to clean up existing duplicates