### PR TITLE
release: merge dev into main

### DIFF
--- a/src/__tests__/api/note-share.test.ts
+++ b/src/__tests__/api/note-share.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  sqlMock,
+  requireAuthMock,
+  checkRateLimitMock,
+  addNoteToTreeMock,
+  getStorageProviderMock,
+  storageMock,
+  generateUUIDMock,
+  isValidUUIDMock,
+} = vi.hoisted(() => ({
+  sqlMock: vi.fn(),
+  requireAuthMock: vi.fn(),
+  checkRateLimitMock: vi.fn(),
+  addNoteToTreeMock: vi.fn(),
+  getStorageProviderMock: vi.fn(),
+  storageMock: {
+    copyObject: vi.fn(),
+    getObject: vi.fn(),
+    putObject: vi.fn(),
+  },
+  generateUUIDMock: vi.fn(),
+  isValidUUIDMock: vi.fn(),
+}));
+
+vi.mock("@/database/pgsql.js", () => ({
+  default: sqlMock,
+}));
+
+vi.mock("@/lib/api-error", () => {
+  class ApiError extends Error {
+    statusCode: number;
+
+    constructor(statusCode: number, message: string) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  }
+
+  return {
+    ApiError,
+    withErrorHandler: (handler: unknown) => handler,
+    requireAuth: requireAuthMock,
+    requireValidId: (value: string) => value,
+  };
+});
+
+vi.mock("@/lib/rateLimiter", () => ({
+  checkRateLimit: checkRateLimitMock,
+}));
+
+vi.mock("@/lib/utils/uuid", () => ({
+  isValidUUID: isValidUUIDMock,
+  generateUUID: generateUUIDMock,
+}));
+
+vi.mock("@/lib/notes/storage/pg-tree.js", () => ({
+  addNoteToTree: addNoteToTreeMock,
+}));
+
+vi.mock("@/lib/storage/init", () => ({
+  getStorageProvider: getStorageProviderMock,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: {
+    warn: vi.fn(),
+  },
+}));
+
+import { POST } from "@/app/api/notes/[id]/share/route";
+
+describe("POST /api/notes/[id]/share", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    requireAuthMock.mockResolvedValue({
+      user_id: "11111111-1111-1111-1111-111111111111",
+      email: "source@example.com",
+    });
+    checkRateLimitMock.mockResolvedValue(null);
+    isValidUUIDMock.mockReturnValue(true);
+    generateUUIDMock.mockReturnValue("99999999-9999-9999-9999-999999999999");
+    addNoteToTreeMock.mockResolvedValue(undefined);
+
+    storageMock.copyObject.mockResolvedValue(undefined);
+    storageMock.getObject.mockResolvedValue("ignored");
+    storageMock.putObject.mockResolvedValue(undefined);
+    getStorageProviderMock.mockReturnValue(storageMock);
+
+    sqlMock
+      .mockResolvedValueOnce([
+        { user_id: "22222222-2222-2222-2222-222222222222" },
+      ])
+      .mockResolvedValueOnce([
+        {
+          note_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          title: "Shared PDF",
+          content: null,
+          s3_key: "notes/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/file.pdf",
+          is_folder: false,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { note_id: "99999999-9999-9999-9999-999999999999" },
+      ]);
+  });
+
+  it("copies S3 object using copyObject for binary-safe cloning", async () => {
+    const request = new Request(
+      "http://localhost/api/notes/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/share",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          targetUserId: "22222222-2222-2222-2222-222222222222",
+        }),
+      },
+    );
+
+    const response = await POST(request as never, {
+      params: Promise.resolve({ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(storageMock.copyObject).toHaveBeenCalledWith(
+      "notes/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/file.pdf",
+      "notes/99999999-9999-9999-9999-999999999999/file.pdf",
+      {},
+    );
+    expect(storageMock.getObject).not.toHaveBeenCalled();
+    expect(storageMock.putObject).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/notes/[id]/share/route.ts
+++ b/src/app/api/notes/[id]/share/route.ts
@@ -1,12 +1,17 @@
-import { NextResponse } from 'next/server';
-import { withErrorHandler, requireAuth, requireValidId, ApiError } from '@/lib/api-error';
-import { checkRateLimit } from '@/lib/rateLimiter';
-import { isValidUUID } from '@/lib/utils/uuid';
-import { generateUUID } from '@/lib/utils/uuid';
-import { addNoteToTree } from '@/lib/notes/storage/pg-tree.js';
-import { getStorageProvider } from '@/lib/storage/init';
-import sql from '@/database/pgsql.js';
-import logger from '@/lib/logger';
+import { NextResponse } from "next/server";
+import {
+  withErrorHandler,
+  requireAuth,
+  requireValidId,
+  ApiError,
+} from "@/lib/api-error";
+import { checkRateLimit } from "@/lib/rateLimiter";
+import { isValidUUID } from "@/lib/utils/uuid";
+import { generateUUID } from "@/lib/utils/uuid";
+import { addNoteToTree } from "@/lib/notes/storage/pg-tree.js";
+import { getStorageProvider } from "@/lib/storage/init";
+import sql from "@/database/pgsql.js";
+import logger from "@/lib/logger";
 
 /**
  * POST /api/notes/:id/share
@@ -22,26 +27,29 @@ import logger from '@/lib/logger';
 export const POST = withErrorHandler(async (request: Request, context: any) => {
   const user = await requireAuth();
 
-  const limited = await checkRateLimit('share', user.user_id);
+  const limited = await checkRateLimit("share", user.user_id);
   if (limited) return limited;
 
   const { id } = await context.params;
-  const sourceNoteId = requireValidId(id, 'note ID');
+  const sourceNoteId = requireValidId(id, "note ID");
 
   const body = await request.json();
   const { targetUserId, targetParentId } = body;
 
   if (!targetUserId || !isValidUUID(targetUserId)) {
-    throw new ApiError(400, 'Invalid or missing targetUserId');
+    throw new ApiError(400, "Invalid or missing targetUserId");
   }
 
   if (targetParentId && !isValidUUID(targetParentId)) {
-    throw new ApiError(400, 'Invalid targetParentId');
+    throw new ApiError(400, "Invalid targetParentId");
   }
 
   // cannot share to yourself
   if (targetUserId === user.user_id) {
-    throw new ApiError(400, 'Cannot share a note with yourself. Use duplicate instead.');
+    throw new ApiError(
+      400,
+      "Cannot share a note with yourself. Use duplicate instead.",
+    );
   }
 
   // verify target user exists and is active
@@ -51,7 +59,7 @@ export const POST = withErrorHandler(async (request: Request, context: any) => {
       AND is_active = true AND deleted_at IS NULL
   `;
   if (!targetUser.length) {
-    throw new ApiError(404, 'Target user not found');
+    throw new ApiError(404, "Target user not found");
   }
 
   // only the owner can share their own note
@@ -64,7 +72,7 @@ export const POST = withErrorHandler(async (request: Request, context: any) => {
   `;
 
   if (!sourceNote.length) {
-    throw new ApiError(404, 'Source note not found');
+    throw new ApiError(404, "Source note not found");
   }
 
   const note = sourceNote[0];
@@ -78,18 +86,18 @@ export const POST = withErrorHandler(async (request: Request, context: any) => {
   if (note.s3_key) {
     try {
       const storage = getStorageProvider();
-      const originalContent = await storage.getObject(note.s3_key);
-      if (originalContent) {
-        const filename = note.s3_key.split('/').pop() ?? 'file';
-        clonedS3Key = `notes/${cloneId}/${filename}`;
-        await storage.putObject(clonedS3Key, originalContent, {
-          contentType: 'application/octet-stream',
-        });
-      }
+      const filename = note.s3_key.split("/").pop() ?? "file";
+      clonedS3Key = `notes/${cloneId}/${filename}`;
+      await storage.copyObject(note.s3_key, clonedS3Key, {});
     } catch (err) {
-      logger.warn('failed to copy S3 object for share, clone will have no file', {
-        sourceKey: note.s3_key, error: err,
-      });
+      logger.warn(
+        "failed to copy S3 object for share, clone will have no file",
+        {
+          sourceKey: note.s3_key,
+          error: err,
+        },
+      );
+      clonedS3Key = null;
     }
   }
 
@@ -108,7 +116,7 @@ export const POST = withErrorHandler(async (request: Request, context: any) => {
     ) VALUES (
       ${cloneId}::uuid,
       ${targetUserId}::uuid,
-      ${note.title + ' (shared)'},
+      ${note.title + " (shared)"},
       ${note.content},
       ${clonedS3Key},
       ${note.is_folder},
@@ -129,16 +137,22 @@ export const POST = withErrorHandler(async (request: Request, context: any) => {
         AND deleted_at IS NULL
     `;
     if (!parentCheck.length) {
-      throw new ApiError(400, 'targetParentId is not a valid folder for the target user');
+      throw new ApiError(
+        400,
+        "targetParentId is not a valid folder for the target user",
+      );
     }
   }
 
   // Add clone to target user's tree
   await addNoteToTree(targetUserId, cloned[0].note_id, targetParentId || null);
 
-  return NextResponse.json({
-    success: true,
-    clonedNoteId: cloned[0].note_id,
-    message: 'Note cloned to target user',
-  }, { status: 201 });
+  return NextResponse.json(
+    {
+      success: true,
+      clonedNoteId: cloned[0].note_id,
+      message: "Note cloned to target user",
+    },
+    { status: 201 },
+  );
 });


### PR DESCRIPTION
## Summary
- add new chat note-planning tools (`moveNote`, `renameNote`, `addTimeBlock`, `completeTimeBlock`) and route tool selection to the right handlers
- harden file proxy and note sharing to preserve binary bytes (S3 proxy now returns raw bytes and share uses `copyObject` to avoid PDF corruption)
- include regression coverage for binary-safe note sharing behavior

## Verification
- pre-commit `npm run lint:all` completed successfully
- pre-commit `npm run test:ci` completed successfully (65 files, 558 tests)
- additional targeted tests: `npm run test -- src/__tests__/api/note-share.test.ts src/__tests__/api/notes.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for note sharing endpoint.

* **Bug Fixes**
  * Improved error handling for note sharing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->