### PR TITLE
fix(vault): pass S3 credentials in import and status routes

### DIFF
--- a/src/app/api/vault/import/route.ts
+++ b/src/app/api/vault/import/route.ts
@@ -35,6 +35,13 @@ export const POST = withErrorHandler(async (request) => {
 
   const s3 = new S3Client({
     region: process.env.STORAGE_REGION || "us-east-1",
+    ...(process.env.STORAGE_ENDPOINT && { endpoint: process.env.STORAGE_ENDPOINT }),
+    ...(process.env.STORAGE_ACCESS_KEY && process.env.STORAGE_SECRET_KEY && {
+      credentials: {
+        accessKeyId: process.env.STORAGE_ACCESS_KEY,
+        secretAccessKey: process.env.STORAGE_SECRET_KEY,
+      },
+    }),
   });
 
   const uploadUrl = await getSignedUrl(

--- a/src/app/api/vault/status/route.ts
+++ b/src/app/api/vault/status/route.ts
@@ -46,6 +46,13 @@ export const GET = withErrorHandler(async (request) => {
     const fullKey = `${prefix}/${job.output_s3_key}`;
     const s3 = new S3Client({
       region: process.env.STORAGE_REGION || "us-east-1",
+      ...(process.env.STORAGE_ENDPOINT && { endpoint: process.env.STORAGE_ENDPOINT }),
+      ...(process.env.STORAGE_ACCESS_KEY && process.env.STORAGE_SECRET_KEY && {
+        credentials: {
+          accessKeyId: process.env.STORAGE_ACCESS_KEY,
+          secretAccessKey: process.env.STORAGE_SECRET_KEY,
+        },
+      }),
     });
 
     downloadUrl = await getSignedUrl(


### PR DESCRIPTION
## Summary
- `S3Client` in `/api/vault/import` and `/api/vault/status` was created without credentials, causing auth failures in local dev (and any env without IAM role)
- Both routes now read `STORAGE_ACCESS_KEY`, `STORAGE_SECRET_KEY`, and `STORAGE_ENDPOINT` from env, matching the pattern used by `StoreS3`

## Test plan
- [ ] Select a `.zip` file in Settings → Data & Export → Import Notes — presigned URL should be returned without 500
- [ ] Export vault — status polling presigned URL should work correctly
- [ ] Verify no regression on production (IAM role still works when env vars are absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)