### PR TITLE
fix(api): restore settings password and notes updates

### DIFF
--- a/src/__tests__/api/auth-change-password.test.js
+++ b/src/__tests__/api/auth-change-password.test.js
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import bcrypt from "bcryptjs";
+
+vi.mock("@/database/pgsql.js", () => {
+  const sqlMock = vi.fn();
+  sqlMock.mockResolvedValue([]);
+  return { default: sqlMock };
+});
+
+vi.mock("bcryptjs", () => ({
+  default: {
+    compare: vi.fn(),
+    hash: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth.js", () => ({
+  validateSession: vi.fn(),
+  createErrorResponse: (message, status = 400, additionalData = {}) =>
+    Response.json(
+      { success: false, error: message, ...additionalData },
+      { status },
+    ),
+  parseJsonBody: vi.fn(async (request) => {
+    try {
+      const data = await request.json();
+      return { data, error: null };
+    } catch {
+      return {
+        data: null,
+        error: Response.json(
+          { success: false, error: "Invalid JSON in request body" },
+          { status: 400 },
+        ),
+      };
+    }
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: {
+    error: vi.fn(),
+  },
+}));
+
+import sql from "@/database/pgsql.js";
+import { validateSession } from "@/lib/auth.js";
+import { POST } from "@/app/api/auth/change-password/route.js";
+
+const MOCK_USER = { user_id: "user-123", email: "test@example.com" };
+
+function makeRequest(body) {
+  return new Request("http://localhost/api/auth/change-password", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(validateSession).mockResolvedValue(MOCK_USER);
+  vi.mocked(sql).mockResolvedValue([]);
+});
+
+describe("POST /api/auth/change-password", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(validateSession).mockResolvedValue(null);
+
+    const response = await POST(
+      makeRequest({ currentPassword: "OldPass123", newPassword: "NewPass123" }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects an incorrect current password", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([{ hashed_password: "stored-hash" }]);
+    vi.mocked(bcrypt.compare).mockResolvedValue(false);
+
+    const response = await POST(
+      makeRequest({
+        currentPassword: "WrongPass123",
+        newPassword: "NewPass123",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Current password is incorrect");
+  });
+
+  it("updates the password when the current password is valid", async () => {
+    vi.mocked(sql)
+      .mockResolvedValueOnce([{ hashed_password: "stored-hash" }])
+      .mockResolvedValueOnce([]);
+    vi.mocked(bcrypt.compare).mockResolvedValue(true);
+    vi.mocked(bcrypt.hash).mockResolvedValue("new-hash");
+
+    const response = await POST(
+      makeRequest({ currentPassword: "OldPass123", newPassword: "NewPass123" }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(bcrypt.hash).toHaveBeenCalledWith("NewPass123", 10);
+    expect(sql).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/api/notes.test.js
+++ b/src/__tests__/api/notes.test.js
@@ -49,6 +49,7 @@ import { GET as notesGET, POST as notesPOST } from "@/app/api/notes/route.js";
 import {
   GET as noteGET,
   PUT as notePUT,
+  PATCH as notePATCH,
   DELETE as noteDELETE,
 } from "@/app/api/notes/[id]/route.js";
 import { validateSession } from "@/lib/auth.js";
@@ -213,6 +214,24 @@ describe("PUT /api/notes/[id]", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.title).toBe("Updated Title");
+  });
+});
+
+describe("PATCH /api/notes/[id]", () => {
+  it("accepts partial note updates through the same handler", async () => {
+    const updatedRow = { ...NOTE_ROW, content: "# Updated" };
+    sql.mockResolvedValueOnce([NOTE_ROW]).mockResolvedValueOnce([updatedRow]);
+
+    const req = makeRequest("PATCH", "http://localhost/api/notes/note-uuid-1", {
+      content: "# Updated",
+    });
+    const res = await notePATCH(req, {
+      params: Promise.resolve({ id: "note-uuid-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.content).toBe("# Updated");
   });
 });
 

--- a/src/app/api/auth/change-password/route.js
+++ b/src/app/api/auth/change-password/route.js
@@ -1,0 +1,80 @@
+import bcrypt from "bcryptjs";
+import sql from "@/database/pgsql.js";
+import {
+  validateSession,
+  createErrorResponse,
+  parseJsonBody,
+} from "@/lib/auth.js";
+import { validatePassword } from "@/lib/validation.js";
+import logger from "@/lib/logger";
+
+export async function POST(request) {
+  try {
+    const user = await validateSession();
+    if (!user) {
+      return createErrorResponse("Unauthorized", 401);
+    }
+
+    const { data: body, error: parseError } = await parseJsonBody(request);
+    if (parseError) return parseError;
+
+    const { currentPassword, newPassword } = body ?? {};
+    if (!currentPassword || !newPassword) {
+      return createErrorResponse(
+        "Current password and new password are required",
+        400,
+      );
+    }
+
+    if (currentPassword === newPassword) {
+      return createErrorResponse(
+        "New password must be different from current password",
+        400,
+      );
+    }
+
+    const passwordValidation = validatePassword(newPassword);
+    if (!passwordValidation.isValid) {
+      return createErrorResponse(passwordValidation.errors.join("; "), 400);
+    }
+
+    const [account] = await sql`
+      SELECT hashed_password
+      FROM app.login
+      WHERE user_id = ${user.user_id}::uuid
+        AND is_active = true
+        AND deleted_at IS NULL
+      LIMIT 1
+    `;
+
+    if (!account?.hashed_password) {
+      return createErrorResponse("Unauthorized", 401);
+    }
+
+    const passwordMatches = await bcrypt.compare(
+      currentPassword,
+      account.hashed_password,
+    );
+    if (!passwordMatches) {
+      return createErrorResponse("Current password is incorrect", 400);
+    }
+
+    const hashedPassword = await bcrypt.hash(newPassword, 10);
+
+    await sql`
+      UPDATE app.login
+      SET hashed_password = ${hashedPassword},
+          reset_token = NULL,
+          reset_token_expires = NULL
+      WHERE user_id = ${user.user_id}::uuid
+    `;
+
+    return Response.json({
+      success: true,
+      message: "Password changed successfully",
+    });
+  } catch (error) {
+    logger.error("change password error", { error });
+    return createErrorResponse("Failed to change password", 500);
+  }
+}

--- a/src/app/api/notes/[id]/route.js
+++ b/src/app/api/notes/[id]/route.js
@@ -164,6 +164,8 @@ export const PUT = withErrorHandler(async (request, { params }) => {
   return NextResponse.json(mapNoteFromDB(dbNote));
 });
 
+export const PATCH = PUT;
+
 export const DELETE = withErrorHandler(async (request, { params }) => {
   // Get authenticated user
   const user = await validateSession();


### PR DESCRIPTION
## Summary
- add the missing `/api/auth/change-password` route used by the settings page and cover it with API tests
- accept `PATCH` on `/api/notes/[id]` so inspector tag edits match the backend contract
- extend notes API coverage for the restored partial update path