### PR TITLE
fix(ai): embedding /v1/v1 double-path bug + Lambda rebuild

### DIFF
--- a/infra/chat-lambda/deploy.sh
+++ b/infra/chat-lambda/deploy.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 #   - Node.js + npm available
 #   - the Lambda needs VPC access if RDS/ElastiCache are in a VPC
 
-REGION="eu-north-1"
+REGION="eu-west-1"
 FUNCTION_NAME="oghmanotes-chat"
 ROLE_NAME="oghmanotes-chat-lambda-role"
 TIMEOUT=300        # 5 minutes


### PR DESCRIPTION
## Summary

- Removed hardcoded `/v1` from embedding and rerank provider URL construction — providers now only append the endpoint path (`/embeddings`, `/rerank`) so `EMBEDDING_API_URL` / `RERANK_API_URL` hold the full base URL including `/v1`
- Rebuilt and redeployed the chat Lambda, which was running a stale bundle that still had the old `/v1/embeddings` path (Amplify builds don't touch the Lambda)
- Fixed `deploy.sh` region `eu-north-1` → `eu-west-1` (Lambda has always lived in eu-west-1)
- Includes all dev work since PR #258: calendar live refresh, RFC 9557 datetime, canvas async Marker pipeline, editor/chat/quiz polish, shared MarkdownRenderer, vault import fixes, RAG threshold tuning, and more

## Test plan

- [ ] `makeMDNote` via chat no longer hits `/v1/v1/embeddings` — embedding call succeeds
- [ ] Semantic search (`getChunks`) returns results for newly created notes
- [ ] Reranking still works (SiliconFlow `/v1/rerank`)
- [ ] Amplify main build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->