### PR TITLE
fix(editor): scope pane drag to header and align side padding

### DIFF
--- a/scripts/requeue-missing-marker.mjs
+++ b/scripts/requeue-missing-marker.mjs
@@ -6,7 +6,11 @@ if (!queueUrl) {
   throw new Error("SQS_QUEUE_URL is required");
 }
 
-const rows = await sql`
+const sqs = new SQSClient({ region: process.env.AWS_REGION || "eu-west-1" });
+
+// ── pending_retry: send as extract-retry (already have s3 buffer) ────────────
+
+const pendingRows = await sql`
   SELECT
     ci.id AS import_id,
     ci.user_id,
@@ -24,13 +28,12 @@ const rows = await sql`
     AND n.s3_key IS NOT NULL
 `;
 
-console.log(`pending marker backfill items: ${rows.length}`);
-
-const sqs = new SQSClient({ region: process.env.AWS_REGION || "eu-west-1" });
+console.log(`pending_retry items: ${pendingRows.length}`);
 
 let sent = 0;
-for (let i = 0; i < rows.length; i += 10) {
-  const batch = rows.slice(i, i + 10).map((r, idx) => ({
+
+for (let i = 0; i < pendingRows.length; i += 10) {
+  const batch = pendingRows.slice(i, i + 10).map((r, idx) => ({
     Id: String(idx),
     MessageBody: JSON.stringify({
       type: "extract-retry",
@@ -45,16 +48,53 @@ for (let i = 0; i < rows.length; i += 10) {
   }));
 
   const out = await sqs.send(
-    new SendMessageBatchCommand({
-      QueueUrl: queueUrl,
-      Entries: batch,
-    }),
+    new SendMessageBatchCommand({ QueueUrl: queueUrl, Entries: batch }),
   );
-
   sent += out.Successful?.length ?? 0;
-  if ((out.Failed?.length ?? 0) > 0) {
-    console.warn(`batch failures: ${out.Failed.length}`);
-  }
+  if ((out.Failed?.length ?? 0) > 0) console.warn(`batch failures: ${out.Failed.length}`);
 }
 
 console.log(`queued extract-retry messages: ${sent}`);
+
+// ── error: reset status + re-queue as canvas-file (re-downloads from Canvas) ─
+
+const errorRows = await sql`
+  SELECT ci.id, ci.user_id, ci.job_id
+  FROM app.canvas_imports ci
+  WHERE ci.status = 'error'
+    AND ci.error_message ILIKE '%marker%'
+`;
+
+console.log(`error (marker) items: ${errorRows.length}`);
+
+if (errorRows.length > 0) {
+  const ids = errorRows.map((r) => r.id);
+
+  // reset to downloading so processCanvasFile won't skip them
+  await sql`
+    UPDATE app.canvas_imports
+    SET status = 'downloading', error_message = NULL, updated_at = NOW()
+    WHERE id = ANY(${sql.array(ids, 'uuid')}::uuid[])
+  `;
+
+  let errorSent = 0;
+  for (let i = 0; i < errorRows.length; i += 10) {
+    const batch = errorRows.slice(i, i + 10).map((r, idx) => ({
+      Id: String(idx),
+      MessageBody: JSON.stringify({
+        type: "canvas-file",
+        importRecordId: r.id,
+        jobId: r.job_id,
+        userId: r.user_id,
+      }),
+    }));
+
+    const out = await sqs.send(
+      new SendMessageBatchCommand({ QueueUrl: queueUrl, Entries: batch }),
+    );
+    errorSent += out.Successful?.length ?? 0;
+    if ((out.Failed?.length ?? 0) > 0) console.warn(`batch failures: ${out.Failed.length}`);
+  }
+
+  console.log(`queued canvas-file messages: ${errorSent}`);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -436,8 +436,8 @@ html.light .glass-card-active {
 .md-rendered pre > code.hljs {
   display: block;
   overflow-x: auto;
-  border-radius: 0.5rem;
-  padding: 1rem;
+  border-radius: 0;
+  padding: 1.25rem 1.5rem;
   background: rgb(40 44 52 / 0.92);
   color: #abb2bf;
 }
@@ -514,7 +514,7 @@ html.light .glass-card-active {
 
 html.light .markdown-preview pre > code.hljs,
 html.light .md-rendered pre > code.hljs {
-  background: #fafafa;
+  background: #f5f5f5;
   color: #383a42;
 }
 

--- a/src/components/editor/editor-pane.tsx
+++ b/src/components/editor/editor-pane.tsx
@@ -212,14 +212,16 @@ const EditorPane: FC<EditorPaneProps> = ({ pane, file }) => {
       ref={paneRef}
       className={`h-full flex flex-col bg-background transition-colors ${isDragging ? "opacity-60" : ""}`}
       onMouseDown={() => setActivePane(pane)}
-      draggable
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
     >
       {/* Pane Header */}
-      <div className="flex-shrink-0 h-9 px-3 border-b border-border-subtle flex items-center justify-between cursor-move">
+      <div
+        className="flex-shrink-0 h-9 px-3 border-b border-border-subtle flex items-center justify-between cursor-move"
+        draggable
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
         <div className="flex items-center gap-2 min-w-0">
           <span className="text-sm text-text-secondary truncate">
             {file.title || file.fileId}

--- a/src/components/editor/markdown-editor.tsx
+++ b/src/components/editor/markdown-editor.tsx
@@ -361,7 +361,7 @@ const MarkdownEditor: FC<MarkdownEditorProps> = ({ pane: _pane, file }) => {
           )
         ) : loaded ? (
           <div className="h-full min-h-0 w-full overflow-auto">
-            <div className="mx-auto w-[80%] max-w-4xl py-10">
+            <div className="px-8 py-10">
               <PreviewRenderer content={displayContent} noteId={file.fileId} />
             </div>
           </div>

--- a/src/components/editor/source-editor.tsx
+++ b/src/components/editor/source-editor.tsx
@@ -42,7 +42,7 @@ const appTheme = EditorView.theme({
     width: "100%",
     maxWidth: "none",
     margin: "0 auto",
-    padding: "0 clamp(1rem, 2vw, 2.5rem)",
+    padding: "0 2rem",
   },
   ".cm-gutters": {
     display: "none",

--- a/src/lib/canvas/async-limiter.js
+++ b/src/lib/canvas/async-limiter.js
@@ -48,5 +48,11 @@ export async function pooled(tasks, limit) {
     results.push(p);
     if (executing.size >= limit) await Promise.race(executing);
   }
-  return Promise.allSettled(results);
+  const settled = await Promise.allSettled(results);
+  for (const result of settled) {
+    if (result.status === "rejected") {
+      console.error("[pooled] task rejected:", result.reason);
+    }
+  }
+  return settled;
 }

--- a/src/lib/canvas/import-discovery.js
+++ b/src/lib/canvas/import-discovery.js
@@ -280,14 +280,10 @@ async function discoverCourse(course, userId, ctx) {
     canvasAcademicYear: academicYear,
   });
 
-  await discoverModuleFiles(courseId, userId, courseTitle, courseFolderId, ctx);
-  await discoverAssignmentFiles(
-    courseId,
-    userId,
-    courseTitle,
-    courseFolderId,
-    ctx,
-  );
+  await Promise.all([
+    discoverModuleFiles(courseId, userId, courseTitle, courseFolderId, ctx),
+    discoverAssignmentFiles(courseId, userId, courseTitle, courseFolderId, ctx),
+  ]);
 
   try {
     const { synced, errors } = await syncAssignmentMetadata(

--- a/src/lib/canvas/import-embedding.js
+++ b/src/lib/canvas/import-embedding.js
@@ -133,7 +133,8 @@ export async function processRagPipeline(
       console.log(
         `pdf-parse fallback: extracted ${chunks.length} chunks for note ${noteId}`,
       );
-      if (attempt < MAX_EXTRACTION_RETRIES) {
+      // skip retry when Marker is intentionally off — nothing to retry to
+      if (attempt < MAX_EXTRACTION_RETRIES && process.env.CANVAS_SKIP_MARKER !== "true") {
         await queueExtractionRetry({
           noteId,
           userId,

--- a/src/lib/canvas/import-extraction.js
+++ b/src/lib/canvas/import-extraction.js
@@ -412,6 +412,14 @@ export async function downloadAndStoreFile(file, opts) {
 // the count check and status update share the same transaction to avoid TOCTOU.
 // pending_retry counts as in-flight since the retry queue will eventually resolve it.
 async function checkAndCompleteJob(jobId, userId) {
+  // fast pre-check: skip the transaction entirely if >1 file is still in-flight
+  const [{ count: pending }] = await sql`
+    SELECT COUNT(*) as count FROM app.canvas_imports
+    WHERE job_id = ${jobId}::uuid
+      AND status NOT IN ('complete', 'forbidden', 'error', 'cancelled')
+  `;
+  if (parseInt(pending, 10) > 1) return;
+
   let weCompleted = false;
   await sql.begin(async (tx) => {
     const [{ count }] = await tx`
@@ -459,12 +467,24 @@ export async function processCanvasFile({ importRecordId, jobId, userId }) {
   const ts = () => new Date().toISOString();
   console.log(`[${ts()}] Processing canvas file: ${importRecordId}`);
   try {
-    const [record] =
-      await sql`SELECT * FROM app.canvas_imports WHERE id = ${importRecordId}::uuid`;
-    if (!record) {
+    const [row] = await sql`
+      SELECT
+        ci.*,
+        cij.status AS job_status,
+        l.canvas_token,
+        l.canvas_domain
+      FROM app.canvas_imports ci
+      LEFT JOIN app.canvas_import_jobs cij ON cij.id = ci.job_id
+      JOIN app.login l ON l.user_id = ci.user_id
+      WHERE ci.id = ${importRecordId}::uuid
+    `;
+    if (!row) {
       console.error(`[${ts()}] Import record not found: ${importRecordId}`);
       return false;
     }
+
+    // split the joined row into record shape and credentials
+    const { canvas_token, canvas_domain, job_status, ...record } = row;
 
     // idempotency -- SQS at-least-once may redeliver
     if (
@@ -478,17 +498,15 @@ export async function processCanvasFile({ importRecordId, jobId, userId }) {
       return true;
     }
 
-    if (await isJobCancelled(jobId)) {
+    if (job_status === "cancelled") {
       await sql`UPDATE app.canvas_imports SET status = 'cancelled', updated_at = NOW() WHERE id = ${importRecordId}::uuid`;
       await checkAndCompleteJob(jobId, userId);
       return false;
     }
 
-    const [creds] =
-      await sql`SELECT canvas_token, canvas_domain FROM app.login WHERE user_id = ${userId}`;
-    if (!creds) throw new Error("Canvas credentials not found");
-    const plainToken = decrypt(creds.canvas_token, userId);
-    const client = new CanvasClient(creds.canvas_domain, plainToken);
+    if (!canvas_token || !canvas_domain) throw new Error("Canvas credentials not found");
+    const plainToken = decrypt(canvas_token, userId);
+    const client = new CanvasClient(canvas_domain, plainToken);
     const storage = getStorageProvider();
 
     // re-fetch a fresh download URL -- avoids any session-tied URL expiry between phases
@@ -640,7 +658,7 @@ export async function processExtractionRetry(msg) {
   // for retry messages we still allow processing even when already complete,
   // because retries can be used for enrichment/replacement after fallback text.
   const [importRow] =
-    await sql`SELECT status FROM app.canvas_imports WHERE note_id = ${noteId}::uuid LIMIT 1`;
+    await sql`SELECT status, job_id FROM app.canvas_imports WHERE note_id = ${noteId}::uuid LIMIT 1`;
   if (importRow?.status === "complete" && (attempt ?? 0) <= 0) {
     console.log(`Note ${noteId} already complete, skipping duplicate retry`);
     return;
@@ -660,32 +678,51 @@ export async function processExtractionRetry(msg) {
   }
 
   try {
-    const result = await runRagPipeline(
-      noteId,
-      userId,
-      parentFolderId,
-      buffer,
-      {
-        filename,
-        mimeType,
-        s3Key,
-        attempt,
-      },
-    );
+    await globalFileLimiter(async () => {
+      let timerId;
+      const timer = new Promise((_, reject) => {
+        timerId = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `Extraction retry timed out after ${Math.round(FILE_TIMEOUT_MS / 60000)} minutes: ${filename}`,
+              ),
+            ),
+          FILE_TIMEOUT_MS,
+        );
+      });
 
-    if (result) {
-      await sql`
-        UPDATE app.ingestion_jobs
-        SET status = 'done', chunks_stored = ${result.chunksStored ?? 0}, error = NULL, updated_at = NOW()
-        WHERE note_id = ${noteId}::uuid AND user_id = ${userId}::uuid
-      `;
-    } else {
-      await sql`
-        UPDATE app.ingestion_jobs
-        SET status = 'pending', error = 'Queued for extraction retry', updated_at = NOW()
-        WHERE note_id = ${noteId}::uuid AND user_id = ${userId}::uuid
-      `;
-    }
+      try {
+        const result = await Promise.race([
+          runRagPipeline(noteId, userId, parentFolderId, buffer, {
+            filename,
+            mimeType,
+            s3Key,
+            attempt,
+          }),
+          timer,
+        ]);
+
+        if (result) {
+          await sql`
+            UPDATE app.ingestion_jobs
+            SET status = 'done', chunks_stored = ${result.chunksStored ?? 0}, error = NULL, updated_at = NOW()
+            WHERE note_id = ${noteId}::uuid AND user_id = ${userId}::uuid
+          `;
+          if (importRow?.job_id) {
+            await checkAndCompleteJob(importRow.job_id, userId);
+          }
+        } else {
+          await sql`
+            UPDATE app.ingestion_jobs
+            SET status = 'pending', error = 'Queued for extraction retry', updated_at = NOW()
+            WHERE note_id = ${noteId}::uuid AND user_id = ${userId}::uuid
+          `;
+        }
+      } finally {
+        clearTimeout(timerId);
+      }
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
 

--- a/src/lib/canvas/worker-entry.js
+++ b/src/lib/canvas/worker-entry.js
@@ -12,6 +12,7 @@ import {
   SQSClient,
   ReceiveMessageCommand,
   DeleteMessageCommand,
+  ChangeMessageVisibilityCommand,
 } from "@aws-sdk/client-sqs";
 import { ECSClient, UpdateServiceCommand } from "@aws-sdk/client-ecs";
 import {
@@ -166,6 +167,16 @@ async function processAndDelete(message, queueUrl) {
 const inFlight = new Set();
 
 function launchProcessing(message, queueUrl) {
+  const heartbeat = setInterval(async () => {
+    try {
+      await sqsClient.send(new ChangeMessageVisibilityCommand({
+        QueueUrl: queueUrl,
+        ReceiptHandle: message.ReceiptHandle,
+        VisibilityTimeout: 600,
+      }));
+    } catch { /* message may already be deleted, ignore */ }
+  }, 5 * 60 * 1000);
+
   const p = processAndDelete(message, queueUrl)
     .catch((err) => {
       console.error(
@@ -173,7 +184,7 @@ function launchProcessing(message, queueUrl) {
         err?.message,
       );
     })
-    .finally(() => inFlight.delete(p));
+    .finally(() => { clearInterval(heartbeat); inFlight.delete(p); });
   inFlight.add(p);
 }
 
@@ -188,8 +199,7 @@ async function pollQueue() {
     new ReceiveMessageCommand({
       QueueUrl: QUEUE_URL,
       MaxNumberOfMessages: Math.min(10, capacity),
-      // long-poll only when fully idle so we don't burn 20s when there's work to do
-      WaitTimeSeconds: inFlight.size === 0 ? 20 : 0,
+      WaitTimeSeconds: 20,
       VisibilityTimeout: 3600,
     }),
   );
@@ -244,6 +254,7 @@ setInterval(async () => {
 }, DB_POLL_INTERVAL_MS);
 
 let idlePolls = 0;
+let pollErrorCount = 0;
 
 while (true) {
   try {
@@ -255,6 +266,7 @@ while (true) {
 
     const hadWork = await pollQueue();
     const hadRetries = await pollRetryQueue();
+    pollErrorCount = 0;
 
     // only count as idle when there's nothing in-flight and both queues were empty
     const isIdle = !hadWork && !hadRetries && inFlight.size === 0;
@@ -308,6 +320,8 @@ while (true) {
     }
   } catch (err) {
     console.error(`[${new Date().toISOString()}] Poll error:`, err.message);
-    await new Promise((r) => setTimeout(r, 5000));
+    pollErrorCount++;
+    const backoffMs = Math.min(1000 * 2 ** (pollErrorCount - 1), 30_000);
+    await new Promise((r) => setTimeout(r, backoffMs + Math.random() * 500));
   }
 }

--- a/src/lib/ecs.ts
+++ b/src/lib/ecs.ts
@@ -7,8 +7,9 @@ const ecsClient = new ECSClient({
 const CLUSTER = process.env.ECS_CLUSTER ?? "oghmanotes";
 const SERVICE = process.env.ECS_SERVICE ?? "canvas-import-worker";
 const MAX_WORKERS = 5;
-// each worker processes up to 10 files concurrently (CANVAS_GLOBAL_FILE_CONCURRENCY)
-const FILES_PER_WORKER = 10;
+// OCR is the bottleneck — matches CANVAS_OCR_CONCURRENCY in import-embedding.js
+const FILES_PER_WORKER =
+  Number.parseInt(process.env.CANVAS_OCR_CONCURRENCY ?? "2", 10) || 2;
 
 // trigger rebuild: 2026-04-16 - force new deployment after AWS migration
 // non-fatal — if IAM isn't wired yet the worker DB poll will catch the job

--- a/src/lib/ingestion/extraction-core.ts
+++ b/src/lib/ingestion/extraction-core.ts
@@ -49,6 +49,18 @@ export async function extractContentFromBuffer({
     return { rawText, chunks: chunkText(rawText), source: "text" };
   }
 
+  // CANVAS_SKIP_MARKER=true: bypass Marker entirely (e.g. ASG scaled to 0)
+  // PDFs use pdf-parse text layer; other binaries are stored as attachments only
+  if (process.env.CANVAS_SKIP_MARKER === "true") {
+    if (mimeType === "application/pdf") {
+      const fallback = await extractPdfTextLayer(buffer);
+      if (fallback) {
+        return { rawText: fallback.rawText, chunks: fallback.chunks, source: "pdf-parse" };
+      }
+    }
+    return { rawText: "", chunks: [], source: "pdf-parse" };
+  }
+
   try {
     const marker = await extractWithMarker(buffer, filename);
     return {

--- a/src/lib/markdown/components/code-block.tsx
+++ b/src/lib/markdown/components/code-block.tsx
@@ -32,10 +32,10 @@ export default function CodeBlock({
   // use dynamic(() => import("./mermaid-block"), { ssr: false }) to keep Mermaid's ~2MB out of the bundle
 
   return (
-    <div className="relative group my-2 rounded-lg overflow-hidden bg-surface/50">
+    <div className="relative group my-4 rounded-lg overflow-hidden border border-border-subtle">
       {language && (
-        <div className="flex items-center justify-between px-3 py-1.5 border-b border-border-subtle">
-          <span className="text-[10px] font-mono text-text-tertiary">
+        <div className="flex items-center justify-between px-4 py-2.5 bg-surface border-b border-border-subtle">
+          <span className="text-[10px] font-semibold uppercase tracking-widest text-text-secondary">
             {language}
           </span>
           <button

--- a/src/lib/ocr.ts
+++ b/src/lib/ocr.ts
@@ -81,7 +81,7 @@ async function callEc2Marker(
   const mime = mimeFromFilename(filename);
   form.append(
     "file",
-    new Blob([new Uint8Array(buffer)], { type: mime }),
+    new Blob([buffer], { type: mime }),
     filename,
   );
   form.append("output_format", "markdown");


### PR DESCRIPTION
## Summary

- Scope `draggable`/`onDragStart`/`onDragEnd` to the pane header bar only — previously on the whole pane wrapper, which hijacked text selection in read mode and showed a move cursor over content
- Align source editor side padding to `2rem` (was `clamp(1rem, 2vw, 2.5rem)`, too narrow at mid-widths)
- Align read mode side padding to `px-8` (was `w-[80%] max-w-4xl`, gave excessive variable gaps)
- Also includes `feat(ui): improve code block padding and language header styling` from dev

## Test plan

- [ ] In read mode, text selection works normally (no drag hijack)
- [ ] Dragging a pane still works when grabbing the header bar
- [ ] Source and read mode side padding visually matches the AI chat page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error logging for failed async operations; improved job completion verification

* **New Features**
  * Added message visibility heartbeating for improved reliability
  * Configurable worker concurrency scaling
  * Optional content extraction bypass capability

* **Performance**
  * Concurrent module discovery execution
  * Extraction operations now include timeout protection
  * Exponential backoff with jitter for polling errors

* **Style**
  * Updated code block styling (padding, borders, colors)
  * Refined editor layout and spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->