### PR TITLE
fix: tree unique constraint, soft-delete filters, transactional trash cleanup

### DIFF
--- a/database/migrations/016_tree_items_unique.sql
+++ b/database/migrations/016_tree_items_unique.sql
@@ -1,0 +1,22 @@
+-- Remove duplicate tree links, keeping the most recently updated row per note.
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY user_id, note_id
+      ORDER BY updated_at DESC, id DESC
+    ) AS row_num
+  FROM app.tree_items
+  WHERE note_id IS NOT NULL
+)
+DELETE FROM app.tree_items
+WHERE id IN (
+  SELECT id
+  FROM ranked
+  WHERE row_num > 1
+);
+
+-- Enforce the assumption used throughout the app: one tree row per user/note.
+CREATE UNIQUE INDEX IF NOT EXISTS tree_items_user_note_unique
+ON app.tree_items (user_id, note_id)
+WHERE note_id IS NOT NULL;

--- a/src/app/api/chat/sessions/[id]/route.ts
+++ b/src/app/api/chat/sessions/[id]/route.ts
@@ -35,7 +35,11 @@ export const GET = withErrorHandler(
       const sessions = await sql`
             SELECT s.id, s.title, s.note_id, n.title AS note_title, s.context, s.created_at, s.updated_at
             FROM app.chat_sessions s
-            LEFT JOIN app.notes n ON n.note_id = s.note_id AND n.user_id = s.user_id
+            LEFT JOIN app.notes n
+              ON n.note_id = s.note_id
+             AND n.user_id = s.user_id
+             AND n.deleted = 0
+             AND n.deleted_at IS NULL
             WHERE s.id = ${id}::uuid AND s.user_id = ${user.user_id}::uuid
         `;
       if (sessions.length === 0) {

--- a/src/app/api/chat/sessions/route.ts
+++ b/src/app/api/chat/sessions/route.ts
@@ -17,7 +17,11 @@ export const GET = withErrorHandler(async () => {
             SELECT s.id, s.title, s.note_id, n.title AS note_title, s.context, s.created_at, s.updated_at,
                    COUNT(m.id)::int AS message_count
             FROM app.chat_sessions s
-            LEFT JOIN app.notes n ON n.note_id = s.note_id AND n.user_id = s.user_id
+            LEFT JOIN app.notes n
+              ON n.note_id = s.note_id
+             AND n.user_id = s.user_id
+             AND n.deleted = 0
+             AND n.deleted_at IS NULL
             LEFT JOIN app.chat_messages m ON m.session_id = s.id
             WHERE s.user_id = ${user.user_id}::uuid
             GROUP BY s.id, n.title

--- a/src/app/api/pdf/annotations/route.js
+++ b/src/app/api/pdf/annotations/route.js
@@ -34,7 +34,10 @@ export const GET = withErrorHandler(async (request) => {
   // Verify user owns this note
   const noteResult = await sql`
     SELECT note_id FROM app.notes
-    WHERE note_id = ${noteId}::uuid AND user_id = ${user.user_id}::uuid
+    WHERE note_id = ${noteId}::uuid
+      AND user_id = ${user.user_id}::uuid
+      AND deleted = 0
+      AND deleted_at IS NULL
   `;
 
   if (noteResult.length === 0) {
@@ -85,7 +88,10 @@ export const POST = withErrorHandler(async (request) => {
   // Verify user owns this note
   const noteResult = await sql`
     SELECT note_id FROM app.notes
-    WHERE note_id = ${noteId}::uuid AND user_id = ${user.user_id}::uuid
+    WHERE note_id = ${noteId}::uuid
+      AND user_id = ${user.user_id}::uuid
+      AND deleted = 0
+      AND deleted_at IS NULL
   `;
 
   if (noteResult.length === 0) {

--- a/src/app/api/quiz/questions/[id]/related/route.ts
+++ b/src/app/api/quiz/questions/[id]/related/route.ts
@@ -34,6 +34,8 @@ export const GET = withErrorHandler(
       JOIN app.chunks c ON c.id = e.chunk_id
       JOIN app.notes n ON n.note_id = c.document_id
       WHERE c.user_id = ${userId}::uuid
+        AND n.deleted = 0
+        AND n.deleted_at IS NULL
         AND c.id != ${question.chunk_id}::uuid
         AND (e.embedding <=> (
           SELECT embedding FROM app.embeddings WHERE chunk_id = ${question.chunk_id}::uuid LIMIT 1

--- a/src/app/api/trash/route.ts
+++ b/src/app/api/trash/route.ts
@@ -2,17 +2,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateSession } from '@/lib/auth';
 import { isValidUUID } from '@/lib/utils/uuid';
-import { getStorageProvider } from '@/lib/storage/init';
 import { withErrorHandler, tracedError } from '@/lib/api-error';
 import sql from '@/database/pgsql';
 import { addNoteToTree } from '@/lib/notes/storage/pg-tree.js';
+import { cleanupNoteDependencies } from '@/lib/notes/storage/note-cleanup';
 import logger from '@/lib/logger';
 
 async function fetchTrashItems(userId: string) {
     const rows = await sql`
         SELECT note_id, title, content, is_folder, deleted_at, created_at, updated_at
         FROM app.notes
-        WHERE user_id = ${userId}::uuid AND deleted = 1
+        WHERE user_id = ${userId}::uuid AND deleted = 1 AND deleted_at IS NOT NULL
         ORDER BY deleted_at DESC
     `;
     return rows.map((note: { note_id: string; title: string; content: string; is_folder: boolean; deleted_at: string | null; created_at: string | null; updated_at: string | null }) => ({
@@ -29,7 +29,7 @@ async function fetchTrashItems(userId: string) {
 async function requireNoteInTrash(userId: string, id: string): Promise<boolean> {
     const rows = await sql`
         SELECT note_id FROM app.notes
-        WHERE note_id = ${id}::uuid AND user_id = ${userId}::uuid AND deleted = 1
+        WHERE note_id = ${id}::uuid AND user_id = ${userId}::uuid AND deleted = 1 AND deleted_at IS NOT NULL
     `;
     return rows.length > 0;
 }
@@ -81,24 +81,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
         }
 
         if (body.action === 'delete') {
-            // clean S3 objects before removing DB rows (best-effort)
-            const storage = getStorageProvider();
-            const s3Rows = await sql`
-                SELECT s3_key FROM app.notes WHERE note_id = ${id}::uuid AND user_id = ${user.user_id}::uuid AND s3_key IS NOT NULL
-                UNION ALL
-                SELECT s3_key FROM app.attachments WHERE note_id = ${id}::uuid AND user_id = ${user.user_id}::uuid AND s3_key IS NOT NULL
-            `;
-            await Promise.all(s3Rows.map(async (r: { s3_key: string }) => {
-                try { await storage.deleteObject(r.s3_key); }
-                catch (err) { logger.warn('S3 delete failed', { key: r.s3_key, err }); }
-            }));
-
-            // clean up embeddings and chunks for this note
-            await sql`DELETE FROM app.embeddings WHERE chunk_id IN (SELECT id FROM app.chunks WHERE document_id = ${id}::uuid AND user_id = ${user.user_id}::uuid)`;
-            await sql`DELETE FROM app.chunks WHERE document_id = ${id}::uuid AND user_id = ${user.user_id}::uuid`;
-
-            await sql`DELETE FROM app.pdf_annotations WHERE note_id = ${id}::uuid AND user_id = ${user.user_id}::uuid`;
-            await sql`DELETE FROM app.attachments WHERE note_id = ${id}::uuid AND user_id = ${user.user_id}::uuid`;
+            await cleanupNoteDependencies(user.user_id, id);
             await sql`DELETE FROM app.notes WHERE note_id = ${id}::uuid AND user_id = ${user.user_id}::uuid`;
             return NextResponse.json({ success: true });
         }

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -117,7 +117,10 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
   } else {
     const exists = await sql`
       SELECT 1 FROM app.notes
-      WHERE note_id = ${noteId}::uuid AND user_id = ${session.user_id}::uuid
+      WHERE note_id = ${noteId}::uuid
+        AND user_id = ${session.user_id}::uuid
+        AND deleted = 0
+        AND deleted_at IS NULL
       LIMIT 1
     `;
     if (!exists.length) return tracedError("Note not found", 404);

--- a/src/lib/notes/storage/note-cleanup.ts
+++ b/src/lib/notes/storage/note-cleanup.ts
@@ -1,0 +1,136 @@
+import sql from "@/database/pgsql.js";
+import { getStorageProvider } from "@/lib/storage/init";
+import logger from "@/lib/logger";
+
+function uniqueKeys(rows: Array<{ s3_key: string | null }>): string[] {
+  return [...new Set(rows.map((row) => row.s3_key).filter(Boolean))] as string[];
+}
+
+// permanently clean up all dependencies of a note before final deletion.
+// only call this on permanent delete from trash — NOT on soft-delete,
+// since soft-deleted notes can be restored and should keep their data.
+export async function cleanupNoteDependencies(
+  userId: string,
+  noteId: string,
+): Promise<void> {
+  // collect S3 keys before deleting rows
+  const storageRows = await sql`
+    SELECT s3_key
+    FROM app.notes
+    WHERE note_id = ${noteId}::uuid
+      AND user_id = ${userId}::uuid
+      AND s3_key IS NOT NULL
+    UNION
+    SELECT s3_key
+    FROM app.attachments
+    WHERE note_id = ${noteId}::uuid
+      AND user_id = ${userId}::uuid
+      AND s3_key IS NOT NULL
+  `;
+
+  // delete all DB dependencies in a single transaction
+  await sql.begin(async (tx) => {
+    await tx`
+      DELETE FROM app.chat_messages
+      WHERE session_id IN (
+        SELECT id FROM app.chat_sessions
+        WHERE user_id = ${userId}::uuid AND note_id = ${noteId}::uuid
+      )
+    `;
+
+    await tx`
+      DELETE FROM app.chat_sessions
+      WHERE user_id = ${userId}::uuid AND note_id = ${noteId}::uuid
+    `;
+
+    await tx`
+      DELETE FROM app.quiz_sessions qs
+      WHERE qs.user_id = ${userId}::uuid
+        AND EXISTS (
+          SELECT 1
+          FROM jsonb_array_elements_text(qs.card_ids) AS session_card(card_id)
+          JOIN app.quiz_cards qc ON qc.id = session_card.card_id::uuid
+          JOIN app.quiz_questions qq ON qq.id = qc.question_id
+          WHERE qc.user_id = ${userId}::uuid
+            AND qq.user_id = ${userId}::uuid
+            AND qq.note_id = ${noteId}::uuid
+        )
+    `;
+
+    await tx`
+      DELETE FROM app.quiz_reviews
+      WHERE user_id = ${userId}::uuid
+        AND question_id IN (
+          SELECT id FROM app.quiz_questions
+          WHERE user_id = ${userId}::uuid AND note_id = ${noteId}::uuid
+        )
+    `;
+
+    await tx`
+      DELETE FROM app.quiz_cards
+      WHERE user_id = ${userId}::uuid
+        AND question_id IN (
+          SELECT id FROM app.quiz_questions
+          WHERE user_id = ${userId}::uuid AND note_id = ${noteId}::uuid
+        )
+    `;
+
+    await tx`
+      DELETE FROM app.quiz_questions
+      WHERE user_id = ${userId}::uuid AND note_id = ${noteId}::uuid
+    `;
+
+    await tx`
+      DELETE FROM app.embeddings
+      WHERE chunk_id IN (
+        SELECT id FROM app.chunks
+        WHERE document_id = ${noteId}::uuid AND user_id = ${userId}::uuid
+      )
+    `;
+
+    await tx`
+      DELETE FROM app.chunks
+      WHERE document_id = ${noteId}::uuid AND user_id = ${userId}::uuid
+    `;
+
+    await tx`
+      DELETE FROM app.pdf_annotations
+      WHERE note_id = ${noteId}::uuid AND user_id = ${userId}::uuid
+    `;
+
+    await tx`
+      DELETE FROM app.attachments
+      WHERE note_id = ${noteId}::uuid AND user_id = ${userId}::uuid
+    `;
+
+    await tx`
+      DELETE FROM app.ingestion_jobs
+      WHERE note_id = ${noteId}::uuid AND user_id = ${userId}::uuid
+    `;
+
+    await tx`
+      DELETE FROM app.canvas_imports
+      WHERE note_id = ${noteId}::uuid AND user_id = ${userId}::uuid
+    `;
+
+    await tx`
+      DELETE FROM app.tree_items
+      WHERE note_id = ${noteId}::uuid AND user_id = ${userId}::uuid
+    `;
+  });
+
+  // best-effort S3 cleanup after transaction commits
+  const storageKeys = uniqueKeys(storageRows as Array<{ s3_key: string | null }>);
+  if (storageKeys.length === 0) return;
+
+  const storage = getStorageProvider();
+  await Promise.all(
+    storageKeys.map(async (key) => {
+      try {
+        await storage.deleteObject(key);
+      } catch (error) {
+        logger.warn("note cleanup S3 delete failed", { key, error });
+      }
+    }),
+  );
+}

--- a/src/lib/quiz/generate-background.ts
+++ b/src/lib/quiz/generate-background.ts
@@ -23,8 +23,11 @@ export async function getUncoveredChunkIds(
     // scoped to specific chunks (e.g. from an import job)
     const rows = await sql`
       SELECT c.id FROM app.chunks c
+      JOIN app.notes n ON n.note_id = c.document_id
       WHERE c.user_id = ${userId}::uuid
         AND c.id = ANY(${opts.chunkIds}::uuid[])
+        AND n.deleted = 0
+        AND n.deleted_at IS NULL
         AND NOT EXISTS (
           SELECT 1 FROM app.quiz_questions qq
           WHERE qq.chunk_id = c.id AND qq.user_id = ${userId}::uuid
@@ -42,6 +45,8 @@ export async function getUncoveredChunkIds(
       JOIN app.notes n ON c.document_id = n.note_id
       WHERE c.user_id = ${userId}::uuid
         AND n.canvas_course_id = ${opts.courseId}
+        AND n.deleted = 0
+        AND n.deleted_at IS NULL
         AND NOT EXISTS (
           SELECT 1 FROM app.quiz_questions qq
           WHERE qq.chunk_id = c.id AND qq.user_id = ${userId}::uuid
@@ -55,7 +60,10 @@ export async function getUncoveredChunkIds(
   // all uncovered chunks for user
   const rows = await sql`
     SELECT c.id FROM app.chunks c
+    JOIN app.notes n ON n.note_id = c.document_id
     WHERE c.user_id = ${userId}::uuid
+      AND n.deleted = 0
+      AND n.deleted_at IS NULL
       AND NOT EXISTS (
         SELECT 1 FROM app.quiz_questions qq
         WHERE qq.chunk_id = c.id AND qq.user_id = ${userId}::uuid
@@ -82,6 +90,9 @@ export async function generateBatch(
       FROM app.chunks c
       JOIN app.notes n ON c.document_id = n.note_id
       WHERE c.id = ${chunkId}::uuid
+        AND c.user_id = ${userId}::uuid
+        AND n.deleted = 0
+        AND n.deleted_at IS NULL
     `;
     if (!chunk) return;
 

--- a/src/lib/quiz/generate.ts
+++ b/src/lib/quiz/generate.ts
@@ -182,6 +182,8 @@ export async function generateQuestion(
       JOIN app.notes n ON qq.note_id = n.note_id
       WHERE qq.user_id = ${userId}::uuid
         AND n.canvas_course_id = ${courseId}
+        AND n.deleted = 0
+        AND n.deleted_at IS NULL
       ORDER BY qq.created_at DESC
       LIMIT 5
     `;

--- a/src/lib/quiz/select.ts
+++ b/src/lib/quiz/select.ts
@@ -99,6 +99,7 @@ export async function resolveChunkIds(
                 WHERE c.user_id = ${userId}::uuid
                   AND n.canvas_course_id = ${filterValue as number}
                   AND n.deleted = 0
+                  AND n.deleted_at IS NULL
             `;
       return rows.map((r: any) => r.id);
     }
@@ -109,15 +110,20 @@ export async function resolveChunkIds(
                 WHERE c.user_id = ${userId}::uuid
                   AND n.canvas_module_id = ${filterValue as number}
                   AND n.deleted = 0
+                  AND n.deleted_at IS NULL
             `;
       return rows.map((r: any) => r.id);
     }
     case "note": {
       const noteIds = filterValue as string[];
       const rows = await sql`
-                SELECT id FROM app.chunks
-                WHERE user_id = ${userId}::uuid
-                  AND document_id = ANY(${noteIds}::uuid[])
+                SELECT c.id
+                FROM app.chunks c
+                JOIN app.notes n ON n.note_id = c.document_id
+                WHERE c.user_id = ${userId}::uuid
+                  AND c.document_id = ANY(${noteIds}::uuid[])
+                  AND n.deleted = 0
+                  AND n.deleted_at IS NULL
             `;
       return rows.map((r: any) => r.id);
     }
@@ -128,7 +134,10 @@ export async function resolveChunkIds(
                 SELECT c.id
                 FROM app.embeddings e
                 JOIN app.chunks c ON c.id = e.chunk_id
+                JOIN app.notes n ON n.note_id = c.document_id
                 WHERE c.user_id = ${userId}::uuid
+                  AND n.deleted = 0
+                  AND n.deleted_at IS NULL
                 ORDER BY e.embedding <=> ${JSON.stringify(vector)}::vector
                 LIMIT 30
             `;
@@ -151,9 +160,13 @@ export async function resolveChunkIds(
       }
       if (noteIds.size === 0) return [];
       const rows = await sql`
-                SELECT id FROM app.chunks
-                WHERE user_id = ${userId}::uuid
-                  AND document_id = ANY(${[...noteIds]}::uuid[])
+                SELECT c.id
+                FROM app.chunks c
+                JOIN app.notes n ON n.note_id = c.document_id
+                WHERE c.user_id = ${userId}::uuid
+                  AND c.document_id = ANY(${[...noteIds]}::uuid[])
+                  AND n.deleted = 0
+                  AND n.deleted_at IS NULL
             `;
       return rows.map((r: any) => r.id);
     }
@@ -163,6 +176,7 @@ export async function resolveChunkIds(
                 JOIN app.notes n ON c.document_id = n.note_id
                 WHERE c.user_id = ${userId}::uuid
                   AND n.deleted = 0
+                  AND n.deleted_at IS NULL
             `;
       return rows.map((r: any) => r.id);
     }


### PR DESCRIPTION
## Summary

- **Migration 016**: dedup tree_items rows and add unique constraint on `(user_id, note_id)` — required by existing `ON CONFLICT` clause in `addNoteToTree`
- **API soft-delete filters**: add `deleted = 0 AND deleted_at IS NULL` to chat session joins, upload ownership check, PDF annotation ownership checks
- **Quiz soft-delete filters**: add same filters to related questions, quiz generation, background batch generation, and all 6 chunk selection branches (course, module, note, search, chat_session, all)
- **Transactional trash cleanup**: new `cleanupNoteDependencies` helper that deletes all note dependencies (chat, quiz, embeddings, chunks, annotations, attachments, ingestion jobs, canvas imports, tree items) in a single DB transaction before S3 cleanup. Only called on permanent delete — soft-delete path unchanged.

## Test plan

- [ ] 545/545 tests pass, 0 lint errors
- [ ] Soft-delete a note -> restore it -> verify quiz cards, chat sessions, embeddings are intact
- [ ] Permanently delete from trash -> verify all dependencies cleaned up
- [ ] Search, quiz generation, chat sessions don't show trashed note content
- [ ] Upload to trashed note returns 404
- [ ] Run migration 016 on dev DB -> verify unique index created