### PR TITLE
fix(rag): tighten relevance thresholds and prevent hallucination

### DIFF
--- a/src/lib/chat/rag-pipeline.ts
+++ b/src/lib/chat/rag-pipeline.ts
@@ -16,7 +16,7 @@ export interface SearchResult {
 
 // cosine distance threshold — chunks further than this are considered irrelevant
 // Cohere multilingual-v3.0 distances: 0 = identical, ~0.3 = very similar, ~0.7 = weakly related
-const MAX_DISTANCE = 0.75;
+const MAX_DISTANCE = 0.55;
 
 // search chunks+embeddings tables, joining back to notes for metadata
 export async function semanticSearch(
@@ -100,7 +100,7 @@ export async function resolveScopedNoteIds(
 
 export function buildSystemPrompt(results: SearchResult[]): string {
   if (results.length === 0) {
-    return "You are a helpful study assistant. No relevant note content was retrieved for this question — use your tools (getChunks, readNote) to search the attached notes before answering. If the notes truly contain nothing relevant, answer from general knowledge and say so.";
+    return "You are a helpful study assistant. No relevant note content was retrieved for this question. You MUST use your tools (getChunks, readNote) to search before making any claims about what notes exist or what they contain — never invent note titles or content. Only after checking tools should you answer; if nothing is found, say so explicitly.";
   }
 
   // group chunks by note for cleaner context
@@ -118,8 +118,8 @@ export function buildSystemPrompt(results: SearchResult[]): string {
   });
 
   return `You are a helpful study assistant with access to the user's notes.
-The notes below show what the user is currently studying. Use them as helpful context — cite which note your answer draws from when relevant — but you are not limited to them. Feel free to supplement with your broader knowledge, explain concepts in more depth, or reference up-to-date information the notes may not cover.
-If you go beyond the notes, briefly mention that you're drawing on general knowledge so the user knows.
+The notes below were retrieved as relevant context. When answering questions about the user's notes or library, only make claims that are grounded in the retrieved content or in what you have verified via tools (getChunks, readNote). Never invent note titles, note contents, or folder structures — if you are unsure what notes exist, use getChunks or readNote to check before answering.
+You may supplement retrieved note content with broader knowledge to explain concepts in more depth, but always be clear when you're drawing on general knowledge rather than the user's notes.
 
 NOTES CONTEXT:
 ${blocks.join("\n\n")}`;

--- a/src/lib/rerank.ts
+++ b/src/lib/rerank.ts
@@ -5,7 +5,7 @@ import logger from "@/lib/logger";
 import { defaultRerankProvider } from "@/lib/providers/self-hosted-rerank";
 
 const TOP_N = 5;
-const MIN_RELEVANCE = 0.15;
+const MIN_RELEVANCE = 0.25;
 
 interface RerankResult {
   index: number;
@@ -38,11 +38,10 @@ export async function rerankChunks(
     const filtered = results.filter((r) => r.score >= MIN_RELEVANCE);
 
     if (filtered.length === 0 && chunks.length > 0) {
-      logger.warn("rerank: all results below relevance threshold, falling back to vector order", {
+      logger.warn("rerank: all results below relevance threshold, returning empty to force tool use", {
         query: query.slice(0, 50),
         candidateCount: chunks.length,
       });
-      return fallbackTopN(chunks, topN);
     }
 
     return filtered;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- `MAX_DISTANCE` 0.75 → 0.55: only semantically close chunks enter the pipeline
- `MIN_RELEVANCE` 0.15 → 0.25: reranker filters more aggressively
- Removed fallback-to-vector-order when all rerank scores are below threshold — empty context now forces the LLM to use tools instead of receiving irrelevant chunks
- Hardened system prompt to explicitly prohibit inventing note titles or content before verifying via tools
- `moduleResolution: node` → `bundler` in tsconfig

## Test plan
- [ ] Ask chat about a note that exists — should retrieve correctly
- [ ] Ask chat about a folder — should use getChunks/readNote, not hallucinate
- [ ] Ask a question with no relevant notes — should say "nothing found" via tools, not invent content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tightened semantic search relevance filtering to retrieve more accurate results
  * Enhanced AI assistant to require content verification before making claims about note existence or content
  * Strengthened response grounding to prevent invention of note titles, content, or folder structures
  * Improved clarity when assistant uses general knowledge versus retrieved notes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->