### PR TITLE
feat(canvas): async Marker pipeline with 5s fast-path and full binary support

### DIFF
--- a/src/lib/canvas/import-embedding.js
+++ b/src/lib/canvas/import-embedding.js
@@ -19,6 +19,9 @@ import { persistMarkerAssetsForNote } from "../marker-output.ts";
 import { createAsyncLimiter } from "./async-limiter.js";
 import { parseEnvConcurrency } from "./import-metrics.js";
 import logger from "../logger.ts";
+import { sqsClient, getMarkerQueueUrl, getCanvasImportQueueUrl } from "../sqs";
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import { ensureMarkerRunning } from "../marker-ec2.ts";
 
 // ── Concurrency limiters ────────────────────────────────────────────────────
 
@@ -91,10 +94,11 @@ export async function processRagPipeline(
     canvasCourseId = null,
     canvasModuleId = null,
     canvasAssignmentId = null,
+    extractionOverride = null,
   } = ragOpts;
   try {
     const extractionStart = Date.now();
-    const extraction = await ocrLimiter(() =>
+    const extraction = extractionOverride ?? await ocrLimiter(() =>
       extractContentFromBuffer({
         buffer,
         filename: filename ?? "document.pdf",
@@ -111,6 +115,38 @@ export async function processRagPipeline(
       markerMetadata = null,
     } = extraction;
     const isText = source === "text";
+
+    // pending-marker: Marker timed out on fast-path — queued to Marker SQS by caller
+    // skipped: non-PDF binary with no Marker and no text fallback — stored as attachment only
+    if (source === "pending-marker") {
+      const markerQueueUrl = getMarkerQueueUrl();
+      if (markerQueueUrl && s3Key) {
+        await sqsClient.send(new SendMessageCommand({
+          QueueUrl: markerQueueUrl,
+          MessageBody: JSON.stringify({
+            noteId,
+            userId,
+            jobId: jobId ?? null,
+            s3Key,
+            filename: filename ?? "document",
+            mimeType: mimeType ?? "application/octet-stream",
+            parentFolderId: parentFolderId ?? null,
+            callbackQueueUrl: getCanvasImportQueueUrl(),
+            resultS3Prefix: "marker-results/",
+          }),
+        }));
+        ensureMarkerRunning().catch(() => {}); // fire-and-forget ASG scale-up
+      }
+      await sql`
+        UPDATE app.canvas_imports
+        SET status = 'pending_marker', updated_at = NOW()
+        WHERE note_id = ${noteId}::uuid
+      `;
+      return null;
+    }
+    if (source === "skipped") {
+      return null;
+    }
 
     logger.info("canvas-import-file-extracted", {
       jobId,
@@ -134,7 +170,7 @@ export async function processRagPipeline(
         `pdf-parse fallback: extracted ${chunks.length} chunks for note ${noteId}`,
       );
       // skip retry when Marker is intentionally off — nothing to retry to
-      if (attempt < MAX_EXTRACTION_RETRIES && process.env.CANVAS_SKIP_MARKER !== "true") {
+      if (attempt < MAX_EXTRACTION_RETRIES && process.env.CANVAS_SKIP_MARKER !== "true" && source !== "skipped") {
         await queueExtractionRetry({
           noteId,
           userId,

--- a/src/lib/canvas/import-extraction.js
+++ b/src/lib/canvas/import-extraction.js
@@ -488,7 +488,7 @@ export async function processCanvasFile({ importRecordId, jobId, userId }) {
 
     // idempotency -- SQS at-least-once may redeliver
     if (
-      ["complete", "forbidden", "error", "cancelled", "pending_retry"].includes(
+      ["complete", "forbidden", "error", "cancelled", "pending_retry", "pending_marker"].includes(
         record.status,
       )
     ) {
@@ -741,5 +741,78 @@ export async function processExtractionRetry(msg) {
     console.error(
       `[${new Date().toISOString()}] Extraction retry failed for note ${noteId}: ${message}`,
     );
+  }
+}
+
+// ── Marker-complete handler ──────────────────────────────────────────────────
+
+export async function processMarkerComplete(msg) {
+  const { noteId, userId, jobId, filename, mimeType, parentFolderId, resultKey } = msg;
+  const ts = () => new Date().toISOString();
+  console.log(`[${ts()}] processMarkerComplete: note ${noteId}`);
+
+  const [importRow] = await sql`
+    SELECT status, job_id FROM app.canvas_imports WHERE note_id = ${noteId}::uuid LIMIT 1
+  `;
+  if (!importRow || importRow.status === "complete") {
+    console.log(`[${ts()}] Note ${noteId} already complete or missing, skipping marker-complete`);
+    return;
+  }
+
+  const storage = getStorageProvider();
+  const resultBuffer = await storage.getObject(resultKey);
+  if (!resultBuffer) {
+    await sql`UPDATE app.canvas_imports SET status = 'error', error_message = 'Marker result missing from S3', updated_at = NOW() WHERE note_id = ${noteId}::uuid`;
+    return;
+  }
+
+  let markerOutput;
+  try {
+    markerOutput = JSON.parse(resultBuffer.toString());
+  } catch {
+    await sql`UPDATE app.canvas_imports SET status = 'error', error_message = 'Marker result JSON parse failed', updated_at = NOW() WHERE note_id = ${noteId}::uuid`;
+    return;
+  }
+
+  const { output: rawMarkdown = "", images = {}, metadata = null } = markerOutput;
+
+  const { normalizeMarkerMarkdown } = await import("../marker-output.ts");
+  const { splitMarkdownToChunks } = await import("../ocr.ts");
+
+  const normalizedText = normalizeMarkerMarkdown(rawMarkdown);
+  const chunks = splitMarkdownToChunks(normalizedText);
+
+  try {
+    const result = await processRagPipeline(
+      noteId,
+      userId,
+      parentFolderId ?? null,
+      null,
+      {
+        filename: filename ?? "document",
+        mimeType: mimeType ?? "application/octet-stream",
+        s3Key: null,
+        attempt: 0,
+        jobId: jobId ?? importRow.job_id,
+        extractionOverride: {
+          rawText: normalizedText,
+          chunks,
+          source: "marker",
+          markerImages: images,
+          markerMetadata: metadata,
+        },
+      },
+      findOrCreateNote,
+    );
+
+    if (result) {
+      await sql`UPDATE app.canvas_imports SET status = 'complete', updated_at = NOW() WHERE note_id = ${noteId}::uuid`;
+      const effectiveJobId = jobId ?? importRow.job_id;
+      if (effectiveJobId) await checkAndCompleteJob(effectiveJobId, userId);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[${ts()}] processMarkerComplete failed for note ${noteId}: ${message}`);
+    await sql`UPDATE app.canvas_imports SET status = 'error', error_message = ${message}, updated_at = NOW() WHERE note_id = ${noteId}::uuid`;
   }
 }

--- a/src/lib/canvas/import-worker.js
+++ b/src/lib/canvas/import-worker.js
@@ -115,4 +115,4 @@ export async function processImportJob(jobId) {
 // ── Re-exports for worker-entry.js ──────────────────────────────────────────
 
 export { processDiscoverJob } from "./import-discovery.js";
-export { processCanvasFile, processDirectExtraction, processExtractionRetry } from "./import-extraction.js";
+export { processCanvasFile, processDirectExtraction, processExtractionRetry, processMarkerComplete } from "./import-extraction.js";

--- a/src/lib/canvas/worker-entry.js
+++ b/src/lib/canvas/worker-entry.js
@@ -21,6 +21,7 @@ import {
   processCanvasFile,
   processExtractionRetry,
   processDirectExtraction,
+  processMarkerComplete,
 } from "./import-worker.js";
 import { processVaultImport } from "../vault/import-worker.js";
 import { processVaultExport } from "../vault/export-worker.js";
@@ -142,6 +143,9 @@ async function processAndDelete(message, queueUrl) {
       break;
     case "extract-retry":
       await processExtractionRetry(body);
+      break;
+    case "marker-complete":
+      await processMarkerComplete(body);
       break;
     case "vault-export":
       await processVaultExport(body);

--- a/src/lib/ingestion/extraction-core.ts
+++ b/src/lib/ingestion/extraction-core.ts
@@ -1,8 +1,8 @@
 import { chunkText } from "@/lib/chunking";
-import { extractWithMarker } from "@/lib/ocr";
+import { extractWithMarker, MarkerPendingError } from "@/lib/ocr";
 import type { MarkerImages } from "@/lib/marker-output";
 
-export type ExtractionSource = "text" | "marker" | "pdf-parse";
+export type ExtractionSource = "text" | "marker" | "pdf-parse" | "pending-marker" | "skipped";
 
 export interface ExtractionResult {
   rawText: string;
@@ -62,7 +62,7 @@ export async function extractContentFromBuffer({
   }
 
   try {
-    const marker = await extractWithMarker(buffer, filename);
+    const marker = await extractWithMarker(buffer, filename, { fastPath: true });
     return {
       rawText: marker.text,
       chunks: marker.chunks,
@@ -70,18 +70,17 @@ export async function extractContentFromBuffer({
       markerImages: marker.images ?? {},
       markerMetadata: marker.metadata ?? null,
     };
-  } catch (markerError) {
-    // Keep fallback scoped to PDFs (text-layer only, not OCR).
+  } catch (err) {
+    if (err instanceof MarkerPendingError) {
+      return { rawText: "", chunks: [], source: "pending-marker" };
+    }
+    // hard error — pdf-parse fallback for PDFs, skipped for other binaries
     if (mimeType === "application/pdf") {
       const fallback = await extractPdfTextLayer(buffer);
       if (fallback) {
-        return {
-          rawText: fallback.rawText,
-          chunks: fallback.chunks,
-          source: "pdf-parse",
-        };
+        return { rawText: fallback.rawText, chunks: fallback.chunks, source: "pdf-parse" };
       }
     }
-    throw markerError;
+    return { rawText: "", chunks: [], source: "skipped" };
   }
 }

--- a/src/lib/ocr.ts
+++ b/src/lib/ocr.ts
@@ -2,10 +2,15 @@
 // Marker API: synchronous POST /marker/upload
 
 import { ensureMarkerRunning } from "./marker-ec2";
-import {
-  normalizeMarkerMarkdown,
-} from "./marker-output";
+import { normalizeMarkerMarkdown } from "./marker-output";
 import type { MarkerImages } from "./marker-output";
+
+export class MarkerPendingError extends Error {
+  constructor() {
+    super("Marker did not respond within fast-path timeout");
+    this.name = "MarkerPendingError";
+  }
+}
 
 export interface MarkerResult {
   text: string;
@@ -24,6 +29,8 @@ const TOTAL_TIMEOUT_MS = parsePositiveIntEnv(
   "MARKER_REQUEST_TIMEOUT_MS",
   600_000,
 );
+
+const MARKER_FAST_PATH_MS = parsePositiveIntEnv("MARKER_FAST_PATH_MS", 5_000);
 
 const MIME_MAP: Record<string, string> = {
   pdf: "application/pdf",
@@ -44,6 +51,7 @@ function mimeFromFilename(filename: string): string {
 export async function extractWithMarker(
   buffer: Buffer,
   filename: string,
+  options: { fastPath?: boolean } = {},
 ): Promise<MarkerResult> {
   const hasAsgConfig = Boolean(process.env.MARKER_ASG_NAME);
   const hasInstanceConfig = Boolean(process.env.MARKER_EC2_INSTANCE_ID);
@@ -52,6 +60,22 @@ export async function extractWithMarker(
     throw new Error(
       "Marker is not configured (set MARKER_ASG_NAME or MARKER_EC2_INSTANCE_ID)",
     );
+  }
+
+  if (options.fastPath) {
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new MarkerPendingError()), MARKER_FAST_PATH_MS),
+    );
+    const markerUrl = await Promise.race([
+      ensureMarkerRunning(),
+      timeoutPromise,
+    ]);
+    const result = await Promise.race([
+      callEc2Marker(`${markerUrl}/marker/upload`, buffer, filename),
+      timeoutPromise,
+    ]);
+    if (!result) throw new Error("Marker returned no result");
+    return { ...result, source: "ec2" };
   }
 
   const markerUrl = await ensureMarkerRunning();
@@ -79,11 +103,9 @@ async function callEc2Marker(
 } | null> {
   const form = new FormData();
   const mime = mimeFromFilename(filename);
-  form.append(
-    "file",
-    new Blob([buffer], { type: mime }),
-    filename,
-  );
+  const fileBytes = new Uint8Array(buffer.length);
+  fileBytes.set(buffer);
+  form.append("file", new Blob([fileBytes], { type: mime }), filename);
   form.append("output_format", "markdown");
   form.append("paginate_output", "false");
 
@@ -115,16 +137,17 @@ async function callEc2Marker(
         ? (json.images as MarkerImages)
         : {};
     const metadata =
-      json.metadata && typeof json.metadata === "object"
-        ? json.metadata
-        : null;
+      json.metadata && typeof json.metadata === "object" ? json.metadata : null;
     return { text, chunks, images, metadata };
   } finally {
     clearTimeout(timeout);
   }
 }
 
-function splitMarkdownToChunks(markdown: string, targetSize = 500): string[] {
+export function splitMarkdownToChunks(
+  markdown: string,
+  targetSize = 500,
+): string[] {
   if (!markdown?.trim()) return [];
 
   const pages = markdown.split(/\n-{3,}\n/);

--- a/src/lib/sqs.ts
+++ b/src/lib/sqs.ts
@@ -15,5 +15,9 @@ export function getExtractRetryQueueUrl(): string {
   return process.env.SQS_EXTRACT_RETRY_QUEUE_URL ?? "";
 }
 
+export function getMarkerQueueUrl(): string {
+  return process.env.SQS_MARKER_QUEUE_URL ?? "";
+}
+
 // removed stale module-level exports — they bake in "" during next build
 // because env vars are unset at build time. use the getter functions above.


### PR DESCRIPTION
## Summary

- All binary files (PDF, DOCX, PPTX, DOC, PPT) now go through Marker — previously only PDFs were sent; DOCX/PPTX either failed hard or returned empty
- **5s fast-path**: if Marker responds within `MARKER_FAST_PATH_MS` (default 5s), extraction and embedding run inline as before. On timeout, a `marker-job` is queued to `SQS_MARKER_QUEUE_URL` and the worker moves on immediately — no blocking
- **Async completion**: Marker server processes from SQS, writes `{ output, images, metadata }` to S3 at `marker-results/{noteId}.json`, sends a `marker-complete` message back to the main queue. `processMarkerComplete` picks this up, runs the full embedding pipeline via `extractionOverride`, and calls `checkAndCompleteJob`
- `pending_marker` status added to the idempotency skip list so SQS redeliveries don't reprocess queued files
- Hard Marker errors on non-PDF binaries return `source=skipped` (file stored as attachment, no embeddings) instead of erroring the import
- `pdf-parse` remains the fallback for PDFs on hard Marker error only

## New env vars

| Var | Default | Purpose |
|-----|---------|---------|
| `SQS_MARKER_QUEUE_URL` | — | Queue Marker pulls jobs from |
| `MARKER_FAST_PATH_MS` | `5000` | Inline timeout before queuing async |

## Marker server contract

`marker-job` message sent to `SQS_MARKER_QUEUE_URL`:
```json
{ "noteId", "userId", "jobId", "s3Key", "filename", "mimeType", "parentFolderId", "callbackQueueUrl", "resultS3Prefix" }
```

`marker-complete` message Marker sends back to `callbackQueueUrl`:
```json
{ "type": "marker-complete", "noteId", "userId", "jobId", "filename", "mimeType", "parentFolderId", "resultKey" }
```
where `resultKey` → S3 JSON: `{ "output": "<markdown>", "images": {}, "metadata": {} }`

## Test plan

- [ ] Import a PDF with Marker warm — should embed inline (source=marker in logs)
- [ ] Import a PDF with Marker cold (ASG=0) — should fall back to pdf-parse after 5s, queue extract-retry
- [ ] Import a DOCX/PPTX with Marker cold — should show `pending_marker` status, worker moves on
- [ ] Simulate `marker-complete` message — should embed and mark complete
- [ ] Import a DOCX with Marker hard-erroring — should show `skipped`, file stored as attachment
- [ ] Verify `CANVAS_SKIP_MARKER=true` still bypasses all Marker paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)