### PR TITLE
feat(chat): AI chat polish + markdown architecture

### DIFF
--- a/src/__tests__/lib/preview-renderer.test.ts
+++ b/src/__tests__/lib/preview-renderer.test.ts
@@ -19,8 +19,9 @@ describe("PreviewRenderer", () => {
   it("renders fenced code without language as a block", () => {
     const html = renderPreview("```\nconst value = 1\n```");
 
-    expect(html).toContain("<pre><code");
-    expect(html).not.toContain("rounded bg-surface");
+    // CodeBlock wraps the pre; verify a <pre> element is present (block render)
+    expect(html).toContain("<pre");
+    expect(html).not.toContain('class="rounded bg-surface');
   });
 
   it("keeps list styling for task lists", () => {

--- a/src/app/chat/chat-page-client.tsx
+++ b/src/app/chat/chat-page-client.tsx
@@ -35,6 +35,18 @@ interface ContextItem {
   title: string;
 }
 
+function relativeDate(ms: number): string {
+  const diff = Date.now() - ms;
+  const m = Math.floor(diff / 60_000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d`;
+  return new Date(ms).toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
 export default function ChatPageClient() {
   const { t } = useI18n();
   const router = useRouter();
@@ -62,6 +74,7 @@ export default function ChatPageClient() {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [activeId, setActiveId] = useState<string | null>(routeSessionId);
   const [loaded, setLoaded] = useState(false);
+  const [mountKey, setMountKey] = useState(0);
   const [selectedNotes, setSelectedNotes] = useState<ContextItem[]>([]);
   const [selectedFolders, setSelectedFolders] = useState<ContextItem[]>([]);
 
@@ -196,11 +209,13 @@ export default function ChatPageClient() {
   }, [loadSessions]);
 
   const newConversation = useCallback(() => {
+    setMountKey((prev) => prev + 1);
     setActiveId(null);
     router.push(draftHref);
   }, [draftHref, router]);
 
   const clearContextAndStartNewChat = useCallback(() => {
+    setMountKey((prev) => prev + 1);
     setSelectedNotes([]);
     setSelectedFolders([]);
     setActiveId(null);
@@ -253,6 +268,7 @@ export default function ChatPageClient() {
     if (!res.ok) return;
     setConversations((prev) => prev.filter((c) => c.id !== id));
     if (activeId === id) {
+      setMountKey((prev) => prev + 1);
       setActiveId(null);
       router.replace(draftHref);
     }
@@ -286,16 +302,6 @@ export default function ChatPageClient() {
     setSelectedFolders([]);
     syncScopeUrl([], []);
   };
-
-  const chatInstanceKey =
-    activeId ??
-    [
-      "new",
-      paramNoteId ?? "",
-      paramFolderId ?? "",
-      selectedNotes.map((note) => note.id).join(","),
-      selectedFolders.map((folder) => folder.id).join(","),
-    ].join(":");
 
   return (
     <div className="h-screen w-screen flex bg-app-page text-text overflow-hidden">
@@ -342,6 +348,7 @@ export default function ChatPageClient() {
             <button
               key={conv.id}
               onClick={() => {
+                setMountKey((prev) => prev + 1);
                 setActiveId(conv.id);
                 router.push(`/chat/${conv.id}`);
               }}
@@ -351,28 +358,36 @@ export default function ChatPageClient() {
                   : "glass-card-interactive text-text-tertiary hover:text-text-secondary"
               }`}
             >
-              <div className="flex items-start justify-between gap-1">
-                <p className="font-medium truncate text-sm flex-1">
+              <div className="flex items-center justify-between gap-1">
+                <p className="font-medium truncate text-sm flex-1 min-w-0">
                   {conv.title}
                 </p>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void deleteConversation(conv.id);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
+                <div className="flex items-center gap-1 flex-shrink-0">
+                  <span
+                    className="text-[10px] text-text-tertiary opacity-60 group-hover:opacity-0 transition-opacity"
+                    suppressHydrationWarning
+                  >
+                    {relativeDate(conv.createdAt)}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={(e) => {
                       e.stopPropagation();
                       void deleteConversation(conv.id);
-                    }
-                  }}
-                  className="opacity-0 group-hover:opacity-100 p-2 min-h-[44px] min-w-[44px] flex items-center justify-center text-text-tertiary hover:text-error-400 transition-all flex-shrink-0 -mr-1"
-                  title={t("chat.delete_conversation")}
-                  aria-label={t("chat.delete_conversation")}
-                >
-                  <TrashIcon className="w-3.5 h-3.5" />
-                </button>
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.stopPropagation();
+                        void deleteConversation(conv.id);
+                      }
+                    }}
+                    className="opacity-0 group-hover:opacity-100 p-2 min-h-[44px] min-w-[44px] flex items-center justify-center text-text-tertiary hover:text-error-400 transition-all -mr-1"
+                    title={t("chat.delete_conversation")}
+                    aria-label={t("chat.delete_conversation")}
+                  >
+                    <TrashIcon className="w-3.5 h-3.5" />
+                  </button>
+                </div>
               </div>
               {conv.noteTitle && (
                 <div className="flex items-center gap-1 mt-0.5 text-text-tertiary">
@@ -380,12 +395,6 @@ export default function ChatPageClient() {
                   <span className="truncate">{conv.noteTitle}</span>
                 </div>
               )}
-              <p className="text-text-tertiary opacity-60 mt-0.5" suppressHydrationWarning>
-                {new Date(conv.createdAt).toLocaleDateString([], {
-                  month: "short",
-                  day: "numeric",
-                })}
-              </p>
             </button>
           ))}
           {loaded && conversations.length === 0 && (
@@ -473,7 +482,7 @@ export default function ChatPageClient() {
         </header>
 
         <ChatInterface
-          key={chatInstanceKey}
+          key={mountKey}
           sessionId={activeId ?? undefined}
           noteId={
             selectedNotes.length === 1 && selectedFolders.length === 0
@@ -493,6 +502,7 @@ export default function ChatPageClient() {
           selectedFolders={selectedFolders}
           onSessionCreated={handleSessionCreated}
           onClearContext={clearContextAndStartNewChat}
+          onStreamComplete={loadSessions}
           className="flex-1 min-h-0"
         />
       </main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -432,7 +432,8 @@ html.light .glass-card-active {
 }
 
 /* markdown preview code highlighting (aligned with CodeMirror one-dark/one-light) */
-.markdown-preview pre > code.hljs {
+.markdown-preview pre > code.hljs,
+.md-rendered pre > code.hljs {
   display: block;
   overflow-x: auto;
   border-radius: 0.5rem;
@@ -442,7 +443,9 @@ html.light .glass-card-active {
 }
 
 .markdown-preview .hljs-comment,
-.markdown-preview .hljs-quote {
+.markdown-preview .hljs-quote,
+.md-rendered .hljs-comment,
+.md-rendered .hljs-quote {
   color: #5c6370;
 }
 
@@ -455,7 +458,17 @@ html.light .glass-card-active {
 .markdown-preview .hljs-type,
 .markdown-preview .hljs-attr,
 .markdown-preview .hljs-built_in,
-.markdown-preview .hljs-builtin-name {
+.markdown-preview .hljs-builtin-name,
+.md-rendered .hljs-keyword,
+.md-rendered .hljs-selector-tag,
+.md-rendered .hljs-literal,
+.md-rendered .hljs-name,
+.md-rendered .hljs-doctag,
+.md-rendered .hljs-section,
+.md-rendered .hljs-type,
+.md-rendered .hljs-attr,
+.md-rendered .hljs-built_in,
+.md-rendered .hljs-builtin-name {
   color: #c678dd;
 }
 
@@ -464,7 +477,13 @@ html.light .glass-card-active {
 .markdown-preview .hljs-regexp,
 .markdown-preview .hljs-symbol,
 .markdown-preview .hljs-bullet,
-.markdown-preview .hljs-link {
+.markdown-preview .hljs-link,
+.md-rendered .hljs-string,
+.md-rendered .hljs-title,
+.md-rendered .hljs-regexp,
+.md-rendered .hljs-symbol,
+.md-rendered .hljs-bullet,
+.md-rendered .hljs-link {
   color: #98c379;
 }
 
@@ -472,26 +491,37 @@ html.light .glass-card-active {
 .markdown-preview .hljs-meta,
 .markdown-preview .hljs-variable,
 .markdown-preview .hljs-template-variable,
-.markdown-preview .hljs-addition {
+.markdown-preview .hljs-addition,
+.md-rendered .hljs-number,
+.md-rendered .hljs-meta,
+.md-rendered .hljs-variable,
+.md-rendered .hljs-template-variable,
+.md-rendered .hljs-addition {
   color: #d19a66;
 }
 
-.markdown-preview .hljs-deletion {
+.markdown-preview .hljs-deletion,
+.md-rendered .hljs-deletion {
   color: #e06c75;
 }
 
 .markdown-preview .hljs-title,
-.markdown-preview .hljs-function .hljs-title {
+.markdown-preview .hljs-function .hljs-title,
+.md-rendered .hljs-title,
+.md-rendered .hljs-function .hljs-title {
   color: #61afef;
 }
 
-html.light .markdown-preview pre > code.hljs {
+html.light .markdown-preview pre > code.hljs,
+html.light .md-rendered pre > code.hljs {
   background: #fafafa;
   color: #383a42;
 }
 
 html.light .markdown-preview .hljs-comment,
-html.light .markdown-preview .hljs-quote {
+html.light .markdown-preview .hljs-quote,
+html.light .md-rendered .hljs-comment,
+html.light .md-rendered .hljs-quote {
   color: #a0a1a7;
 }
 
@@ -504,7 +534,17 @@ html.light .markdown-preview .hljs-section,
 html.light .markdown-preview .hljs-type,
 html.light .markdown-preview .hljs-attr,
 html.light .markdown-preview .hljs-built_in,
-html.light .markdown-preview .hljs-builtin-name {
+html.light .markdown-preview .hljs-builtin-name,
+html.light .md-rendered .hljs-keyword,
+html.light .md-rendered .hljs-selector-tag,
+html.light .md-rendered .hljs-literal,
+html.light .md-rendered .hljs-name,
+html.light .md-rendered .hljs-doctag,
+html.light .md-rendered .hljs-section,
+html.light .md-rendered .hljs-type,
+html.light .md-rendered .hljs-attr,
+html.light .md-rendered .hljs-built_in,
+html.light .md-rendered .hljs-builtin-name {
   color: #a626a4;
 }
 
@@ -513,7 +553,13 @@ html.light .markdown-preview .hljs-title,
 html.light .markdown-preview .hljs-regexp,
 html.light .markdown-preview .hljs-symbol,
 html.light .markdown-preview .hljs-bullet,
-html.light .markdown-preview .hljs-link {
+html.light .markdown-preview .hljs-link,
+html.light .md-rendered .hljs-string,
+html.light .md-rendered .hljs-title,
+html.light .md-rendered .hljs-regexp,
+html.light .md-rendered .hljs-symbol,
+html.light .md-rendered .hljs-bullet,
+html.light .md-rendered .hljs-link {
   color: #50a14f;
 }
 
@@ -521,16 +567,24 @@ html.light .markdown-preview .hljs-number,
 html.light .markdown-preview .hljs-meta,
 html.light .markdown-preview .hljs-variable,
 html.light .markdown-preview .hljs-template-variable,
-html.light .markdown-preview .hljs-addition {
+html.light .markdown-preview .hljs-addition,
+html.light .md-rendered .hljs-number,
+html.light .md-rendered .hljs-meta,
+html.light .md-rendered .hljs-variable,
+html.light .md-rendered .hljs-template-variable,
+html.light .md-rendered .hljs-addition {
   color: #986801;
 }
 
-html.light .markdown-preview .hljs-deletion {
+html.light .markdown-preview .hljs-deletion,
+html.light .md-rendered .hljs-deletion {
   color: #e45649;
 }
 
 html.light .markdown-preview .hljs-title,
-html.light .markdown-preview .hljs-function .hljs-title {
+html.light .markdown-preview .hljs-function .hljs-title,
+html.light .md-rendered .hljs-title,
+html.light .md-rendered .hljs-function .hljs-title {
   color: #4078f2;
 }
 

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -53,7 +53,6 @@ const ChatInterface: FC<ChatInterfaceProps> = ({
     thinkingMode,
     toggleThinking,
     restoredMessages,
-    restored,
     updateRefs,
   } = useChatPersistence({
     compact,

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -63,7 +63,6 @@ const ChatInterface: FC<ChatInterfaceProps> = ({
   } = useChatPersistence({
     compact,
     controlledSessionId,
-    welcomeMessage,
   });
 
   const {

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -6,6 +6,7 @@ import useI18n from "@/lib/notes/hooks/use-i18n";
 import { useChatStream } from "@/lib/chat/hooks/use-chat-stream";
 import { useChatPersistence } from "@/lib/chat/hooks/use-chat-persistence";
 import { CompactMessageBubble, FullMessageBubble } from "./message-bubble";
+import ChatSplash from "./chat-splash";
 
 // re-export types so existing consumers keep working
 export type {
@@ -28,16 +29,10 @@ interface ChatInterfaceProps {
   onSessionCreated?: (sessionId: string, title: string) => void;
   /** Called when the user clears the current scope */
   onClearContext?: () => void;
+  /** Called when a stream completes — useful for refreshing session list order */
+  onStreamComplete?: () => void;
   /** Optional extra class on the wrapper */
   className?: string;
-}
-
-// i18n keys
-const WELCOME_COMPACT_KEY = "chat.welcome_compact";
-const WELCOME_FULL_KEY = "chat.welcome_full";
-
-function makeWelcomeMessage(t: (key: string) => string, compact: boolean): string {
-  return compact ? t(WELCOME_COMPACT_KEY) : t(WELCOME_FULL_KEY);
 }
 
 const ChatInterface: FC<ChatInterfaceProps> = ({
@@ -49,10 +44,10 @@ const ChatInterface: FC<ChatInterfaceProps> = ({
   selectedFolders = [],
   onSessionCreated,
   onClearContext,
+  onStreamComplete,
   className = "",
 }) => {
   const { t } = useI18n();
-  const welcomeMessage = makeWelcomeMessage(t, compact);
 
   const {
     thinkingMode,
@@ -82,22 +77,8 @@ const ChatInterface: FC<ChatInterfaceProps> = ({
     selectedFolders,
     thinkingMode,
     onSessionCreated,
+    onStreamComplete,
   });
-
-  // initialize messages with the welcome message
-  const initialized = useRef(false);
-  useEffect(() => {
-    if (initialized.current) return;
-    initialized.current = true;
-    setMessages([
-      {
-        id: "welcome",
-        role: "assistant",
-        content: welcomeMessage,
-        timestamp: Date.now(),
-      },
-    ]);
-  }, [welcomeMessage, setMessages]);
 
   // apply restored session messages when available
   useEffect(() => {
@@ -131,9 +112,7 @@ const ChatInterface: FC<ChatInterfaceProps> = ({
 
     setInput("");
 
-    // build history (skip welcome message)
     const history = messages
-      .filter((m) => m.id !== "welcome")
       .filter((m) => m.content.trim().length > 0)
       .map((m) => ({ role: m.role, content: m.content }));
 
@@ -162,14 +141,7 @@ const ChatInterface: FC<ChatInterfaceProps> = ({
       }
     }
 
-    setMessages([
-      {
-        id: "welcome",
-        role: "assistant",
-        content: welcomeMessage,
-        timestamp: Date.now(),
-      },
-    ]);
+    setMessages([]);
     setSessionId(null);
     setError(null);
   };
@@ -228,9 +200,13 @@ const ChatInterface: FC<ChatInterfaceProps> = ({
     <div className={`flex flex-col h-full ${className}`}>
       {/* messages */}
       <div className="flex-1 overflow-y-auto px-4 md:px-8 lg:px-12 py-6 space-y-5 obsidian-scrollbar">
-        {messages.map((m) => (
-          <FullMessageBubble key={m.id} message={m} sessionId={sessionId} />
-        ))}
+        {messages.length === 0 ? (
+          <ChatSplash />
+        ) : (
+          messages.map((m) => (
+            <FullMessageBubble key={m.id} message={m} sessionId={sessionId} />
+          ))
+        )}
 
         {error && (
           <div className="flex justify-center">

--- a/src/components/chat/chat-markdown.tsx
+++ b/src/components/chat/chat-markdown.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import MarkdownRenderer from "@/lib/markdown/renderer";
+import { markdownSanitizeSchema } from "@/lib/markdown/sanitize-schema";
+import remarkBreaks from "remark-breaks";
+import rehypeHighlight from "rehype-highlight";
+import rehypeSanitize from "rehype-sanitize";
+
+export default function ChatMarkdown({ children }: { children: string }) {
+  return (
+    <MarkdownRenderer
+      className="text-sm leading-relaxed"
+      remarkPlugins={[remarkBreaks]}
+      rehypePlugins={[rehypeHighlight, [rehypeSanitize, markdownSanitizeSchema]]}
+      components={{
+        p: ({ children }: any) => <p className="mb-2 last:mb-0">{children}</p>,
+        h1: ({ children }: any) => (
+          <h1 className="text-xl font-bold text-text mt-3 mb-1.5">{children}</h1>
+        ),
+        h2: ({ children }: any) => (
+          <h2 className="text-lg font-bold text-text mt-3 mb-1">{children}</h2>
+        ),
+        h3: ({ children }: any) => (
+          <h3 className="text-base font-semibold text-text mt-2 mb-1">{children}</h3>
+        ),
+        h4: ({ children }: any) => (
+          <h4 className="font-medium text-text mt-2 mb-0.5">{children}</h4>
+        ),
+        blockquote: ({ children }: any) => (
+          <blockquote className="border-l-2 border-primary-500/40 pl-3 my-2 text-text-tertiary italic">
+            {children}
+          </blockquote>
+        ),
+        ul: ({ children, className }: any) => (
+          <ul
+            className={[
+              "list-disc list-outside pl-5 my-2 space-y-0.5 text-text",
+              className,
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          >
+            {children}
+          </ul>
+        ),
+        ol: ({ children, className }: any) => (
+          <ol
+            className={[
+              "list-decimal list-outside pl-5 my-2 space-y-0.5 text-text",
+              className,
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          >
+            {children}
+          </ol>
+        ),
+        li: ({ children }: any) => (
+          <li className="leading-relaxed">{children}</li>
+        ),
+        hr: () => <hr className="my-3 border-border-subtle" />,
+        table: ({ children }: any) => (
+          <div className="overflow-x-auto my-2">
+            <table className="text-xs border-collapse w-full">{children}</table>
+          </div>
+        ),
+        th: ({ children }: any) => (
+          <th className="border border-border px-3 py-1.5 bg-surface font-semibold text-left text-text-secondary">
+            {children}
+          </th>
+        ),
+        td: ({ children }: any) => (
+          <td className="border border-border px-3 py-1.5 text-text-secondary">
+            {children}
+          </td>
+        ),
+      }}
+    >
+      {children}
+    </MarkdownRenderer>
+  );
+}

--- a/src/components/chat/chat-splash.tsx
+++ b/src/components/chat/chat-splash.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { type FC } from "react";
+import { SparklesIcon } from "@heroicons/react/24/outline";
+
+const ChatSplash: FC = () => (
+  <div className="flex-1 flex flex-col items-center justify-center gap-4 px-6 text-center">
+    <div className="w-12 h-12 rounded-2xl bg-primary-500/10 border border-primary-500/20 flex items-center justify-center">
+      <SparklesIcon className="w-6 h-6 text-primary-400" />
+    </div>
+    <div className="space-y-1">
+      <h2 className="text-base font-semibold text-text-secondary">
+        OghmaNotes AI
+      </h2>
+      <p className="text-sm text-text-tertiary max-w-xs">
+        Ask anything about your notes, or start a conversation.
+      </p>
+    </div>
+  </div>
+);
+
+export default ChatSplash;

--- a/src/components/chat/message-bubble.tsx
+++ b/src/components/chat/message-bubble.tsx
@@ -6,9 +6,8 @@ import {
   ChevronDownIcon,
   ClipboardDocumentIcon,
 } from "@heroicons/react/24/outline";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import type { Message } from "./chat-interface";
+import ChatMarkdown from "./chat-markdown";
 
 // relevance level from cosine distance
 function relevanceLabel(distance: number): { label: string; color: string } {
@@ -184,49 +183,6 @@ const CopyMessageButton: FC<{
   );
 };
 
-// shared markdown renderer config
-const markdownComponents = {
-  p: ({ children }: { children?: React.ReactNode }) => (
-    <p className="mb-2 last:mb-0">{children}</p>
-  ),
-  ul: ({ children }: { children?: React.ReactNode }) => (
-    <ul className="list-disc list-inside mb-2 space-y-0.5">{children}</ul>
-  ),
-  ol: ({ children }: { children?: React.ReactNode }) => (
-    <ol className="list-decimal list-inside mb-2 space-y-0.5">{children}</ol>
-  ),
-  code: ({
-    children,
-    className: cls,
-  }: {
-    children?: React.ReactNode;
-    className?: string;
-  }) => {
-    const isBlock = cls?.includes("language-");
-    return isBlock ? (
-      <code className="block bg-black/30 rounded-lg p-3 text-xs font-mono my-2 overflow-x-auto whitespace-pre">
-        {children}
-      </code>
-    ) : (
-      <code className="bg-subtle px-1.5 py-0.5 rounded text-xs font-mono">
-        {children}
-      </code>
-    );
-  },
-  em: ({ children }: { children?: React.ReactNode }) => (
-    <em className="italic text-text-tertiary/80">{children}</em>
-  ),
-  strong: ({ children }: { children?: React.ReactNode }) => (
-    <strong className="font-semibold text-text">{children}</strong>
-  ),
-  h3: ({ children }: { children?: React.ReactNode }) => (
-    <h3 className="font-semibold text-text mt-3 mb-1">{children}</h3>
-  ),
-  h4: ({ children }: { children?: React.ReactNode }) => (
-    <h4 className="font-medium text-text mt-2 mb-1">{children}</h4>
-  ),
-};
-
 // full-page message bubble
 export const FullMessageBubble: FC<{
   message: Message;
@@ -237,13 +193,22 @@ export const FullMessageBubble: FC<{
   if (m.role === "user") {
     return (
       <div className="flex justify-end">
-        <div className="max-w-lg">
+        <div className="max-w-2xl">
           <div className="relative px-4 py-3 pr-12 rounded-2xl rounded-br-sm bg-primary-500/85 text-text-on-primary text-sm leading-relaxed">
             {hasContent && (
               <CopyMessageButton content={m.content} variant="full-user" />
             )}
             <p>{m.content}</p>
           </div>
+          <p
+            className="text-xs text-text-tertiary opacity-60 mt-1 text-right"
+            suppressHydrationWarning
+          >
+            {new Date(m.timestamp).toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </p>
         </div>
       </div>
     );
@@ -267,12 +232,7 @@ export const FullMessageBubble: FC<{
           <CopyMessageButton content={m.content} variant="full-assistant" />
         )}
         {hasContent ? (
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            components={markdownComponents}
-          >
-            {m.content}
-          </ReactMarkdown>
+          <ChatMarkdown>{m.content}</ChatMarkdown>
         ) : !m.thinking ? (
           <TypingDots />
         ) : null}
@@ -328,21 +288,7 @@ export const CompactMessageBubble: FC<{ message: Message }> = ({
           )}
           {m.role === "assistant" ? (
             hasContent ? (
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                components={{
-                  p: ({ children }) => (
-                    <p className="mb-1 last:mb-0">{children}</p>
-                  ),
-                  code: ({ children }) => (
-                    <code className="bg-subtle px-1 rounded text-xs">
-                      {children}
-                    </code>
-                  ),
-                }}
-              >
-                {m.content}
-              </ReactMarkdown>
+              <ChatMarkdown>{m.content}</ChatMarkdown>
             ) : (
               <TypingDots />
             )

--- a/src/components/editor/preview-renderer.tsx
+++ b/src/components/editor/preview-renderer.tsx
@@ -1,226 +1,155 @@
 "use client";
 
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
 import rehypeHighlight from "rehype-highlight";
 import rehypeRaw from "rehype-raw";
-import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import rehypeSanitize from "rehype-sanitize";
+import MarkdownRenderer from "@/lib/markdown/renderer";
+import { markdownSanitizeSchema } from "@/lib/markdown/sanitize-schema";
 
 interface PreviewRendererProps {
   content: string;
   noteId?: string;
 }
 
-const sanitizeSchema = structuredClone(defaultSchema);
-sanitizeSchema.tagNames = [
-  ...(sanitizeSchema.tagNames ?? []),
-  "mark",
-  "details",
-  "summary",
-  "kbd",
-  "sup",
-  "sub",
-];
-sanitizeSchema.attributes = {
-  ...(sanitizeSchema.attributes ?? {}),
-  code: [
-    ...(sanitizeSchema.attributes?.code ?? []),
-    ["className", /^language-[a-z0-9_-]+$/i, "hljs"],
-  ],
-  span: [
-    ...(sanitizeSchema.attributes?.span ?? []),
-    ["className", /^hljs(?:-[a-z0-9_]+)?$/i],
-  ],
-  details: ["open"],
-};
-
 export default function PreviewRenderer({ content, noteId }: PreviewRendererProps) {
   return (
-    <div
+    <MarkdownRenderer
       className="markdown-preview w-full prose prose-lg prose-invert max-w-none"
-      dir="ltr"
-    >
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkBreaks]}
-        rehypePlugins={[
-          rehypeRaw,
-          rehypeHighlight,
-          [rehypeSanitize, sanitizeSchema],
-        ]}
-        components={{
-          // Links rendered to open in new tabs for safety, styled with hover effects
-          a: ({ node: _node, ...props }) => (
-            <a
+      remarkPlugins={[remarkBreaks]}
+      rehypePlugins={[
+        rehypeRaw,
+        rehypeHighlight,
+        [rehypeSanitize, markdownSanitizeSchema],
+      ]}
+      components={{
+        img: ({ node: _node, src, alt, ...props }) => {
+          const rawSrc = typeof src === "string" ? src.trim() : "";
+          const isAbsolute =
+            rawSrc.startsWith("http://") ||
+            rawSrc.startsWith("https://") ||
+            rawSrc.startsWith("data:") ||
+            rawSrc.startsWith("/");
+
+          const resolvedSrc =
+            !isAbsolute &&
+            noteId &&
+            /^_page_\d+_(?:Picture|Figure)_\d+\.(?:png|jpg|jpeg|webp|gif|bmp)$/i.test(
+              rawSrc,
+            )
+              ? `/api/notes/${noteId}/assets?name=${encodeURIComponent(rawSrc)}`
+              : rawSrc;
+
+          return (
+            <img
               {...props}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary-400 hover:underline"
+              src={resolvedSrc}
+              alt={alt ?? ""}
+              loading="lazy"
             />
-          ),
-          img: ({ node: _node, src, alt, ...props }) => {
-            const rawSrc = typeof src === "string" ? src.trim() : "";
-            const isAbsolute =
-              rawSrc.startsWith("http://") ||
-              rawSrc.startsWith("https://") ||
-              rawSrc.startsWith("data:") ||
-              rawSrc.startsWith("/");
-
-            const resolvedSrc =
-              !isAbsolute &&
-              noteId &&
-              /^_page_\d+_(?:Picture|Figure)_\d+\.(?:png|jpg|jpeg|webp|gif|bmp)$/i.test(
-                rawSrc,
-              )
-                ? `/api/notes/${noteId}/assets?name=${encodeURIComponent(rawSrc)}`
-                : rawSrc;
-
+          );
+        },
+        // custom heading anchors
+        h1: ({ node: _node, children, ...props }) => (
+          <h1 className="text-4xl font-bold mt-8 mb-4" {...props}>
+            {children}
+          </h1>
+        ),
+        h2: ({ node: _node, children, ...props }) => (
+          <h2 className="text-3xl font-bold mt-6 mb-3" {...props}>
+            {children}
+          </h2>
+        ),
+        h3: ({ node: _node, children, ...props }) => (
+          <h3 className="text-2xl font-bold mt-4 mb-2" {...props}>
+            {children}
+          </h3>
+        ),
+        // custom blockquote styling: consistent margins and dark mode support
+        blockquote: ({ node: _node, children, ...props }) => (
+          <blockquote
+            className="border-l-4 border-primary-500 pl-4 italic my-4 text-text-secondary"
+            {...props}
+          >
+            {children}
+          </blockquote>
+        ),
+        // custom table styling
+        table: ({ node: _node, children, ...props }) => (
+          <div className="overflow-x-auto my-4">
+            <table className="min-w-full border border-border" {...props}>
+              {children}
+            </table>
+          </div>
+        ),
+        th: ({ node: _node, children, ...props }) => (
+          <th
+            className="border border-border px-4 py-2 bg-surface font-semibold text-left"
+            {...props}
+          >
+            {children}
+          </th>
+        ),
+        td: ({ node: _node, children, ...props }) => (
+          <td className="border border-border px-4 py-2" {...props}>
+            {children}
+          </td>
+        ),
+        // explicit list styles — Tailwind base resets list-style-type by default
+        ul: ({ node: _node, children, className, ...props }) => (
+          <ul
+            {...props}
+            className={[
+              "list-disc list-outside pl-6 my-3 space-y-1 text-text",
+              className,
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          >
+            {children}
+          </ul>
+        ),
+        ol: ({ node: _node, children, className, ...props }) => (
+          <ol
+            {...props}
+            className={[
+              "list-decimal list-outside pl-6 my-3 space-y-1 text-text",
+              className,
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          >
+            {children}
+          </ol>
+        ),
+        li: ({ node: _node, children, className, ...props }) => (
+          <li
+            {...props}
+            className={["ml-1 leading-relaxed", className]
+              .filter(Boolean)
+              .join(" ")}
+          >
+            {children}
+          </li>
+        ),
+        input: ({ node: _node, type, className, ...props }) => {
+          if (type === "checkbox") {
             return (
-              <img
+              <input
+                type="checkbox"
                 {...props}
-                src={resolvedSrc}
-                alt={alt ?? ""}
-                loading="lazy"
+                className={["mr-2 align-middle accent-primary-500", className]
+                  .filter(Boolean)
+                  .join(" ")}
               />
             );
-          },
-          // custom code block styling
-          code: ({
-            node: _node,
-            className,
-            children,
-            inline,
-            ...props
-          }: any) => {
-            const contentText = Array.isArray(children)
-              ? children.join("")
-              : String(children ?? "");
-            const language = /language-([a-z0-9_-]+)/i
-              .exec(className ?? "")?.[1]
-              ?.toLowerCase();
-            const isInline =
-              inline ?? (!className && !contentText.includes("\n"));
+          }
 
-            if (isInline) {
-              return (
-                <code
-                  className="rounded bg-surface text-sm px-1.5 py-0.5 font-mono"
-                  {...props}
-                >
-                  {children}
-                </code>
-              );
-            }
-
-            return (
-              // data-language keeps renderer-extension hooks simple (mermaid, runners)
-              <code className={className} data-language={language} {...props}>
-                {children}
-              </code>
-            );
-          },
-          // custom heading anchors
-          h1: ({ node: _node, children, ...props }) => (
-            <h1 className="text-4xl font-bold mt-8 mb-4" {...props}>
-              {children}
-            </h1>
-          ),
-          h2: ({ node: _node, children, ...props }) => (
-            <h2 className="text-3xl font-bold mt-6 mb-3" {...props}>
-              {children}
-            </h2>
-          ),
-          h3: ({ node: _node, children, ...props }) => (
-            <h3 className="text-2xl font-bold mt-4 mb-2" {...props}>
-              {children}
-            </h3>
-          ),
-          // custom blockquote styling: consistent margins and dark mode support
-          blockquote: ({ node: _node, children, ...props }) => (
-            <blockquote
-              className="border-l-4 border-primary-500 pl-4 italic my-4 text-text-secondary"
-              {...props}
-            >
-              {children}
-            </blockquote>
-          ),
-          // custom table styling
-          table: ({ node: _node, children, ...props }) => (
-            <div className="overflow-x-auto my-4">
-              <table className="min-w-full border border-border" {...props}>
-                {children}
-              </table>
-            </div>
-          ),
-          th: ({ node: _node, children, ...props }) => (
-            <th
-              className="border border-border px-4 py-2 bg-surface font-semibold text-left"
-              {...props}
-            >
-              {children}
-            </th>
-          ),
-          td: ({ node: _node, children, ...props }) => (
-            <td className="border border-border px-4 py-2" {...props}>
-              {children}
-            </td>
-          ),
-          // explicit list styles — Tailwind base resets list-style-type by default
-          ul: ({ node: _node, children, className, ...props }) => (
-            <ul
-              {...props}
-              className={[
-                "list-disc list-outside pl-6 my-3 space-y-1 text-text",
-                className,
-              ]
-                .filter(Boolean)
-                .join(" ")}
-            >
-              {children}
-            </ul>
-          ),
-          ol: ({ node: _node, children, className, ...props }) => (
-            <ol
-              {...props}
-              className={[
-                "list-decimal list-outside pl-6 my-3 space-y-1 text-text",
-                className,
-              ]
-                .filter(Boolean)
-                .join(" ")}
-            >
-              {children}
-            </ol>
-          ),
-          li: ({ node: _node, children, className, ...props }) => (
-            <li
-              {...props}
-              className={["ml-1 leading-relaxed", className]
-                .filter(Boolean)
-                .join(" ")}
-            >
-              {children}
-            </li>
-          ),
-          input: ({ node: _node, type, className, ...props }) => {
-            if (type === "checkbox") {
-              return (
-                <input
-                  type="checkbox"
-                  {...props}
-                  className={["mr-2 align-middle accent-primary-500", className]
-                    .filter(Boolean)
-                    .join(" ")}
-                />
-              );
-            }
-
-            return <input type={type} {...props} className={className} />;
-          },
-        }}
-      >
-        {content || "*No content*"}
-      </ReactMarkdown>
-    </div>
+          return <input type={type} {...props} className={className} />;
+        },
+      }}
+    >
+      {content || "*No content*"}
+    </MarkdownRenderer>
   );
 }

--- a/src/components/quiz/quiz-markdown.tsx
+++ b/src/components/quiz/quiz-markdown.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import rehypeHighlight from "rehype-highlight";
+import MarkdownRenderer from "@/lib/markdown/renderer";
 
 interface QuizMarkdownProps {
   children: string;
@@ -13,51 +12,26 @@ interface QuizMarkdownProps {
 
 export default function QuizMarkdown({ children, className }: QuizMarkdownProps) {
   return (
-    <div className={className}>
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm, remarkMath]}
+    <MarkdownRenderer
+      className={className}
+      remarkPlugins={[remarkMath]}
       rehypePlugins={[rehypeKatex, rehypeHighlight]}
       components={{
-        p: ({ children }) => (
+        p: ({ children }: any) => (
           <p className="mb-1.5 last:mb-0 leading-relaxed">{children}</p>
         ),
-        strong: ({ children }) => (
-          <strong className="font-semibold text-text">{children}</strong>
-        ),
-        em: ({ children }) => <em className="italic">{children}</em>,
-        ol: ({ children }) => (
+        ol: ({ children }: any) => (
           <ol className="list-decimal list-outside pl-4 space-y-1 my-1.5">
             {children}
           </ol>
         ),
-        ul: ({ children }) => (
+        ul: ({ children }: any) => (
           <ul className="list-disc list-outside pl-4 space-y-1 my-1.5">
             {children}
           </ul>
         ),
-        li: ({ children }) => <li className="leading-relaxed">{children}</li>,
-        pre: ({ children }) => (
-          <pre className="bg-surface rounded-radius-sm p-3 overflow-x-auto my-2 text-xs leading-relaxed">
-            {children}
-          </pre>
-        ),
-        code: ({ children, className }) => {
-          // inside a <pre> block — block code
-          if (className) {
-            return (
-              <code className={`${className} font-mono text-xs`}>
-                {children}
-              </code>
-            );
-          }
-          // inline code
-          return (
-            <code className="bg-surface px-1 py-0.5 rounded text-xs font-mono text-text-secondary">
-              {children}
-            </code>
-          );
-        },
-        blockquote: ({ children }) => (
+        li: ({ children }: any) => <li className="leading-relaxed">{children}</li>,
+        blockquote: ({ children }: any) => (
           <blockquote className="border-l-2 border-border-subtle pl-3 text-text-tertiary my-1.5 italic">
             {children}
           </blockquote>
@@ -65,7 +39,6 @@ export default function QuizMarkdown({ children, className }: QuizMarkdownProps)
       }}
     >
       {children}
-    </ReactMarkdown>
-    </div>
+    </MarkdownRenderer>
   );
 }

--- a/src/lib/chat/hooks/use-chat-persistence.ts
+++ b/src/lib/chat/hooks/use-chat-persistence.ts
@@ -15,7 +15,6 @@ interface PersistenceRefs {
 interface UseChatPersistenceOptions {
   compact: boolean;
   controlledSessionId?: string;
-  welcomeMessage: string;
 }
 
 interface UseChatPersistenceResult {
@@ -34,7 +33,7 @@ interface UseChatPersistenceResult {
 export function useChatPersistence(
   options: UseChatPersistenceOptions,
 ): UseChatPersistenceResult {
-  const { compact, controlledSessionId, welcomeMessage } = options;
+  const { compact, controlledSessionId } = options;
 
   // thinking mode
   const [thinkingMode, setThinkingMode] = useState<LlmThinkingMode>("auto");
@@ -138,7 +137,6 @@ export function useChatPersistence(
       }
     };
     void restore();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [controlledSessionId, compact, restored]);
 
   // refs for unload handlers (kept in sync by the consumer)

--- a/src/lib/chat/hooks/use-chat-persistence.ts
+++ b/src/lib/chat/hooks/use-chat-persistence.ts
@@ -128,12 +128,6 @@ export function useChatPersistence(
         }
 
         setRestoredMessages([
-          {
-            id: "welcome",
-            role: "assistant",
-            content: welcomeMessage,
-            timestamp: Date.now(),
-          },
           ...serverMessages,
           ...(draftMsg ? [draftMsg] : []),
         ]);

--- a/src/lib/chat/hooks/use-chat-stream.ts
+++ b/src/lib/chat/hooks/use-chat-stream.ts
@@ -183,6 +183,7 @@ export function useChatStream(
                     sources: Array.isArray(data.sources) ? data.sources : [],
                     retrieval: data.retrieval,
                     searchContext: data.searchContext ?? undefined,
+                    timestamp: Date.now(),
                   }
                 : m,
             ),
@@ -197,6 +198,12 @@ export function useChatStream(
         }
 
         await consumeStream(res.body, assistantId, text);
+        const completionTime = Date.now();
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId ? { ...m, timestamp: completionTime } : m,
+          ),
+        );
         clearDraft(sessionIdRef.current);
         onStreamComplete?.();
       } catch (err) {

--- a/src/lib/chat/hooks/use-chat-stream.ts
+++ b/src/lib/chat/hooks/use-chat-stream.ts
@@ -21,6 +21,8 @@ interface UseChatStreamOptions {
   selectedFolders: ChatContextItem[];
   thinkingMode: LlmThinkingMode;
   onSessionCreated?: (sessionId: string, title: string) => void;
+  /** called when a stream completes — useful for refreshing session list order */
+  onStreamComplete?: () => void;
 }
 
 interface UseChatStreamResult {
@@ -101,6 +103,7 @@ export function useChatStream(
     selectedFolders,
     thinkingMode,
     onSessionCreated,
+    onStreamComplete,
   } = options;
 
   const [messages, setMessages] = useState<Message[]>([]);
@@ -185,6 +188,7 @@ export function useChatStream(
             ),
           );
           clearDraft(data.sessionId || sessionIdRef.current);
+          onStreamComplete?.();
           return;
         }
 
@@ -194,6 +198,7 @@ export function useChatStream(
 
         await consumeStream(res.body, assistantId, text);
         clearDraft(sessionIdRef.current);
+        onStreamComplete?.();
       } catch (err) {
         const errMsg =
           err instanceof Error ? err.message : t("error.something_went_wrong");

--- a/src/lib/markdown/components/code-block.tsx
+++ b/src/lib/markdown/components/code-block.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { ClipboardDocumentIcon, CheckIcon } from "@heroicons/react/24/outline";
+
+interface CodeBlockProps {
+  language?: string;
+  className?: string;
+  children: React.ReactNode;
+  /** raw text content for clipboard — extracted from children by the renderer */
+  rawContent?: string;
+}
+
+export default function CodeBlock({
+  language,
+  className,
+  children,
+  rawContent,
+}: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const text =
+      rawContent ?? (typeof children === "string" ? children : "");
+    if (!text || !navigator.clipboard?.writeText) return;
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  // future: if (language === "mermaid") return <MermaidBlock>{children}</MermaidBlock>;
+  // use dynamic(() => import("./mermaid-block"), { ssr: false }) to keep Mermaid's ~2MB out of the bundle
+
+  return (
+    <div className="relative group my-2 rounded-lg overflow-hidden bg-surface/50">
+      {language && (
+        <div className="flex items-center justify-between px-3 py-1.5 border-b border-border-subtle">
+          <span className="text-[10px] font-mono text-text-tertiary">
+            {language}
+          </span>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="opacity-0 group-hover:opacity-100 p-1 rounded text-text-tertiary hover:text-text-secondary transition-all"
+            aria-label="Copy code"
+            title={copied ? "Copied" : "Copy"}
+          >
+            {copied ? (
+              <CheckIcon className="w-3.5 h-3.5 text-green-400" />
+            ) : (
+              <ClipboardDocumentIcon className="w-3.5 h-3.5" />
+            )}
+          </button>
+        </div>
+      )}
+      <pre className={`overflow-x-auto ${className ?? ""}`}>{children}</pre>
+    </div>
+  );
+}

--- a/src/lib/markdown/renderer.tsx
+++ b/src/lib/markdown/renderer.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { Components } from "react-markdown";
+import type { PluggableList } from "unified";
+import CodeBlock from "./components/code-block";
+
+export interface MarkdownRendererProps {
+  children: string;
+  className?: string;
+  remarkPlugins?: PluggableList;
+  rehypePlugins?: PluggableList;
+  /** merged with (and overrides) base components */
+  components?: Partial<Components>;
+}
+
+const baseComponents: Partial<Components> = {
+  a: ({ href, children, ...props }: any) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-primary-400 underline underline-offset-2 hover:text-primary-300 transition-colors"
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+  // pre extracts language and delegates to CodeBlock;
+  // code passes through hljs classes so rehype-highlight tokens survive
+  pre: ({ children }: any) => {
+    const codeEl = (children as any)?.props;
+    const cls: string = codeEl?.className ?? "";
+    const lang = /language-([a-z0-9_-]+)/i.exec(cls)?.[1];
+    const rawContent =
+      typeof codeEl?.children === "string" ? codeEl.children : undefined;
+    return (
+      <CodeBlock language={lang} rawContent={rawContent}>
+        {children}
+      </CodeBlock>
+    );
+  },
+  code: ({ children, className, ...props }: any) => {
+    const isInline = !className;
+    if (isInline) {
+      return (
+        <code
+          className="bg-subtle px-1.5 py-0.5 rounded text-xs font-mono"
+          {...props}
+        >
+          {children}
+        </code>
+      );
+    }
+    return (
+      <code className={className} {...props}>
+        {children}
+      </code>
+    );
+  },
+  strong: ({ children }: any) => (
+    <strong className="font-semibold text-text">{children}</strong>
+  ),
+  em: ({ children }: any) => <em className="italic">{children}</em>,
+};
+
+export default function MarkdownRenderer({
+  children,
+  className,
+  remarkPlugins,
+  rehypePlugins,
+  components,
+}: MarkdownRendererProps) {
+  const merged = { ...baseComponents, ...components };
+  const wrapperClass = ["md-rendered", className].filter(Boolean).join(" ");
+
+  return (
+    <div className={wrapperClass}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, ...(remarkPlugins ?? [])]}
+        rehypePlugins={rehypePlugins ?? []}
+        components={merged}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/src/lib/markdown/sanitize-schema.ts
+++ b/src/lib/markdown/sanitize-schema.ts
@@ -1,0 +1,24 @@
+import { defaultSchema } from "rehype-sanitize";
+
+export const markdownSanitizeSchema = structuredClone(defaultSchema);
+markdownSanitizeSchema.tagNames = [
+  ...(markdownSanitizeSchema.tagNames ?? []),
+  "mark",
+  "details",
+  "summary",
+  "kbd",
+  "sup",
+  "sub",
+];
+markdownSanitizeSchema.attributes = {
+  ...(markdownSanitizeSchema.attributes ?? {}),
+  code: [
+    ...(markdownSanitizeSchema.attributes?.code ?? []),
+    ["className", /^language-[a-z0-9_-]+$/i, "hljs"],
+  ],
+  span: [
+    ...(markdownSanitizeSchema.attributes?.span ?? []),
+    ["className", /^hljs(?:-[a-z0-9_]+)?$/i],
+  ],
+  details: ["open"],
+};


### PR DESCRIPTION
## Summary

- **Markdown architecture**: extracted shared `MarkdownRenderer` primitive with `CodeBlock` (copy button, language label, Mermaid stub for later). All three renderers — notes preview, quiz, chat — now compose from it. Zero duplicate inline/block code detection or link handling.
- **Chat stream bug fixed**: `mountKey` counter replaces `chatInstanceKey` on `<ChatInterface>`. Session ID assigned mid-stream no longer remounts the component — responses stream through without needing a page refresh.
- **Splash card**: proper empty state replaces the fake welcome message bubble. Old sessions restore clean history with no injected messages.
- **Timestamps**: user messages show send time; assistant timestamp stamped at stream completion (not request time).
- **Sidebar polish**: `onStreamComplete` refreshes session order after each response; relative dates (`2m` / `4h` / `3d` / `Jan 5`) shown inline next to title, fading on hover to reveal the delete button.
- **Security**: `ChatMarkdown` has no `rehype-raw` — LLM output is never parsed as raw HTML, `<script>`/`<iframe>` in AI responses are escaped to literal text.

## Files changed

**New:**
- `src/lib/markdown/sanitize-schema.ts` — shared rehype-sanitize config
- `src/lib/markdown/renderer.tsx` — `MarkdownRenderer` core primitive
- `src/lib/markdown/components/code-block.tsx` — copy button + lang label + Mermaid stub
- `src/components/chat/chat-markdown.tsx` — chat-scale renderer (no rehype-raw)
- `src/components/chat/chat-splash.tsx` — empty state splash card

**Modified:**
- `src/app/globals.css` — extend hljs theme to `.md-rendered` via comma selectors
- `src/components/editor/preview-renderer.tsx` — composes from MarkdownRenderer
- `src/components/quiz/quiz-markdown.tsx` — composes from MarkdownRenderer
- `src/components/chat/message-bubble.tsx` — uses ChatMarkdown, adds user timestamps
- `src/components/chat/chat-interface.tsx` — splash card empty state, onStreamComplete prop
- `src/lib/chat/hooks/use-chat-persistence.ts` — no welcome message in restored sessions
- `src/lib/chat/hooks/use-chat-stream.ts` — stream-end timestamp, onStreamComplete callback
- `src/app/chat/chat-page-client.tsx` — mountKey fix, loadSessions on complete, relativeDate sidebar

## Test plan

- [ ] Notes preview — headings, code highlighting, tables, images, task lists render identically
- [ ] Quiz — math (KaTeX) and code highlighting still work
- [ ] Chat stream — send a message, URL changes to `/chat/<uuid>` mid-stream, response continues without reset
- [ ] Splash card — new chat shows splash, old session shows only history (no welcome bubble)
- [ ] Code block copy — hover a code block, copy button appears, clipboard works
- [ ] Timestamps — user bubble shows HH:MM; assistant timestamp updates when stream ends
- [ ] Sidebar — session moves to top after response; dates show relative format; delete icon appears on hover
- [ ] Security — paste `<script>alert(1)</script>` into AI response field, verify it renders as escaped text

## CI

563 tests passing, 0 lint errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relative timestamps in conversation list (e.g., "just now", "2h ago")
  * Chat splash screen displayed when no active conversation
  * Copy-to-clipboard functionality for code blocks

* **Bug Fixes**
  * Session data now refreshes when message streaming completes

* **Refactor**
  * Unified markdown rendering system across chat, editor, and quiz components
  * Improved code syntax highlighting for rendered markdown
  * Streamlined chat initialization and welcome message handling

* **Style**
  * Added timestamps to user messages in chat
  * Enhanced code block and markdown element styling

* **Tests**
  * Updated code rendering test assertions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->