### PR TITLE
feat(calendar): AI calendar integration fixes

### DIFF
--- a/src/components/calendar/month-view.tsx
+++ b/src/components/calendar/month-view.tsx
@@ -118,6 +118,20 @@ export default function MonthView() {
     fetchTimeBlocks(start, end);
   }, [anchor, fetchTimeBlocks]);
 
+  // refresh when AI creates/completes a time block
+  useEffect(() => {
+    const refresh = () => {
+      const year = anchor.getFullYear();
+      const month = anchor.getMonth();
+      fetchTimeBlocks(
+        new Date(year, month - 1, 20).toISOString(),
+        new Date(year, month + 2, 10).toISOString(),
+      );
+    };
+    window.addEventListener("oghma:time-block-changed", refresh);
+    return () => window.removeEventListener("oghma:time-block-changed", refresh);
+  }, [anchor, fetchTimeBlocks]);
+
   // fetch quiz review dates for streak badges
   useEffect(() => {
     const year = anchor.getFullYear();

--- a/src/components/calendar/week-view.tsx
+++ b/src/components/calendar/week-view.tsx
@@ -82,6 +82,18 @@ export default function WeekView() {
     fetchTimeBlocks(start, end);
   }, [weekDays, fetchTimeBlocks]);
 
+  // refresh when AI creates/completes a time block
+  useEffect(() => {
+    const refresh = () => {
+      fetchTimeBlocks(
+        weekDays[0].date + "T00:00:00Z",
+        weekDays[6].date + "T23:59:59Z",
+      );
+    };
+    window.addEventListener("oghma:time-block-changed", refresh);
+    return () => window.removeEventListener("oghma:time-block-changed", refresh);
+  }, [weekDays, fetchTimeBlocks]);
+
   // scroll to 8am on mount
   useEffect(() => {
     if (scrollRef.current) {

--- a/src/lib/chat/build-stream.ts
+++ b/src/lib/chat/build-stream.ts
@@ -128,7 +128,7 @@ function buildToolInstruction(
     "IMPORTANT: When notes or folders are listed in SESSION MEMORY scope, the user has explicitly attached them. If NOTES CONTEXT is empty or thin, ALWAYS call getChunks(scope='session', mode='both') before answering any question about those notes. If getChunks still returns nothing, call readNote(noteId) directly using the note IDs from SESSION MEMORY — readNote returns the full content up to 20,000 characters.\n" +
     "CREATE NOTE: findFolder (if parentID unknown) → makeMDNote. Skip findFolder if parentID is already known from context.\n" +
     "ORGANISE: moveNote (needs targetFolderId — use findFolder first), renameNote.\n" +
-    "CALENDAR: addTimeBlock creates a scheduled study block on the calendar with pomodoro tracking. This is NOT a note. completeTimeBlock marks a block done.\n\n" +
+    "CALENDAR: getTimeBlocks lists existing calendar blocks for a date range. addTimeBlock creates a new scheduled study block with pomodoro tracking. completeTimeBlock marks a block done. These are NOT notes.\n\n" +
     "Key distinction: scheduling/study blocks/time blocks/calendar → addTimeBlock. Writing/saving/documenting → makeMDNote. Never create a note when the user wants a calendar block." +
     scopedParentHint +
     (canvasInstruction ? `\n\n${canvasInstruction}` : "")
@@ -425,6 +425,29 @@ function createChatTools(
     },
   });
 
+  const getTimeBlocks = tool({
+    description:
+      "List the user's scheduled time blocks. Use to check what's already on the calendar before adding new blocks, or to confirm a block was created.",
+    inputSchema: z.object({
+      start: z.string().describe("ISO 8601 start of range"),
+      end: z.string().describe("ISO 8601 end of range"),
+    }),
+    execute: async ({ start, end }) => {
+      const rows = await sql`
+        SELECT tb.id, tb.title, tb.starts_at, tb.ends_at, tb.pomodoro_count, tb.completed,
+               a.title AS assignment_title
+        FROM app.time_blocks tb
+        LEFT JOIN app.assignments a ON a.id = tb.assignment_id AND a.user_id = ${userId}::uuid
+        WHERE tb.user_id = ${userId}::uuid
+          AND tb.starts_at < ${end}::timestamptz
+          AND tb.ends_at > ${start}::timestamptz
+        ORDER BY tb.starts_at ASC
+        LIMIT 50
+      `;
+      return { blocks: rows };
+    },
+  });
+
   const addTimeBlock = tool({
     description:
       "Add a study/scheduling block to the calendar with automatic pomodoro tracking. " +
@@ -437,6 +460,7 @@ function createChatTools(
       assignmentId: z.string().uuid().optional(),
     }),
     execute: async ({ title: blockTitle, startsAt, endsAt, assignmentId }) => {
+      console.log("[addTimeBlock] called", { blockTitle, startsAt, endsAt, assignmentId, userId });
       const start = new Date(startsAt);
       const end = new Date(endsAt);
       const durationMins = (end.getTime() - start.getTime()) / 60000;
@@ -462,6 +486,7 @@ function createChatTools(
         RETURNING id, title, starts_at, ends_at, pomodoro_count
       `;
 
+      console.log("[addTimeBlock] inserted", { blockId: row.id, title: row.title });
       return {
         blockId: row.id,
         title: row.title,
@@ -498,6 +523,7 @@ function createChatTools(
       makeMDNote,
       moveNote,
       renameNote,
+      getTimeBlocks,
       addTimeBlock,
       completeTimeBlock,
       ...canvasTools,

--- a/src/lib/chat/hooks/use-chat-stream.ts
+++ b/src/lib/chat/hooks/use-chat-stream.ts
@@ -331,6 +331,14 @@ export function useChatStream(
             handleNewSession(update.sessionId, userText);
           }
 
+          if (
+            update.type === "tool-call" &&
+            (update.toolName === "addTimeBlock" ||
+              update.toolName === "completeTimeBlock")
+          ) {
+            window.dispatchEvent(new CustomEvent("oghma:time-block-changed"));
+          }
+
           setMessages((prev) =>
             prev.map((m) =>
               m.id === assistantId

--- a/src/lib/chat/hooks/use-chat-stream.ts
+++ b/src/lib/chat/hooks/use-chat-stream.ts
@@ -217,13 +217,16 @@ export function useChatStream(
           throw new Error("Missing stream body");
         }
 
-        await consumeStream(res.body, assistantId, text);
+        const { timeBlockChanged } = await consumeStream(res.body, assistantId, text);
         const completionTime = Date.now();
         setMessages((prev) =>
           prev.map((m) =>
             m.id === assistantId ? { ...m, timestamp: completionTime } : m,
           ),
         );
+        if (timeBlockChanged) {
+          window.dispatchEvent(new CustomEvent("oghma:time-block-changed"));
+        }
         clearDraft(sessionIdRef.current);
         onStreamComplete?.();
       } catch (err) {
@@ -307,7 +310,8 @@ export function useChatStream(
     body: ReadableStream<Uint8Array>,
     assistantId: string,
     userText: string,
-  ): Promise<void> {
+  ): Promise<{ timeBlockChanged: boolean }> {
+    let timeBlockChanged = false;
     const reader = body.getReader();
     const decoder = new TextDecoder();
     const parseState = { buffer: "" };
@@ -336,7 +340,7 @@ export function useChatStream(
             (update.toolName === "addTimeBlock" ||
               update.toolName === "completeTimeBlock")
           ) {
-            window.dispatchEvent(new CustomEvent("oghma:time-block-changed"));
+            timeBlockChanged = true;
           }
 
           setMessages((prev) =>
@@ -354,6 +358,7 @@ export function useChatStream(
       // yield to the macrotask queue so React can flush pending renders
       await new Promise<void>((r) => setTimeout(r, 0));
     }
+    return { timeBlockChanged };
   }
 
   return {

--- a/src/lib/chat/parse-sse-frame.ts
+++ b/src/lib/chat/parse-sse-frame.ts
@@ -9,6 +9,7 @@ const TOOL_CALL_LABELS: Record<string, string> = {
   makeMDNote: "Creating note",
   moveNote: "Moving note",
   renameNote: "Renaming note",
+  getTimeBlocks: "Checking calendar",
   addTimeBlock: "Scheduling study block",
   completeTimeBlock: "Marking block complete",
   canvas_list_courses: "Reading Canvas courses",
@@ -24,7 +25,7 @@ export type MessageUpdate =
   | { type: "search"; searchContext: SearchContextData }
   | { type: "thinking"; text: string }
   | { type: "token"; text: string; thinkingDuration?: number }
-  | { type: "tool-call"; label: string }
+  | { type: "tool-call"; label: string; toolName: string }
   | { type: "error"; message: string };
 
 /**
@@ -77,7 +78,7 @@ export function parseSseFrame(frame: SseFrame): MessageUpdate | null {
     case "tool-call": {
       const toolName = typeof payload.toolName === "string" ? payload.toolName : "";
       const label = TOOL_CALL_LABELS[toolName] ?? toolName;
-      return { type: "tool-call", label };
+      return { type: "tool-call", label, toolName };
     }
 
     case "error": {


### PR DESCRIPTION
## Summary
- Calendar views (month + week) now auto-refresh when AI creates or completes a time block — no page reload needed
- Add `getTimeBlocks` tool so the AI can read existing blocks before adding new ones and confirm creation
- Add `console.log` to `addTimeBlock.execute` for CloudWatch diagnostics
- Expose `toolName` in the `tool-call` SSE update type (was label-only)

## Test plan
- [ ] Ask AI to schedule a study block — it should appear on the calendar immediately
- [ ] Ask AI to list your calendar blocks — it should use `getTimeBlocks` and return them
- [ ] Check CloudWatch `/aws/lambda/oghmanotes-chat` for `[addTimeBlock] called/inserted` logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability for the chat to query and list existing time blocks within a date range.
  * Calendar views now automatically refresh when time blocks are modified through chat interactions.

* **Improvements**
  * Enhanced synchronization between chat-based calendar operations and calendar interface displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->