### PR TITLE
feat: add sidebar multi-select delete

### DIFF
--- a/src/__tests__/components/notes/sidebar-selection-utils.test.ts
+++ b/src/__tests__/components/notes/sidebar-selection-utils.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import TreeActions, { DEFAULT_TREE, ROOT_ID } from "@/lib/notes/types/tree";
+import {
+  getTopLevelSelectedIds,
+  getVisibleRangeSelection,
+  getVisibleTreeItemIds,
+  treeItemContainsId,
+  toggleSelectedId,
+} from "@/components/notes/sidebar/selection-utils";
+
+describe("sidebar selection utilities", () => {
+  it("excludes selected descendants when an ancestor is selected", () => {
+    let tree = TreeActions.addItem(DEFAULT_TREE, "folder");
+    tree = TreeActions.addItem(tree, "child", "folder");
+    tree = TreeActions.addItem(tree, "grandchild", "child");
+    tree = TreeActions.addItem(tree, "sibling");
+
+    expect(
+      getTopLevelSelectedIds(
+        ["folder", "child", "grandchild", "sibling"],
+        tree,
+      ),
+    ).toEqual(["folder", "sibling"]);
+  });
+
+  it("returns a shift-click range from the visible tree order", () => {
+    let tree = TreeActions.addItem(DEFAULT_TREE, "a");
+    tree = TreeActions.addItem(tree, "folder");
+    tree = TreeActions.addItem(tree, "b", "folder");
+    tree = TreeActions.addItem(tree, "c", "folder");
+    tree = TreeActions.addItem(tree, "d");
+
+    const visibleIds = getVisibleTreeItemIds(tree, new Set(["folder"]));
+
+    expect(visibleIds).toEqual(["a", "folder", "b", "c", "d"]);
+    expect(getVisibleRangeSelection(visibleIds, "folder", "c")).toEqual([
+      "folder",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("does not include collapsed descendants in visible order", () => {
+    let tree = TreeActions.addItem(DEFAULT_TREE, "folder");
+    tree = TreeActions.addItem(tree, "child", "folder");
+    tree = TreeActions.addItem(tree, "after");
+
+    expect(getVisibleTreeItemIds(tree, new Set())).toEqual(["folder", "after"]);
+  });
+
+  it("toggles one selected id without changing the others", () => {
+    expect(Array.from(toggleSelectedId(new Set(["a", "b"]), "b"))).toEqual([
+      "a",
+    ]);
+    expect(Array.from(toggleSelectedId(new Set(["a"]), "b"))).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("never returns root as a top-level delete candidate", () => {
+    const tree = TreeActions.addItem(DEFAULT_TREE, "a");
+    expect(getTopLevelSelectedIds([ROOT_ID, "a"], tree)).toEqual(["a"]);
+  });
+
+  it("detects whether one loaded tree item contains another", () => {
+    let tree = TreeActions.addItem(DEFAULT_TREE, "folder");
+    tree = TreeActions.addItem(tree, "child", "folder");
+    tree = TreeActions.addItem(tree, "after");
+
+    expect(treeItemContainsId(tree, "folder", "child")).toBe(true);
+    expect(treeItemContainsId(tree, "folder", "after")).toBe(false);
+  });
+});

--- a/src/components/notes/sidebar/note-context-menu.tsx
+++ b/src/components/notes/sidebar/note-context-menu.tsx
@@ -7,7 +7,7 @@ import useContextMenuStore from "@/lib/notes/state/context-menu";
 
 interface NoteContextMenuPortalProps {
   onRename: (id: string) => void;
-  onDelete: (id: string) => void;
+  onDelete: (ids: string[]) => void;
   onDuplicate: (id: string) => void;
   onTogglePin: (id: string) => void;
   onCreateNote: (parentId: string) => void;
@@ -63,8 +63,15 @@ export default function NoteContextMenuPortal({
   onOpenInSplit,
 }: NoteContextMenuPortalProps) {
   const { t } = useI18n();
-  const { openMenuId, position, isFolder, isPinned, closeMenu } =
-    useContextMenuStore();
+  const {
+    openMenuId,
+    position,
+    isFolder,
+    isPinned,
+    selectedCount,
+    selectionIds,
+    closeMenu,
+  } = useContextMenuStore();
   const menuRef = useRef<HTMLDivElement>(null);
   const [adjusted, setAdjusted] = useState<{ x: number; y: number } | null>(
     null,
@@ -120,6 +127,7 @@ export default function NoteContextMenuPortal({
     fn();
     closeMenu();
   };
+  const isMultiSelectMenu = selectedCount > 1;
 
   // svg icons inline for crisp rendering
   const icons = {
@@ -216,72 +224,85 @@ export default function NoteContextMenuPortal({
       }}
       onClick={(e) => e.stopPropagation()}
     >
-      {!isFolder && (
+      {isMultiSelectMenu ? (
         <MenuItem
-          label={isPinned ? t("Unpin") : t("Pin to favorites")}
-          icon={icons.pin}
-          onClick={() => run(() => onTogglePin(openMenuId))}
+          label={t("Delete selected")}
+          icon={icons.trash}
+          onClick={() => run(() => onDelete(selectionIds))}
+          danger
         />
-      )}
-
-      <MenuItem
-        label={t("Rename")}
-        shortcut="F2"
-        icon={icons.rename}
-        onClick={() => run(() => onRename(openMenuId))}
-      />
-
-      {!isFolder && (
-        <MenuItem
-          label={t("Duplicate")}
-          icon={icons.duplicate}
-          onClick={() => run(() => onDuplicate(openMenuId))}
-        />
-      )}
-
-      {(isFolder || openMenuId === "root") && (
+      ) : (
         <>
-          <Separator />
+          {!isFolder && (
+            <MenuItem
+              label={isPinned ? t("Unpin") : t("Pin to favorites")}
+              icon={icons.pin}
+              onClick={() => run(() => onTogglePin(openMenuId))}
+            />
+          )}
+
           <MenuItem
-            label={t("New note")}
-            icon={icons.newNote}
-            onClick={() =>
-              run(() =>
-                onCreateNote(openMenuId === "root" ? "root" : openMenuId),
-              )
-            }
+            label={t("Rename")}
+            shortcut="F2"
+            icon={icons.rename}
+            onClick={() => run(() => onRename(openMenuId))}
           />
+
+          {!isFolder && (
+            <MenuItem
+              label={t("Duplicate")}
+              icon={icons.duplicate}
+              onClick={() => run(() => onDuplicate(openMenuId))}
+            />
+          )}
+
+          {(isFolder || openMenuId === "root") && (
+            <>
+              <Separator />
+              <MenuItem
+                label={t("New note")}
+                icon={icons.newNote}
+                onClick={() =>
+                  run(() =>
+                    onCreateNote(openMenuId === "root" ? "root" : openMenuId),
+                  )
+                }
+              />
+              <MenuItem
+                label={t("New folder")}
+                icon={icons.newFolder}
+                onClick={() =>
+                  run(() =>
+                    onCreateFolder(
+                      openMenuId === "root" ? "root" : openMenuId,
+                    ),
+                  )
+                }
+              />
+            </>
+          )}
+
+          {!isFolder && (
+            <>
+              <Separator />
+              <MenuItem
+                label={t("Open in split view")}
+                icon={icons.split}
+                onClick={() => run(() => onOpenInSplit(openMenuId))}
+              />
+            </>
+          )}
+
+          <Separator />
+
           <MenuItem
-            label={t("New folder")}
-            icon={icons.newFolder}
-            onClick={() =>
-              run(() =>
-                onCreateFolder(openMenuId === "root" ? "root" : openMenuId),
-              )
-            }
+            label={t("Delete")}
+            icon={icons.trash}
+            onClick={() => run(() => onDelete([openMenuId]))}
+            danger
           />
         </>
       )}
-
-      {!isFolder && (
-        <>
-          <Separator />
-          <MenuItem
-            label={t("Open in split view")}
-            icon={icons.split}
-            onClick={() => run(() => onOpenInSplit(openMenuId))}
-          />
-        </>
-      )}
-
-      <Separator />
-
-      <MenuItem
-        label={t("Delete")}
-        icon={icons.trash}
-        onClick={() => run(() => onDelete(openMenuId))}
-        danger
-      />
     </div>,
     document.body,
   );

--- a/src/components/notes/sidebar/selection-utils.ts
+++ b/src/components/notes/sidebar/selection-utils.ts
@@ -1,0 +1,101 @@
+import { ROOT_ID, TreeModel } from "@/lib/notes/types/tree";
+
+export function getVisibleTreeItemIds(
+  tree: TreeModel,
+  expandedIds: Set<string>,
+  rootId = ROOT_ID,
+): string[] {
+  const root = tree.items[rootId];
+  if (!root) return [];
+
+  const result: string[] = [];
+
+  const visit = (id: string) => {
+    if (id === ROOT_ID || !tree.items[id]) return;
+
+    result.push(id);
+
+    if (!expandedIds.has(id)) return;
+    for (const childId of tree.items[id].children) {
+      visit(childId);
+    }
+  };
+
+  for (const childId of root.children) {
+    visit(childId);
+  }
+
+  return result;
+}
+
+export function getVisibleRangeSelection(
+  visibleIds: string[],
+  anchorId: string | null,
+  clickedId: string,
+): string[] {
+  if (!anchorId) return [clickedId];
+
+  const anchorIndex = visibleIds.indexOf(anchorId);
+  const clickedIndex = visibleIds.indexOf(clickedId);
+
+  if (anchorIndex === -1 || clickedIndex === -1) return [clickedId];
+
+  const start = Math.min(anchorIndex, clickedIndex);
+  const end = Math.max(anchorIndex, clickedIndex);
+  return visibleIds.slice(start, end + 1);
+}
+
+export function toggleSelectedId(
+  selectedIds: Set<string>,
+  clickedId: string,
+): Set<string> {
+  const next = new Set(selectedIds);
+  if (next.has(clickedId)) {
+    next.delete(clickedId);
+  } else {
+    next.add(clickedId);
+  }
+  return next;
+}
+
+export function getTopLevelSelectedIds(
+  selectedIds: Iterable<string>,
+  tree: TreeModel,
+): string[] {
+  const selected = new Set(
+    Array.from(selectedIds).filter((id) => id !== ROOT_ID && tree.items[id]),
+  );
+  const parentById = new Map<string, string>();
+
+  for (const parentId in tree.items) {
+    for (const childId of tree.items[parentId].children) {
+      parentById.set(childId, parentId);
+    }
+  }
+
+  return Array.from(selected).filter((id) => {
+    let parentId = parentById.get(id);
+    while (parentId) {
+      if (selected.has(parentId)) return false;
+      if (parentId === ROOT_ID) return true;
+      parentId = parentById.get(parentId);
+    }
+    return true;
+  });
+}
+
+export function treeItemContainsId(
+  tree: TreeModel,
+  ancestorId: string,
+  descendantId: string,
+): boolean {
+  const ancestor = tree.items[ancestorId];
+  if (!ancestor) return false;
+
+  for (const childId of ancestor.children) {
+    if (childId === descendantId) return true;
+    if (treeItemContainsId(tree, childId, descendantId)) return true;
+  }
+
+  return false;
+}

--- a/src/components/notes/sidebar/sidebar-list.tsx
+++ b/src/components/notes/sidebar/sidebar-list.tsx
@@ -19,7 +19,12 @@ import { NOTE_PINNED } from "@/lib/notes/types/meta";
 import { NoteModel } from "@/lib/notes/types/note";
 import CreateNoteModal from "@/components/notes/create-note-modal";
 import { useTreeData } from "./use-tree-data";
-import { useSidebarActions } from "./use-sidebar-actions";
+import { DeleteConfirmTarget, useSidebarActions } from "./use-sidebar-actions";
+import {
+  getVisibleRangeSelection,
+  getVisibleTreeItemIds,
+  toggleSelectedId,
+} from "./selection-utils";
 
 const SidebarList = () => {
   const { t } = useI18n();
@@ -31,7 +36,11 @@ const SidebarList = () => {
 
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [deleteConfirmTarget, setDeleteConfirmTarget] =
+    useState<DeleteConfirmTarget>(null);
+  const [selectionAnchorId, setSelectionAnchorId] = useState<string | null>(
+    null,
+  );
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const handleRefreshTree = useCallback(async () => {
@@ -44,6 +53,13 @@ const SidebarList = () => {
       setIsRefreshing(false);
     }
   }, [refreshTree]);
+
+  // active note from URL
+  const activeId = useMemo(() => {
+    if (!pathname || pathname === "/") return null;
+    const segs = pathname.split("/").filter(Boolean);
+    return segs[0] === "notes" ? (segs[1] ?? null) : (segs[0] ?? null);
+  }, [pathname]);
 
   const treeData = useTreeData();
 
@@ -65,6 +81,7 @@ const SidebarList = () => {
     handleCollapseAll,
     handleRename,
     handleDeleteRequest,
+    handleBulkDeleteRequest,
     handleDeleteConfirm,
     handleDuplicate,
     handleTogglePin,
@@ -74,14 +91,86 @@ const SidebarList = () => {
     handleOpenInAIChat,
     handleItemContextMenu,
     handleDrop,
-  } = useSidebarActions({ setRenamingId, setDeleteConfirmId, deleteConfirmId });
+  } = useSidebarActions({
+    setRenamingId,
+    setDeleteConfirmTarget,
+    deleteConfirmTarget,
+    activeId,
+    setSelectionAnchorId,
+    onDeleteSelectionCleared: () => setSelectionAnchorId(null),
+  });
 
-  // active note from URL
-  const activeId = useMemo(() => {
-    if (!pathname || pathname === "/") return null;
-    const segs = pathname.split("/").filter(Boolean);
-    return segs[0] === "notes" ? (segs[1] ?? null) : (segs[0] ?? null);
-  }, [pathname]);
+  const visibleIds = useMemo(
+    () => getVisibleTreeItemIds(tree, expandedIds),
+    [tree, expandedIds],
+  );
+
+  const selectedCount = selectedIds.size;
+  const deleteIds = deleteConfirmTarget?.ids ?? [];
+  const deleteHasFolder = deleteIds.some(
+    (id) => (tree.items[id]?.children?.length ?? 0) > 0,
+  );
+  const singleDeleteId =
+    deleteConfirmTarget?.mode === "single" ? deleteConfirmTarget.ids[0] : null;
+
+  const handleRowClick = useCallback(
+    (
+      e: React.MouseEvent,
+      itemId: string,
+      isFolder: boolean,
+      nodeData: NoteModel | undefined,
+      isExpanded: boolean,
+    ) => {
+      if (e.shiftKey) {
+        setSelectedIds(
+          new Set(
+            getVisibleRangeSelection(visibleIds, selectionAnchorId, itemId),
+          ),
+        );
+        return;
+      }
+
+      if (e.metaKey || e.ctrlKey) {
+        setSelectedIds(toggleSelectedId(selectedIds, itemId));
+        setSelectionAnchorId(itemId);
+        return;
+      }
+
+      setSelectedIds(new Set([itemId]));
+      setSelectionAnchorId(itemId);
+
+      if (isFolder) {
+        const next = new Set(expandedIds);
+        if (isExpanded) {
+          next.delete(itemId);
+        } else {
+          next.add(itemId);
+          const ti = useNoteTreeStore.getState().tree.items[itemId];
+          if (ti && !ti.childrenLoaded) loadChildren(itemId);
+        }
+        setExpandedIds(next);
+      } else if (nodeData) {
+        const { setPaneA, setActivePane } = useLayoutStore.getState();
+        setPaneA(buildFileSpec(nodeData));
+        setActivePane("A");
+        const href = pathname?.startsWith("/notes")
+          ? `/notes/${itemId}`
+          : `/${itemId}`;
+        router.push(href);
+      }
+    },
+    [
+      expandedIds,
+      loadChildren,
+      pathname,
+      router,
+      selectedIds,
+      selectionAnchorId,
+      setExpandedIds,
+      setSelectedIds,
+      visibleIds,
+    ],
+  );
 
   // view state for react-complex-tree
   const viewState = useMemo(
@@ -113,6 +202,30 @@ const SidebarList = () => {
           <span className="flex-1 text-[11px] font-semibold uppercase tracking-wider text-text-tertiary select-none">
             {t("Notes")}
           </span>
+          {selectedCount > 1 && (
+            <div className="flex items-center gap-1 mr-1 text-[11px] text-text-tertiary">
+              <span>{selectedCount} selected</span>
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleBulkDeleteRequest(Array.from(selectedIds));
+                }}
+                className="p-0.5 rounded hover:bg-error-500/10 text-text-tertiary hover:text-error-400 transition-colors"
+                title={t("Delete selected")}
+              >
+                <svg
+                  className="w-3.5 h-3.5"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                >
+                  <path d="M5 6h10M8 6V4h4v2M6 6v10a1 1 0 001 1h6a1 1 0 001-1V6" />
+                </svg>
+              </button>
+            </div>
+          )}
           {!initLoaded && (
             <svg
               className="animate-spin h-3 w-3 text-text-tertiary mr-1"
@@ -253,6 +366,7 @@ const SidebarList = () => {
                 const isActive = activeId === item.index;
                 const isItemRenaming = renamingId === item.index;
                 const itemId = item.index as string;
+                const isSelected = selectedIds.has(itemId);
 
                 return (
                   <TreeItem
@@ -262,6 +376,7 @@ const SidebarList = () => {
                     isFolder={!!isFolder}
                     isExpanded={isExpanded}
                     isActive={!!isActive}
+                    isSelected={isSelected}
                     isDragging={isDragging}
                     isLoading={loadingChildren.has(itemId)}
                     hasChildren={hasChildren}
@@ -285,29 +400,15 @@ const SidebarList = () => {
                         setExpandedIds(next);
                       }
                     }}
-                    onClick={() => {
-                      if (isFolder) {
-                        const next = new Set(expandedIds);
-                        if (isExpanded) {
-                          next.delete(itemId);
-                        } else {
-                          next.add(itemId);
-                          const ti =
-                            useNoteTreeStore.getState().tree.items[itemId];
-                          if (ti && !ti.childrenLoaded) loadChildren(itemId);
-                        }
-                        setExpandedIds(next);
-                      } else if (nodeData) {
-                        const { setPaneA, setActivePane } =
-                          useLayoutStore.getState();
-                        setPaneA(buildFileSpec(nodeData));
-                        setActivePane("A");
-                        const href = pathname?.startsWith("/notes")
-                          ? `/notes/${itemId}`
-                          : `/${itemId}`;
-                        router.push(href);
-                      }
-                    }}
+                    onClick={(e) =>
+                      handleRowClick(
+                        e,
+                        itemId,
+                        !!isFolder,
+                        nodeData,
+                        isExpanded,
+                      )
+                    }
                     onRenameComplete={async (newTitle) => {
                       if (nodeData) {
                         await mutateNote(itemId, { title: newTitle });
@@ -333,7 +434,14 @@ const SidebarList = () => {
                           rect.bottom + 4,
                           !!isFolder,
                           _isPinned,
+                          isSelected && selectedIds.size > 1
+                            ? Array.from(selectedIds)
+                            : [itemId],
                         );
+                      if (!isSelected || selectedIds.size <= 1) {
+                        setSelectedIds(new Set([itemId]));
+                        setSelectionAnchorId(itemId);
+                      }
                     }}
                     onOpenInAIChat={(e) => {
                       e.preventDefault();
@@ -361,7 +469,13 @@ const SidebarList = () => {
 
       <NoteContextMenu
         onRename={handleRename}
-        onDelete={handleDeleteRequest}
+        onDelete={(ids) => {
+          if (ids.length === 1) {
+            handleDeleteRequest(ids[0]);
+          } else {
+            handleBulkDeleteRequest(ids);
+          }
+        }}
         onDuplicate={handleDuplicate}
         onTogglePin={handleTogglePin}
         onCreateNote={handleContextCreateNote}
@@ -370,22 +484,40 @@ const SidebarList = () => {
       />
 
       {/* delete confirmation overlay */}
-      {deleteConfirmId && (
+      {deleteConfirmTarget && (
         <div
           className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/50"
-          onClick={() => setDeleteConfirmId(null)}
+          onClick={() => setDeleteConfirmTarget(null)}
         >
           <div
             className="bg-surface rounded-lg shadow-2xl ring-1 ring-border-subtle p-5 w-[320px] space-y-4"
             onClick={(e) => e.stopPropagation()}
           >
             <p className="text-sm text-text-secondary">
-              {t("Delete")}{" "}
-              <span className="font-medium text-text">
-                {tree.items[deleteConfirmId]?.data?.title || t("Untitled")}
-              </span>
-              ?
-              {(tree.items[deleteConfirmId]?.children?.length ?? 0) > 0 && (
+              {deleteConfirmTarget.mode === "bulk" ? (
+                <>
+                  <span className="font-medium text-text">
+                    {t("Delete")} {deleteIds.length} {t("selected items")}?
+                  </span>
+                  <span className="block mt-1 text-text-tertiary text-xs">
+                    {deleteHasFolder
+                      ? t("Selected folders and their contents will be deleted.")
+                      : t("The selected notes will be deleted.")}
+                  </span>
+                </>
+              ) : (
+                <>
+                  {t("Delete")}{" "}
+                  <span className="font-medium text-text">
+                    {singleDeleteId
+                      ? tree.items[singleDeleteId]?.data?.title ||
+                        t("Untitled")
+                      : t("Untitled")}
+                  </span>
+                  ?
+                </>
+              )}
+              {deleteConfirmTarget.mode === "single" && deleteHasFolder && (
                 <span className="block mt-1 text-text-tertiary text-xs">
                   {t("This folder and all its contents will be deleted.")}
                 </span>
@@ -393,7 +525,7 @@ const SidebarList = () => {
             </p>
             <div className="flex justify-end gap-2">
               <button
-                onClick={() => setDeleteConfirmId(null)}
+                onClick={() => setDeleteConfirmTarget(null)}
                 className="px-3 py-1.5 text-xs font-medium rounded text-text-secondary hover:bg-white/[0.06] transition-colors"
               >
                 {t("Cancel")}

--- a/src/components/notes/sidebar/tree-item.tsx
+++ b/src/components/notes/sidebar/tree-item.tsx
@@ -11,6 +11,7 @@ export interface TreeItemProps {
   isFolder: boolean;
   isExpanded: boolean;
   isActive: boolean;
+  isSelected: boolean;
   isDragging: boolean;
   isLoading: boolean;
   hasChildren: boolean;
@@ -21,7 +22,7 @@ export interface TreeItemProps {
   initLoaded: boolean;
   onContextMenu: (e: React.MouseEvent) => void;
   onToggle: () => void;
-  onClick: () => void;
+  onClick: (e: React.MouseEvent) => void;
   onRenameComplete: (newTitle: string) => void | Promise<void>;
   onAddNote: (e: React.MouseEvent) => void | Promise<void>;
   onDotsClick: (e: React.MouseEvent) => void;
@@ -35,6 +36,7 @@ const TreeItem: React.FC<TreeItemProps> = memo(
     isFolder,
     isExpanded,
     isActive,
+    isSelected,
     isDragging,
     isLoading,
     hasChildren,
@@ -121,11 +123,18 @@ const TreeItem: React.FC<TreeItemProps> = memo(
           className={`
             group/item flex items-center h-[26px] pr-1 cursor-pointer select-none
             transition-colors duration-75 rounded-[3px] mx-0.5
+            ${isActive ? "bg-subtle text-text-secondary" : ""}
             ${
-              isActive
-                ? "bg-subtle text-text-secondary"
-                : "text-text-tertiary hover:text-text-secondary hover:bg-subtle"
+              !isActive && isSelected
+                ? "bg-primary-500/10 text-text-secondary"
+                : ""
             }
+            ${
+              !isActive && !isSelected
+                ? "text-text-tertiary hover:text-text-secondary hover:bg-subtle"
+                : ""
+            }
+            ${isActive && isSelected ? "ring-1 ring-primary-500/20" : ""}
             ${isDragging ? "opacity-40" : ""}
           `}
           style={{ paddingLeft: `${pl + 4}px` }}
@@ -133,7 +142,7 @@ const TreeItem: React.FC<TreeItemProps> = memo(
           onContextMenu={onContextMenu}
           onClick={(e) => {
             interactiveProps.onClick?.(e);
-            onClick();
+            onClick(e);
           }}
           onDragStart={(e: React.DragEvent) => {
             rctProps.onDragStart?.(e);

--- a/src/components/notes/sidebar/use-sidebar-actions.ts
+++ b/src/components/notes/sidebar/use-sidebar-actions.ts
@@ -8,14 +8,30 @@ import useContextMenuStore from "@/lib/notes/state/context-menu";
 import { buildFileSpec } from "@/lib/notes/utils/file-spec";
 import { NOTE_PINNED } from "@/lib/notes/types/meta";
 import { NoteModel } from "@/lib/notes/types/note";
+import { getTopLevelSelectedIds, treeItemContainsId } from "./selection-utils";
+
+export type DeleteConfirmTarget =
+  | { mode: "single"; ids: [string] }
+  | { mode: "bulk"; ids: string[] }
+  | null;
 
 // sidebar CRUD operations and action callbacks
 export function useSidebarActions(deps: {
   setRenamingId: (id: string | null) => void;
-  setDeleteConfirmId: (id: string | null) => void;
-  deleteConfirmId: string | null;
+  setDeleteConfirmTarget: (target: DeleteConfirmTarget) => void;
+  deleteConfirmTarget: DeleteConfirmTarget;
+  activeId: string | null;
+  setSelectionAnchorId: (id: string | null) => void;
+  onDeleteSelectionCleared: () => void;
 }) {
-  const { setRenamingId, setDeleteConfirmId, deleteConfirmId } = deps;
+  const {
+    setRenamingId,
+    setDeleteConfirmTarget,
+    deleteConfirmTarget,
+    activeId,
+    setSelectionAnchorId,
+    onDeleteSelectionCleared,
+  } = deps;
   const router = useRouter();
 
   const {
@@ -28,6 +44,9 @@ export function useSidebarActions(deps: {
     loadChildren,
     expandedIds,
     setExpandedIds,
+    selectedIds,
+    setSelectedIds,
+    refreshTree,
   } = useNoteTreeStore();
   const { createNote, createFolder, mutateNote, removeNote } = useNoteStore();
 
@@ -137,22 +156,111 @@ export function useSidebarActions(deps: {
         toast.error("Please wait for notes to load");
         return;
       }
-      setDeleteConfirmId(id);
+      setDeleteConfirmTarget({ mode: "single", ids: [id] });
     },
-    [initLoaded, setDeleteConfirmId],
+    [initLoaded, setDeleteConfirmTarget],
+  );
+
+  const handleBulkDeleteRequest = useCallback(
+    (ids: string[]) => {
+      if (!initLoaded) {
+        toast.error("Please wait for notes to load");
+        return;
+      }
+      const cleanIds = ids.filter((id) => id !== "root" && tree.items[id]);
+      if (cleanIds.length === 0) return;
+      if (cleanIds.length === 1) {
+        setDeleteConfirmTarget({ mode: "single", ids: [cleanIds[0]] });
+        return;
+      }
+      setDeleteConfirmTarget({ mode: "bulk", ids: cleanIds });
+    },
+    [initLoaded, setDeleteConfirmTarget, tree.items],
   );
 
   // confirm and execute delete
   const handleDeleteConfirm = useCallback(async () => {
-    if (!deleteConfirmId) return;
-    const id = deleteConfirmId;
-    setDeleteConfirmId(null);
-    try {
-      await removeNote(id);
-    } catch {
-      toast.error("Failed to delete");
+    if (!deleteConfirmTarget) return;
+
+    const target = deleteConfirmTarget;
+    setDeleteConfirmTarget(null);
+
+    if (target.mode === "single") {
+      const id = target.ids[0];
+      try {
+        await removeNote(id);
+        const nextSelected = new Set(useNoteTreeStore.getState().selectedIds);
+        nextSelected.delete(id);
+        setSelectedIds(nextSelected);
+        onDeleteSelectionCleared();
+        if (activeId === id) router.push("/notes");
+      } catch {
+        toast.error("Failed to delete");
+      }
+      return;
     }
-  }, [deleteConfirmId, removeNote, setDeleteConfirmId]);
+
+    const idsToDelete = getTopLevelSelectedIds(target.ids, tree);
+    let deletedCount = 0;
+    let failedCount = 0;
+    const deletedIds = new Set<string>();
+
+    for (const id of idsToDelete) {
+      try {
+        await removeNote(id);
+        deletedCount += 1;
+        deletedIds.add(id);
+      } catch {
+        failedCount += 1;
+      }
+    }
+
+    if (failedCount === 0) {
+      setSelectedIds(new Set());
+      onDeleteSelectionCleared();
+      if (
+        activeId &&
+        idsToDelete.some(
+          (id) => id === activeId || treeItemContainsId(tree, id, activeId),
+        )
+      ) {
+        router.push("/notes");
+      }
+      return;
+    }
+
+    if (deletedCount > 0) {
+      toast.error(
+        `Deleted ${deletedCount} items. Failed to delete ${failedCount} items.`,
+      );
+      const remainingSelection = new Set(
+        target.ids.filter(
+          (id) =>
+            !Array.from(deletedIds).some(
+              (deletedId) =>
+                deletedId === id || treeItemContainsId(tree, deletedId, id),
+            ),
+        ),
+      );
+      setSelectedIds(remainingSelection);
+      await refreshTree();
+      return;
+    }
+
+    toast.error("Failed to delete selected items.");
+    setSelectedIds(new Set(target.ids));
+    await refreshTree();
+  }, [
+    activeId,
+    deleteConfirmTarget,
+    onDeleteSelectionCleared,
+    refreshTree,
+    removeNote,
+    router,
+    setDeleteConfirmTarget,
+    setSelectedIds,
+    tree,
+  ]);
 
   // duplicate a note
   const handleDuplicate = useCallback(
@@ -274,11 +382,28 @@ export function useSidebarActions(deps: {
       isPinned: boolean,
     ) => {
       e.preventDefault();
+      const selectedGroup =
+        selectedIds.has(itemId) && selectedIds.size > 1
+          ? Array.from(selectedIds).filter((id) => id !== "root")
+          : [itemId];
+
+      if (selectedGroup.length === 1) {
+        setSelectedIds(new Set([itemId]));
+        setSelectionAnchorId(itemId);
+      }
+
       useContextMenuStore
         .getState()
-        .setOpenMenu(itemId, e.clientX, e.clientY, isFolder, isPinned);
+        .setOpenMenu(
+          itemId,
+          e.clientX,
+          e.clientY,
+          isFolder,
+          isPinned,
+          selectedGroup,
+        );
     },
-    [],
+    [selectedIds, setSelectedIds, setSelectionAnchorId],
   );
 
   // drag and drop handler
@@ -380,6 +505,7 @@ export function useSidebarActions(deps: {
     handleCollapseAll,
     handleRename,
     handleDeleteRequest,
+    handleBulkDeleteRequest,
     handleDeleteConfirm,
     handleDuplicate,
     handleTogglePin,

--- a/src/lib/notes/state/context-menu.ts
+++ b/src/lib/notes/state/context-menu.ts
@@ -1,11 +1,20 @@
-import { create } from 'zustand';
+import { create } from "zustand";
 
 interface ContextMenuState {
   openMenuId: string | null;
   position: { x: number; y: number };
   isFolder: boolean;
   isPinned: boolean;
-  setOpenMenu: (id: string, x: number, y: number, isFolder: boolean, isPinned: boolean) => void;
+  selectedCount: number;
+  selectionIds: string[];
+  setOpenMenu: (
+    id: string,
+    x: number,
+    y: number,
+    isFolder: boolean,
+    isPinned: boolean,
+    selectionIds?: string[],
+  ) => void;
   closeMenu: () => void;
 }
 
@@ -14,8 +23,19 @@ const useContextMenuStore = create<ContextMenuState>((set) => ({
   position: { x: 0, y: 0 },
   isFolder: false,
   isPinned: false,
-  setOpenMenu: (id, x, y, isFolder, isPinned) => set({ openMenuId: id, position: { x, y }, isFolder, isPinned }),
-  closeMenu: () => set({ openMenuId: null }),
+  selectedCount: 0,
+  selectionIds: [],
+  setOpenMenu: (id, x, y, isFolder, isPinned, selectionIds = [id]) =>
+    set({
+      openMenuId: id,
+      position: { x, y },
+      isFolder,
+      isPinned,
+      selectionIds,
+      selectedCount: selectionIds.length,
+    }),
+  closeMenu: () =>
+    set({ openMenuId: null, selectionIds: [], selectedCount: 0 }),
 }));
 
 export default useContextMenuStore;


### PR DESCRIPTION
## Summary

- Add familiar Ctrl/Cmd and Shift multi-select behavior to the notes sidebar.

- Add bulk delete confirmation and top-level selected item filtering so selected descendants are not deleted twice.
- Keep single-item sidebar actions, context menu actions, and drag behavior intact.



## Validation
- npm run lint:all






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-select capability to the notes sidebar with Shift+click for range selection and Ctrl/Meta+click for toggle selection.
  * Added bulk deletion of multiple notes and folders with visual selection indicators.
  * Updated context menu to display "Delete selected" option when multiple items are selected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/semyonfox/oghma/pull/281)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->