### PR TITLE
fix(proxy): return raw buffer for S3 file proxy

### DIFF
--- a/src/app/api/proxy/s3/route.ts
+++ b/src/app/api/proxy/s3/route.ts
@@ -41,9 +41,9 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 
   try {
     const storage = getStorageProvider();
-    const stream = await storage.getObject(path);
+    const { buffer } = await storage.getObjectAndMeta(path);
 
-    if (!stream) {
+    if (!buffer) {
       return tracedError("Failed to fetch file from storage", 500);
     }
 
@@ -53,10 +53,10 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       "Content-Disposition": inline
         ? `inline; filename="${attachment.filename}"`
         : `attachment; filename="${attachment.filename}"`,
+      "Content-Length": buffer.byteLength.toString(),
     };
 
-    // Convert stream to Response with proper headers
-    return new NextResponse(stream as any, {
+    return new NextResponse(buffer, {
       status: 200,
       headers,
     });

--- a/src/app/api/proxy/s3/route.ts
+++ b/src/app/api/proxy/s3/route.ts
@@ -56,7 +56,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       "Content-Length": buffer.byteLength.toString(),
     };
 
-    return new NextResponse(buffer, {
+    return new NextResponse(new Uint8Array(buffer), {
       status: 200,
       headers,
     });


### PR DESCRIPTION
## Summary
- S3 proxy route was calling `getObject()` which converts binary data to UTF-8 string via `toStr()`, corrupting PDFs and other binary files
- Switched to `getObjectAndMeta()` which preserves the raw buffer
- Fixes `FormatError: Bad FCHECK in flate stream` errors in PDF.js

## Test plan
- [ ] Upload a PDF and verify it renders without FCHECK warnings in console
- [ ] Verify non-PDF file downloads still work (images, etc.)
- [ ] Clear IndexedDB cache in browser before testing (old corrupted cache)