### PR TITLE
fix(chat): browser local datetime + Lambda ESM require fix

### DIFF
--- a/infra/chat-lambda/handler.ts
+++ b/infra/chat-lambda/handler.ts
@@ -128,6 +128,7 @@ export const handler = awslambda.streamifyResponse(
         history: requestHistory = [],
         thinkingMode: requestedThinkingMode,
         clientNow,
+        timezone,
       } = body;
 
       const thinkingMode: LlmThinkingMode =
@@ -185,6 +186,7 @@ export const handler = awslambda.streamifyResponse(
           sessionMemoryPrompt,
           thinkingMode,
           clientNow: typeof clientNow === "string" ? clientNow : undefined,
+          timezone: typeof timezone === "string" ? timezone : undefined,
           requestOrigin: event.headers?.origin ?? "",
           referer: event.headers?.referer ?? null,
         });

--- a/infra/chat-lambda/handler.ts
+++ b/infra/chat-lambda/handler.ts
@@ -127,6 +127,7 @@ export const handler = awslambda.streamifyResponse(
         sessionId: requestedSessionId,
         history: requestHistory = [],
         thinkingMode: requestedThinkingMode,
+        clientNow,
       } = body;
 
       const thinkingMode: LlmThinkingMode =
@@ -183,6 +184,7 @@ export const handler = awslambda.streamifyResponse(
           systemPrompt,
           sessionMemoryPrompt,
           thinkingMode,
+          clientNow: typeof clientNow === "string" ? clientNow : undefined,
           requestOrigin: event.headers?.origin ?? "",
           referer: event.headers?.referer ?? null,
         });

--- a/infra/chat-lambda/handler.ts
+++ b/infra/chat-lambda/handler.ts
@@ -127,8 +127,7 @@ export const handler = awslambda.streamifyResponse(
         sessionId: requestedSessionId,
         history: requestHistory = [],
         thinkingMode: requestedThinkingMode,
-        clientNow,
-        timezone,
+        clientDateTime,
       } = body;
 
       const thinkingMode: LlmThinkingMode =
@@ -185,8 +184,7 @@ export const handler = awslambda.streamifyResponse(
           systemPrompt,
           sessionMemoryPrompt,
           thinkingMode,
-          clientNow: typeof clientNow === "string" ? clientNow : undefined,
-          timezone: typeof timezone === "string" ? timezone : undefined,
+          clientDateTime: typeof clientDateTime === "string" ? clientDateTime : undefined,
           requestOrigin: event.headers?.origin ?? "",
           referer: event.headers?.referer ?? null,
         });

--- a/src/lib/chat/build-stream.ts
+++ b/src/lib/chat/build-stream.ts
@@ -62,6 +62,7 @@ export interface BuildLlmCallParams {
   systemPrompt: string;
   sessionMemoryPrompt: string;
   thinkingMode: LlmThinkingMode;
+  clientNow?: string;
   requestOrigin: string;
   referer: string | null;
 }
@@ -119,10 +120,11 @@ async function resolveParentFolderHint(
 function buildToolInstruction(
   scopedParentHint: string,
   canvasInstruction: string,
+  clientNow?: string,
 ): string {
-  const nowUtc = new Date().toISOString();
+  const nowUtc = clientNow ?? new Date().toISOString();
   return (
-    `Current UTC date/time: ${nowUtc}\n\n` +
+    `Current date/time (user's browser): ${nowUtc}\n\n` +
     "You have note and planning tools, plus optional Canvas tools. Tool schemas are provided separately — this section covers workflow and selection.\n\n" +
     "SEARCH: getChunks → readNote. Start with getChunks (prefer scope='session', use 'all' when session isn't enough). Use readNote only after getChunks identifies the right note.\n" +
     "IMPORTANT: When notes or folders are listed in SESSION MEMORY scope, the user has explicitly attached them. If NOTES CONTEXT is empty or thin, ALWAYS call getChunks(scope='session', mode='both') before answering any question about those notes. If getChunks still returns nothing, call readNote(noteId) directly using the note IDs from SESSION MEMORY — readNote returns the full content up to 20,000 characters.\n" +
@@ -556,6 +558,7 @@ export async function buildLlmCall(
   const toolInstruction = buildToolInstruction(
     scopedParentHint,
     canvasInstruction,
+    params.clientNow,
   );
 
   const { tools } = createChatTools(

--- a/src/lib/chat/build-stream.ts
+++ b/src/lib/chat/build-stream.ts
@@ -62,8 +62,7 @@ export interface BuildLlmCallParams {
   systemPrompt: string;
   sessionMemoryPrompt: string;
   thinkingMode: LlmThinkingMode;
-  clientNow?: string;
-  timezone?: string;
+  clientDateTime?: string;
   requestOrigin: string;
   referer: string | null;
 }
@@ -121,13 +120,11 @@ async function resolveParentFolderHint(
 function buildToolInstruction(
   scopedParentHint: string,
   canvasInstruction: string,
-  clientNow?: string,
-  timezone?: string,
+  clientDateTime?: string,
 ): string {
-  const nowUtc = clientNow ?? new Date().toISOString();
-  const tzLine = timezone ? ` (timezone: ${timezone})` : "";
+  const now = clientDateTime ?? new Date().toISOString();
   return (
-    `Current date/time (user's browser): ${nowUtc}${tzLine}\n\n` +
+    `Current date/time: ${now}\n\n` +
     "You have note and planning tools, plus optional Canvas tools. Tool schemas are provided separately — this section covers workflow and selection.\n\n" +
     "SEARCH: getChunks → readNote. Start with getChunks (prefer scope='session', use 'all' when session isn't enough). Use readNote only after getChunks identifies the right note.\n" +
     "IMPORTANT: When notes or folders are listed in SESSION MEMORY scope, the user has explicitly attached them. If NOTES CONTEXT is empty or thin, ALWAYS call getChunks(scope='session', mode='both') before answering any question about those notes. If getChunks still returns nothing, call readNote(noteId) directly using the note IDs from SESSION MEMORY — readNote returns the full content up to 20,000 characters.\n" +
@@ -561,8 +558,7 @@ export async function buildLlmCall(
   const toolInstruction = buildToolInstruction(
     scopedParentHint,
     canvasInstruction,
-    params.clientNow,
-    params.timezone,
+    params.clientDateTime,
   );
 
   const { tools } = createChatTools(

--- a/src/lib/chat/build-stream.ts
+++ b/src/lib/chat/build-stream.ts
@@ -63,6 +63,7 @@ export interface BuildLlmCallParams {
   sessionMemoryPrompt: string;
   thinkingMode: LlmThinkingMode;
   clientNow?: string;
+  timezone?: string;
   requestOrigin: string;
   referer: string | null;
 }
@@ -121,10 +122,12 @@ function buildToolInstruction(
   scopedParentHint: string,
   canvasInstruction: string,
   clientNow?: string,
+  timezone?: string,
 ): string {
   const nowUtc = clientNow ?? new Date().toISOString();
+  const tzLine = timezone ? ` (timezone: ${timezone})` : "";
   return (
-    `Current date/time (user's browser): ${nowUtc}\n\n` +
+    `Current date/time (user's browser): ${nowUtc}${tzLine}\n\n` +
     "You have note and planning tools, plus optional Canvas tools. Tool schemas are provided separately — this section covers workflow and selection.\n\n" +
     "SEARCH: getChunks → readNote. Start with getChunks (prefer scope='session', use 'all' when session isn't enough). Use readNote only after getChunks identifies the right note.\n" +
     "IMPORTANT: When notes or folders are listed in SESSION MEMORY scope, the user has explicitly attached them. If NOTES CONTEXT is empty or thin, ALWAYS call getChunks(scope='session', mode='both') before answering any question about those notes. If getChunks still returns nothing, call readNote(noteId) directly using the note IDs from SESSION MEMORY — readNote returns the full content up to 20,000 characters.\n" +
@@ -559,6 +562,7 @@ export async function buildLlmCall(
     scopedParentHint,
     canvasInstruction,
     params.clientNow,
+    params.timezone,
   );
 
   const { tools } = createChatTools(

--- a/src/lib/chat/hooks/use-chat-stream.ts
+++ b/src/lib/chat/hooks/use-chat-stream.ts
@@ -179,6 +179,14 @@ export function useChatStream(
             history,
             stream: true,
             thinkingMode,
+            clientNow: (() => {
+              const d = new Date();
+              const off = -d.getTimezoneOffset();
+              const s = off >= 0 ? "+" : "-";
+              const h = String(Math.floor(Math.abs(off) / 60)).padStart(2, "0");
+              const m = String(Math.abs(off) % 60).padStart(2, "0");
+              return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}T${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}${s}${h}:${m}`;
+            })(),
           }),
         });
 

--- a/src/lib/chat/hooks/use-chat-stream.ts
+++ b/src/lib/chat/hooks/use-chat-stream.ts
@@ -179,15 +179,15 @@ export function useChatStream(
             history,
             stream: true,
             thinkingMode,
-            clientNow: (() => {
+            clientDateTime: (() => {
               const d = new Date();
+              const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
               const off = -d.getTimezoneOffset();
               const s = off >= 0 ? "+" : "-";
               const h = String(Math.floor(Math.abs(off) / 60)).padStart(2, "0");
               const m = String(Math.abs(off) % 60).padStart(2, "0");
-              return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}T${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}${s}${h}:${m}`;
+              return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}T${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}${s}${h}:${m}[${tz}]`;
             })(),
-            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
           }),
         });
 

--- a/src/lib/chat/hooks/use-chat-stream.ts
+++ b/src/lib/chat/hooks/use-chat-stream.ts
@@ -187,6 +187,7 @@ export function useChatStream(
               const m = String(Math.abs(off) % 60).padStart(2, "0");
               return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}T${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}${s}${h}:${m}`;
             })(),
+            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
           }),
         });
 


### PR DESCRIPTION
## Summary
- Send browser local datetime (with timezone offset, e.g. `2026-04-21T01:10:00+01:00`) to Lambda so AI schedules calendar blocks on the correct local date, not UTC
- Fix Lambda ESM bundle missing `createRequire` shim — was crashing all invocations silently after last rebuild
- Lambda now has its own CloudWatch log group (auto-created)

## Test plan
- [ ] Ask AI to schedule a block for "today" or "tomorrow" — should land on correct local date
- [ ] Check `/aws/lambda/oghmanotes-chat` CloudWatch logs for `[addTimeBlock] called` with correct startsAt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat system now uses your local browser time instead of server time for timestamps, ensuring times reflect your timezone in conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->