### PR TITLE
fix(ai): route embedding to SiliconFlow, reranking to OpenRouter

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -50,7 +50,7 @@ export async function register() {
   const { validateEnv } = await import("@/lib/validateEnv");
   validateEnv();
 
-  // enable X-Ray auto-tracing of all outbound HTTPS calls (Cohere, Kimi, etc.)
+  // enable X-Ray auto-tracing of all outbound HTTPS calls (SiliconFlow, OpenRouter, Kimi, etc.)
   // only when active tracing is enabled (_X_AMZN_TRACE_ID is set by Lambda
   // when active tracing is on — without it captureHTTPsGlobal causes errors)
   if (process.env.NODE_ENV === "production" && process.env._X_AMZN_TRACE_ID) {

--- a/src/lib/chat/rag-pipeline.ts
+++ b/src/lib/chat/rag-pipeline.ts
@@ -15,7 +15,7 @@ export interface SearchResult {
 }
 
 // cosine distance threshold — chunks further than this are considered irrelevant
-// Cohere multilingual-v3.0 distances: 0 = identical, ~0.3 = very similar, ~0.7 = weakly related
+// ~0 = identical, ~0.3 = very similar, ~0.7 = weakly related
 const MAX_DISTANCE = 0.55;
 
 // search chunks+embeddings tables, joining back to notes for metadata

--- a/src/lib/embedText.ts
+++ b/src/lib/embedText.ts
@@ -1,5 +1,5 @@
 // embeds a single query string for semantic search
-// uses the same provider as batch embedding (OpenRouter / any OpenAI-compatible API)
+// uses the same provider as batch embedding (SiliconFlow / any OpenAI-compatible API)
 
 import { defaultEmbeddingProvider } from "@/lib/providers/self-hosted-embeddings";
 

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -1,4 +1,4 @@
-// batch-embeds chunks via the configured embedding provider (OpenRouter, etc.)
+// batch-embeds chunks via the configured embedding provider (SiliconFlow, etc.)
 // strips markdown syntax before embedding — ###, ---, ** etc. are noise in vector space
 // the original markdown chunk text is preserved in chunks.text for LLM RAG context
 

--- a/src/lib/providers/self-hosted-embeddings.ts
+++ b/src/lib/providers/self-hosted-embeddings.ts
@@ -1,4 +1,4 @@
-// embedding provider — calls any OpenAI-compatible endpoint (OpenRouter, ollama, etc.)
+// embedding provider — calls any OpenAI-compatible endpoint (SiliconFlow, ollama, etc.)
 // configured via EMBEDDING_API_URL, EMBEDDING_API_KEY, EMBEDDING_MODEL
 
 export interface EmbeddingProvider {
@@ -31,16 +31,13 @@ class SelfHostedEmbeddingProvider implements EmbeddingProvider {
       throw new Error("Embedding provider not configured (EMBEDDING_API_URL/KEY/MODEL)");
     }
 
-    const nonEmpty = texts.filter((t) => t?.trim());
-    if (nonEmpty.length === 0) return [];
-
     const res = await fetch(`${apiUrl}/v1/embeddings`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
       },
-      body: JSON.stringify({ input: nonEmpty, model }),
+      body: JSON.stringify({ input: texts, model }),
       signal: AbortSignal.timeout(30000),
     });
 
@@ -54,9 +51,9 @@ class SelfHostedEmbeddingProvider implements EmbeddingProvider {
       .map((item: { embedding: number[] }) => item.embedding)
       .filter(Boolean);
 
-    if (embeddings.length !== nonEmpty.length) {
+    if (embeddings.length !== texts.length) {
       throw new Error(
-        `Embedding count mismatch: got ${embeddings.length}, expected ${nonEmpty.length}`,
+        `Embedding count mismatch: got ${embeddings.length}, expected ${texts.length}`,
       );
     }
 

--- a/src/lib/providers/self-hosted-rerank.ts
+++ b/src/lib/providers/self-hosted-rerank.ts
@@ -1,4 +1,4 @@
-// reranking via SiliconFlow / any Cohere-compatible rerank API
+// reranking via OpenRouter / any Cohere-compatible rerank API
 // configured via RERANK_API_URL, RERANK_API_KEY, RERANK_MODEL
 
 export interface RerankProvider {
@@ -35,10 +35,6 @@ class RerankAPIProvider implements RerankProvider {
     const { apiUrl, apiKey, model } = env();
     if (!(apiUrl && apiKey && model)) {
       throw new Error("Rerank provider not configured (RERANK_API_URL/KEY/MODEL)");
-    }
-
-    if (chunks.length <= topN) {
-      return chunks.map((text, index) => ({ index, text, score: 1 }));
     }
 
     const res = await fetch(`${apiUrl}/v1/rerank`, {

--- a/workers/ingestion-worker.ts
+++ b/workers/ingestion-worker.ts
@@ -11,6 +11,7 @@
  * workers if you ever need to scale horizontally.
  */
 
+import { loadSecrets } from "../src/lib/secrets";
 import sql from "../src/database/pgsql.js";
 import { runExtraction } from "../src/app/api/extract/route";
 import logger from "../src/lib/logger";
@@ -89,6 +90,9 @@ function sleep(ms: number) {
 }
 
 async function run() {
+    if (process.env.NODE_ENV === "production") {
+        await loadSecrets();
+    }
     logger.info("ingestion-worker: started");
 
     while (true) {


### PR DESCRIPTION
## Summary
- Corrects the embedding/rerank service wiring: embedding → SiliconFlow, reranking → OpenRouter (URLs, keys, and model names updated in Amplify env vars, Lambda env vars, and Secrets Manager)
- Ingestion worker now calls `loadSecrets()` at startup so it self-configures from Secrets Manager instead of needing secrets baked into the systemd unit
- Removes two instances of duplicated logic: the `chunks <= topN` early-return (owned by the caller in `rerank.ts`) and the non-empty filter in `embedBatch` (callers filter before calling)

## Test Plan
- [ ] Verify chat RAG returns relevant results (embedding + rerank both hitting correct services)
- [ ] Check Lambda logs for no auth errors from embedding/rerank APIs after deploy
- [ ] Confirm Amplify build succeeds on dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved embedding input handling to process all entries consistently
  * Updated reranking logic to always invoke the reranking service

* **Chores**
  * Updated embedding provider references in documentation
  * Enhanced production environment initialization with secret loading

<!-- end of auto-generated comment: release notes by coderabbit.ai -->