### PR TITLE
vault import/export hardening: retries, progress, 409 conflict, cancellation

### DIFF
--- a/database/migrations/029_vault_progress_and_cancel.sql
+++ b/database/migrations/029_vault_progress_and_cancel.sql
@@ -1,0 +1,8 @@
+-- 029: vault job progress + cooperative cancellation
+ALTER TABLE app.canvas_import_jobs
+  ADD COLUMN IF NOT EXISTS processed_files INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS cancel_requested_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_canvas_import_jobs_cancel
+  ON app.canvas_import_jobs (id)
+  WHERE cancel_requested_at IS NOT NULL;

--- a/docs/superpowers/plans/2026-05-13-vault-jobs-hardening.md
+++ b/docs/superpowers/plans/2026-05-13-vault-jobs-hardening.md
@@ -1,0 +1,1108 @@
+# Vault Jobs Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the seven hardening gaps in the vault import/export system: configurable SMTP (self-host blocker), BullMQ retries, export per-file progress, 409-on-conflict, explicit cancellation, RAG opt-out, and orphan cleanup for failed imports.
+
+**Architecture:** Each task is independently shippable. Tasks 0-3 are quick wins (≤30 min each); Task 4 (cancellation) is the largest and depends on Task 3 (the worker needs a place to check for cancellation between files, which the existing `processed % 50` block in `export-worker.js:194-197` already provides). Tasks 5-6 are independent of everything else.
+
+**Tech Stack:** Next.js App Router API routes, BullMQ + Redis, AWS SDK v3 S3 client (MinIO-compatible), `nodemailer` SMTP, Postgres via `@/database/pgsql.js`, vitest for tests.
+
+**Test pattern:** Mirror `src/__tests__/api/canvas-status.test.ts` — mock `@/database/pgsql.js` and `@/lib/api-error`, import the route handler, call with a `NextRequest`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/lib/email.js` | Modify | Read SMTP host/port/secure from env so self-host works without SES |
+| `src/lib/queue.ts` | Modify (line 41-45) | Bump `attempts` to 3 with backoff for vault jobs |
+| `database/migrations/029_vault_progress_and_cancel.sql` | Create | Add `processed_files`, `cancel_requested_at` to `app.canvas_import_jobs` |
+| `src/lib/vault/export-worker.js` | Modify (lines 194-197) | Persist `processed_files`; check `cancel_requested_at` between files |
+| `src/lib/vault/import-worker.js` | Modify (lines 366-368) | Persist `processed_files`; check `cancel_requested_at` between entries; honor `skip_rag` flag |
+| `src/app/api/vault/status/route.ts` | Modify | Surface `processed_files` for exports; expose `cancel_requested` flag |
+| `src/app/api/vault/export/route.ts` | Modify | Return 409 if active job exists unless `?force=true` |
+| `src/app/api/vault/import/start/route.ts` | Modify | Return 409 if active job exists unless `force=true`; pass `skipRAG` into job payload |
+| `src/app/api/vault/jobs/[jobId]/cancel/route.ts` | Create | DELETE endpoint — sets `cancel_requested_at` |
+| `src/components/settings/data-export-section.jsx` | Modify | Add "Cancel" button, handle 409 with confirm-and-force prompt, show export `processed/total` |
+| `src/__tests__/api/vault-export.test.ts` | Create | Coverage for export route conflict + cancel |
+| `src/__tests__/api/vault-import-start.test.ts` | Create | Coverage for import start route conflict + skipRAG |
+| `src/__tests__/api/vault-cancel.test.ts` | Create | Coverage for cancel endpoint |
+| `src/__tests__/api/vault-status.test.ts` | Create | Coverage for new status response shape |
+
+---
+
+## Task 0: Configurable SMTP host (self-host unblock)
+
+**Why:** `src/lib/email.js:7` hardcodes `email-smtp.${sesRegion}.amazonaws.com` — fine for AWS, but a blocker if you deploy off AWS (MinIO + your own Postfix/Mailgun/local mail). Adding three env vars makes the transport portable; SES remains the default when they're unset.
+
+**Files:**
+- Modify: `src/lib/email.js:4-16`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/lib/email-transport.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+describe("email transport configuration", () => {
+  const original = { ...process.env };
+
+  beforeEach(() => {
+    for (const k of Object.keys(process.env)) {
+      if (k.startsWith("SMTP_") || k.startsWith("SES_") || k.startsWith("AWS_SES_")) {
+        delete process.env[k];
+      }
+    }
+  });
+
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  it("uses SMTP_HOST when set", async () => {
+    process.env.SMTP_HOST = "smtp.example.com";
+    process.env.SMTP_PORT = "2525";
+    process.env.SMTP_SECURE = "true";
+    process.env.SMTP_USER = "u";
+    process.env.SMTP_PASS = "p";
+    const { _getTransportOptions } = await import("@/lib/email");
+    const opts = _getTransportOptions();
+    expect(opts.host).toBe("smtp.example.com");
+    expect(opts.port).toBe(2525);
+    expect(opts.secure).toBe(true);
+    expect(opts.auth).toEqual({ user: "u", pass: "p" });
+  });
+
+  it("falls back to SES SMTP host when SMTP_HOST is unset", async () => {
+    process.env.SES_REGION = "us-west-2";
+    process.env.SES_ACCESS_KEY_ID = "k";
+    process.env.SES_SECRET_ACCESS_KEY = "s";
+    const { _getTransportOptions } = await import("@/lib/email");
+    const opts = _getTransportOptions();
+    expect(opts.host).toBe("email-smtp.us-west-2.amazonaws.com");
+    expect(opts.port).toBe(587);
+    expect(opts.secure).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/lib/email-transport.test.ts`
+Expected: FAIL with `_getTransportOptions is not a function`
+
+- [ ] **Step 3: Implement the change in `src/lib/email.js`**
+
+Replace lines 1-16 with:
+
+```javascript
+import nodemailer from "nodemailer";
+
+// Amplify blocks AWS_ prefixed env vars, so fall back to SES_ prefix
+const sesRegion =
+  process.env.AWS_SES_REGION || process.env.SES_REGION || "eu-west-1";
+
+// Exported for tests; not part of the public API.
+export function _getTransportOptions() {
+  const host = process.env.SMTP_HOST || `email-smtp.${sesRegion}.amazonaws.com`;
+  const port = parseInt(process.env.SMTP_PORT || "587", 10);
+  const secure = (process.env.SMTP_SECURE || "false").toLowerCase() === "true";
+  const user =
+    process.env.SMTP_USER ||
+    process.env.AWS_SES_ACCESS_KEY_ID ||
+    process.env.SES_ACCESS_KEY_ID;
+  const pass =
+    process.env.SMTP_PASS ||
+    process.env.AWS_SES_SECRET_ACCESS_KEY ||
+    process.env.SES_SECRET_ACCESS_KEY;
+  return { host, port, secure, auth: { user, pass } };
+}
+
+const transporter = nodemailer.createTransport(_getTransportOptions());
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/__tests__/lib/email-transport.test.ts`
+Expected: PASS (both cases)
+
+- [ ] **Step 5: Update self-host docs**
+
+Append to `README.md` (or `SETUP.md` if it has an env section):
+
+```markdown
+## Self-hosted email (alternative to AWS SES)
+
+Set these env vars to point at any SMTP server:
+
+- `SMTP_HOST` (e.g. `smtp.mailgun.org`, `localhost`)
+- `SMTP_PORT` (default `587`)
+- `SMTP_SECURE` (`true` for port 465 TLS, `false` for STARTTLS)
+- `SMTP_USER`, `SMTP_PASS`
+
+If `SMTP_HOST` is unset, falls back to AWS SES at `email-smtp.${SES_REGION}.amazonaws.com`.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/email.js src/__tests__/lib/email-transport.test.ts README.md
+git commit -m "make smtp transport configurable for self-hosted deployments"
+```
+
+---
+
+## Task 1: BullMQ retry with backoff
+
+**Why:** `src/lib/queue.ts:44` has `attempts: 1` — any transient network blip during a 5-min export becomes a hard failure. Three attempts with exponential backoff (1s, 5s, 25s) catches the vast majority of transient issues without making bad jobs loop forever.
+
+**Files:**
+- Modify: `src/lib/queue.ts:41-45`
+
+- [ ] **Step 1: Make the change**
+
+Replace `src/lib/queue.ts:41-45`:
+
+```typescript
+// keep the last 200 completed/failed jobs for observability; older are pruned
+const DEFAULT_OPTS: JobsOptions = {
+  removeOnComplete: { count: 200 },
+  removeOnFail: { count: 200 },
+  attempts: 3,
+  backoff: { type: "exponential", delay: 1000 },
+};
+```
+
+- [ ] **Step 2: Verify type compiles**
+
+Run: `npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 3: Note the worker idempotency requirement**
+
+Add this comment above `DEFAULT_OPTS`:
+
+```typescript
+// Workers MUST be idempotent: attempts > 1 means a job may re-run mid-processing.
+// Vault import/export workers handle this by checking job.status before mutating DB state
+// and by re-using deterministic S3 keys (vault/{userId}/{jobId}/...).
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/queue.ts
+git commit -m "retry vault/canvas jobs 3x with exponential backoff"
+```
+
+---
+
+## Task 2: Persist export progress + surface in status response
+
+**Why:** Export worker (`export-worker.js:194`) increments a local `processed` counter but never writes it to the DB. Status response (`status/route.ts:91-104`) returns no progress for exports. Adding a `processed_files` column lets the UI show "Exported 312/847 files" mirroring what import already does. This column also becomes the natural place for the cancellation check in Task 4 (worker is already there every 50 files).
+
+**Files:**
+- Create: `database/migrations/029_vault_progress_and_cancel.sql`
+- Modify: `src/lib/vault/export-worker.js:194-198`
+- Modify: `src/lib/vault/import-worker.js` (the progress write site near line 366)
+- Modify: `src/app/api/vault/status/route.ts:23-31, 65-89`
+- Modify: `src/components/settings/data-export-section.jsx` (export progress display)
+- Create: `src/__tests__/api/vault-status.test.ts`
+
+- [ ] **Step 1: Write the migration**
+
+Create `database/migrations/029_vault_progress_and_cancel.sql`:
+
+```sql
+-- 029: vault job progress + cooperative cancellation
+ALTER TABLE app.canvas_import_jobs
+  ADD COLUMN IF NOT EXISTS processed_files INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS cancel_requested_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_canvas_import_jobs_cancel
+  ON app.canvas_import_jobs (id)
+  WHERE cancel_requested_at IS NOT NULL;
+```
+
+- [ ] **Step 2: Apply the migration locally**
+
+Run: `npm run migrate`
+Expected: `applied 029_vault_progress_and_cancel.sql`
+
+- [ ] **Step 3: Update export worker to persist progress**
+
+In `src/lib/vault/export-worker.js`, replace lines 194-198:
+
+```javascript
+        processed++;
+        if (processed % 50 === 0) {
+          await sql`
+            UPDATE app.canvas_import_jobs
+            SET processed_files = ${processed}, updated_at = NOW()
+            WHERE id = ${jobId}::uuid
+          `;
+          console.log(`[${ts()}] Exported ${processed}/${totalFiles} files`);
+        }
+```
+
+Also after the loop ends but before `zip.end()` (around line 205), add a final flush:
+
+```javascript
+    await sql`
+      UPDATE app.canvas_import_jobs
+      SET processed_files = ${processed}
+      WHERE id = ${jobId}::uuid
+    `;
+```
+
+- [ ] **Step 4: Update import worker to persist progress**
+
+In `src/lib/vault/import-worker.js`, find the existing every-10-files update (search for `expected_total` near line 366) and add `processed_files` to that same `UPDATE` so we use one query, not two:
+
+```javascript
+        if (totalFiles % 10 === 0) {
+          await sql`
+            UPDATE app.canvas_import_jobs
+            SET expected_total = ${totalFiles},
+                processed_files = ${totalFiles},
+                updated_at = NOW()
+            WHERE id = ${jobId}::uuid
+          `;
+        }
+```
+
+- [ ] **Step 5: Write the failing status route test**
+
+Create `src/__tests__/api/vault-status.test.ts`:
+
+```typescript
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/database/pgsql.js", () => {
+  const sqlMock = vi.fn();
+  sqlMock.mockResolvedValue([]);
+  return { default: sqlMock };
+});
+
+vi.mock("@/lib/api-error", () => ({
+  requireAuth: vi.fn(),
+  withErrorHandler: (handler: () => Promise<Response>) => handler,
+  ApiError: class extends Error {
+    constructor(public status: number, msg: string) { super(msg); }
+  },
+}));
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: class { send() {} },
+  GetObjectCommand: class { constructor(public input: unknown) {} },
+}));
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: vi.fn().mockResolvedValue("https://signed.example/file.zip"),
+}));
+
+import sql from "@/database/pgsql.js";
+import { requireAuth } from "@/lib/api-error";
+import { GET } from "@/app/api/vault/status/route";
+
+describe("GET /api/vault/status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAuth).mockResolvedValue({ user_id: "u1" } as never);
+    process.env.STORAGE_BUCKET = "test";
+  });
+
+  it("returns export progress with processed_files", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([
+      {
+        id: "j1",
+        type: "vault-export",
+        status: "processing",
+        created_at: "2026-05-13T00:00:00Z",
+        started_at: "2026-05-13T00:00:01Z",
+        completed_at: null,
+        expected_total: 100,
+        processed_files: 42,
+        cancel_requested_at: null,
+        output_s3_key: null,
+        download_url: null,
+        error_message: null,
+      },
+    ] as never);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/vault/status?type=vault-export"),
+    );
+    const body = await res.json();
+
+    expect(body.progress).toEqual({ completed: 42, total: 100, percent: 42 });
+    expect(body.job.cancelRequested).toBe(false);
+  });
+
+  it("flags cancelRequested when cancel_requested_at is set", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([
+      {
+        id: "j1",
+        type: "vault-import",
+        status: "processing",
+        created_at: "2026-05-13T00:00:00Z",
+        started_at: "2026-05-13T00:00:01Z",
+        completed_at: null,
+        expected_total: 10,
+        processed_files: 3,
+        cancel_requested_at: "2026-05-13T00:01:00Z",
+        output_s3_key: null,
+        download_url: null,
+        error_message: null,
+      },
+    ] as never);
+    vi.mocked(sql).mockResolvedValueOnce([{ total: "3" }] as never);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/vault/status?type=vault-import"),
+    );
+    const body = await res.json();
+
+    expect(body.job.cancelRequested).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 6: Run test, confirm it fails**
+
+Run: `npx vitest run src/__tests__/api/vault-status.test.ts`
+Expected: FAIL (response missing `cancelRequested`, export progress is null)
+
+- [ ] **Step 7: Update `src/app/api/vault/status/route.ts`**
+
+Replace lines 23-31 (the SQL `SELECT`):
+
+```typescript
+  const [job] = await sql`
+    SELECT id, type, status, created_at, started_at, completed_at,
+           expected_total, processed_files, cancel_requested_at,
+           error_message, output_s3_key, download_url
+    FROM app.canvas_import_jobs
+    WHERE user_id = ${user.user_id}
+      AND type = ${type}
+    ORDER BY created_at DESC
+    LIMIT 1
+  `;
+```
+
+Replace lines 65-89 (the progress block):
+
+```typescript
+  // unified progress for both import and export
+  let progress = null;
+  if (["processing", "complete"].includes(job.status)) {
+    const completed = job.processed_files ?? 0;
+    const total = job.expected_total ?? 0;
+    progress = {
+      completed,
+      total,
+      percent: total > 0
+        ? Math.min(100, Math.round((completed / total) * 100))
+        : null,
+    };
+  }
+```
+
+Replace the response object (line 91-104):
+
+```typescript
+  return NextResponse.json({
+    job: {
+      jobId: job.id,
+      type: job.type,
+      status: job.status,
+      createdAt: job.created_at,
+      startedAt: job.started_at,
+      completedAt: job.completed_at,
+      expectedTotal: job.expected_total,
+      cancelRequested: !!job.cancel_requested_at,
+      error: job.error_message,
+    },
+    downloadUrl,
+    progress,
+  });
+```
+
+- [ ] **Step 8: Run test, confirm it passes**
+
+Run: `npx vitest run src/__tests__/api/vault-status.test.ts`
+Expected: PASS (both cases)
+
+- [ ] **Step 9: Update UI to show export progress**
+
+In `src/components/settings/data-export-section.jsx`, find the export status block (the part rendered when `exportJob?.status === "processing"`) and use the new `progress` field the same way import already does — `{progress.completed}/{progress.total} files exported · {progress.percent}%`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add database/migrations/029_vault_progress_and_cancel.sql \
+        src/lib/vault/export-worker.js src/lib/vault/import-worker.js \
+        src/app/api/vault/status/route.ts \
+        src/components/settings/data-export-section.jsx \
+        src/__tests__/api/vault-status.test.ts
+git commit -m "persist and surface vault export progress; add cancel_requested_at column"
+```
+
+---
+
+## Task 3: 409 on conflict with `?force=true` override
+
+**Why:** Currently `POST /api/vault/export` silently cancels the in-flight job and starts a new one (`export/route.ts:16-23`). Two confused clicks = lost work with no warning. Returning 409 with `{ activeJobId }` lets the UI prompt the user; `?force=true` keeps the existing replace-and-restart behavior as an explicit opt-in.
+
+**Files:**
+- Modify: `src/app/api/vault/export/route.ts:1-47`
+- Modify: `src/app/api/vault/import/start/route.ts:1-61`
+- Modify: `src/components/settings/data-export-section.jsx` (handle 409)
+- Create: `src/__tests__/api/vault-export.test.ts`
+- Create: `src/__tests__/api/vault-import-start.test.ts`
+
+- [ ] **Step 1: Write the failing test for export**
+
+Create `src/__tests__/api/vault-export.test.ts`:
+
+```typescript
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/database/pgsql.js", () => {
+  const sqlMock = vi.fn() as unknown as { begin: ReturnType<typeof vi.fn> } & ReturnType<typeof vi.fn>;
+  sqlMock.mockResolvedValue([]);
+  sqlMock.begin = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(sqlMock));
+  return { default: sqlMock };
+});
+
+vi.mock("@/lib/api-error", () => ({
+  requireAuth: vi.fn(),
+  withErrorHandler: (handler: (req: NextRequest) => Promise<Response>) => handler,
+  ApiError: class extends Error {
+    constructor(public status: number, msg: string) { super(msg); }
+  },
+}));
+
+vi.mock("@/lib/queue", () => ({
+  enqueueCanvasJob: vi.fn().mockResolvedValue(undefined),
+}));
+
+import sql from "@/database/pgsql.js";
+import { requireAuth } from "@/lib/api-error";
+import { POST } from "@/app/api/vault/export/route";
+
+describe("POST /api/vault/export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAuth).mockResolvedValue({ user_id: "u1" } as never);
+  });
+
+  it("returns 409 when an active export already exists", async () => {
+    // First call: SELECT for existing active job — returns one
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "existing-job" }] as never);
+
+    const res = await POST(new NextRequest("http://localhost/api/vault/export", { method: "POST" }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.activeJobId).toBe("existing-job");
+  });
+
+  it("cancels existing job and starts new one when force=true", async () => {
+    // SELECT returns active job
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "existing-job" }] as never);
+    // UPDATE to cancel
+    vi.mocked(sql).mockResolvedValueOnce([] as never);
+    // INSERT for new job
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "new-job" }] as never);
+
+    const res = await POST(new NextRequest("http://localhost/api/vault/export?force=true", { method: "POST" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jobId).toBe("new-job");
+  });
+
+  it("starts immediately when no active job exists", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([] as never); // no active job
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "new-job" }] as never); // insert
+
+    const res = await POST(new NextRequest("http://localhost/api/vault/export", { method: "POST" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jobId).toBe("new-job");
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm it fails**
+
+Run: `npx vitest run src/__tests__/api/vault-export.test.ts`
+Expected: FAIL (no 409 path)
+
+- [ ] **Step 3: Update `src/app/api/vault/export/route.ts`**
+
+Replace the entire file with:
+
+```typescript
+import { NextResponse } from "next/server";
+import { withErrorHandler, requireAuth } from "@/lib/api-error";
+import sql from "@/database/pgsql.js";
+import { enqueueCanvasJob } from "@/lib/queue";
+
+export const POST = withErrorHandler(async (request) => {
+  const user = await requireAuth();
+  const { searchParams } = new URL(request.url);
+  const force = searchParams.get("force") === "true";
+
+  const [existing] = await sql`
+    SELECT id FROM app.canvas_import_jobs
+    WHERE user_id = ${user.user_id}
+      AND type = 'vault-export'
+      AND status IN ('queued', 'processing')
+    LIMIT 1
+  `;
+
+  if (existing && !force) {
+    return NextResponse.json(
+      { error: "Export already in progress", activeJobId: existing.id },
+      { status: 409 },
+    );
+  }
+
+  const jobId = await sql.begin(async (tx) => {
+    if (existing) {
+      await tx`
+        UPDATE app.canvas_import_jobs
+        SET status = 'cancelled', completed_at = NOW()
+        WHERE user_id = ${user.user_id}
+          AND type = 'vault-export'
+          AND status IN ('queued', 'processing')
+      `;
+    }
+    const [row] = await tx`
+      INSERT INTO app.canvas_import_jobs (user_id, type, status, job_type)
+      VALUES (${user.user_id}, 'vault-export', 'queued', 'export')
+      RETURNING id
+    `;
+    return row.id;
+  });
+
+  await enqueueCanvasJob("vault-export", { jobId, userId: user.user_id });
+  return NextResponse.json({ jobId });
+});
+```
+
+- [ ] **Step 4: Run test, confirm it passes**
+
+Run: `npx vitest run src/__tests__/api/vault-export.test.ts`
+Expected: PASS (all three cases)
+
+- [ ] **Step 5: Write the failing test for import start**
+
+Create `src/__tests__/api/vault-import-start.test.ts` — same pattern as export test above, but for `@/app/api/vault/import/start/route`. Three cases: 409 on active, force=true override, immediate start. Use a body like `{ s3Key: "vault-uploads/u1/abc/x.zip" }`.
+
+```typescript
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/database/pgsql.js", () => {
+  const sqlMock = vi.fn() as unknown as { begin: ReturnType<typeof vi.fn> } & ReturnType<typeof vi.fn>;
+  sqlMock.mockResolvedValue([]);
+  sqlMock.begin = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(sqlMock));
+  return { default: sqlMock };
+});
+vi.mock("@/lib/api-error", () => ({
+  requireAuth: vi.fn(),
+  withErrorHandler: (h: (r: NextRequest) => Promise<Response>) => h,
+  ApiError: class extends Error { constructor(public status: number, msg: string) { super(msg); } },
+}));
+vi.mock("@/lib/queue", () => ({ enqueueCanvasJob: vi.fn().mockResolvedValue(undefined) }));
+
+import sql from "@/database/pgsql.js";
+import { requireAuth } from "@/lib/api-error";
+import { POST } from "@/app/api/vault/import/start/route";
+
+const body = (data: Record<string, unknown>) =>
+  new NextRequest("http://localhost/api/vault/import/start", {
+    method: "POST",
+    body: JSON.stringify(data),
+    headers: { "content-type": "application/json" },
+  });
+
+describe("POST /api/vault/import/start", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAuth).mockResolvedValue({ user_id: "u1" } as never);
+  });
+
+  it("returns 409 when active import exists", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "existing" }] as never);
+    const res = await POST(body({ s3Key: "vault-uploads/u1/abc/x.zip" }));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ activeJobId: "existing" });
+  });
+
+  it("passes skipRAG flag through to job payload", async () => {
+    const { enqueueCanvasJob } = await import("@/lib/queue");
+    vi.mocked(sql).mockResolvedValueOnce([] as never); // no active
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "new" }] as never); // insert
+    await POST(body({ s3Key: "vault-uploads/u1/abc/x.zip", skipRAG: true }));
+    expect(enqueueCanvasJob).toHaveBeenCalledWith(
+      "vault-import",
+      expect.objectContaining({ skipRAG: true }),
+    );
+  });
+});
+```
+
+- [ ] **Step 6: Run test, confirm it fails**
+
+Run: `npx vitest run src/__tests__/api/vault-import-start.test.ts`
+Expected: FAIL (no 409, no skipRAG)
+
+- [ ] **Step 7: Update `src/app/api/vault/import/start/route.ts`**
+
+Apply the same pattern: read body, optionally read `body.force`, return 409 if active and not force, then `INSERT` + `enqueueCanvasJob("vault-import", { jobId, userId, s3Key, skipRAG: !!body.skipRAG })`.
+
+- [ ] **Step 8: Run test, confirm it passes**
+
+Run: `npx vitest run src/__tests__/api/vault-import-start.test.ts`
+Expected: PASS
+
+- [ ] **Step 9: Update UI to handle 409**
+
+In `src/components/settings/data-export-section.jsx`, in `handleVaultExport()` (around line 130) and the import upload completion handler (around line 105-114), after the `fetch` call, check `res.status === 409` and prompt:
+
+```javascript
+if (res.status === 409) {
+  const body = await res.json();
+  const confirm = window.confirm(
+    "An export is already in progress. Cancel it and start a new one?"
+  );
+  if (!confirm) return;
+  const retry = await fetch("/api/vault/export?force=true", { method: "POST" });
+  // ...continue with retry response
+}
+```
+
+Same logic for import — send `{ s3Key, force: true }` in the retry body.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/app/api/vault/export/route.ts \
+        src/app/api/vault/import/start/route.ts \
+        src/components/settings/data-export-section.jsx \
+        src/__tests__/api/vault-export.test.ts \
+        src/__tests__/api/vault-import-start.test.ts
+git commit -m "return 409 on vault job conflict; honor ?force=true for explicit replace"
+```
+
+---
+
+## Task 4: Cooperative cancellation endpoint
+
+**Why:** No way to stop a long-running import. Adding a cancel endpoint that sets `cancel_requested_at`, plus a worker check between files, gives users a real stop button. Cooperative (not preemptive) — the worker decides when to exit cleanly, so partial state is consistent. Depends on Task 2's `cancel_requested_at` column.
+
+**Files:**
+- Create: `src/app/api/vault/jobs/[jobId]/cancel/route.ts`
+- Modify: `src/lib/vault/export-worker.js` (cancel check inside the file loop, around line 194)
+- Modify: `src/lib/vault/import-worker.js` (cancel check inside the entry loop, around line 366)
+- Modify: `src/components/settings/data-export-section.jsx` (Cancel button)
+- Create: `src/__tests__/api/vault-cancel.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/api/vault-cancel.test.ts`:
+
+```typescript
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/database/pgsql.js", () => {
+  const sqlMock = vi.fn();
+  sqlMock.mockResolvedValue([]);
+  return { default: sqlMock };
+});
+vi.mock("@/lib/api-error", () => ({
+  requireAuth: vi.fn(),
+  withErrorHandler: (h: (r: NextRequest, ctx: { params: { jobId: string } }) => Promise<Response>) => h,
+  ApiError: class extends Error { constructor(public status: number, msg: string) { super(msg); } },
+}));
+
+import sql from "@/database/pgsql.js";
+import { requireAuth } from "@/lib/api-error";
+import { DELETE } from "@/app/api/vault/jobs/[jobId]/cancel/route";
+
+describe("DELETE /api/vault/jobs/[jobId]/cancel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAuth).mockResolvedValue({ user_id: "u1" } as never);
+  });
+
+  it("sets cancel_requested_at and returns 200", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "j1" }] as never);
+    const req = new NextRequest("http://localhost/api/vault/jobs/j1/cancel", { method: "DELETE" });
+    const res = await DELETE(req, { params: { jobId: "j1" } } as never);
+    expect(res.status).toBe(200);
+    expect(vi.mocked(sql)).toHaveBeenCalled();
+  });
+
+  it("returns 404 when job not found or not owned by user", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([] as never);
+    const req = new NextRequest("http://localhost/api/vault/jobs/x/cancel", { method: "DELETE" });
+    const res = await DELETE(req, { params: { jobId: "x" } } as never);
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm it fails**
+
+Run: `npx vitest run src/__tests__/api/vault-cancel.test.ts`
+Expected: FAIL (module not found)
+
+- [ ] **Step 3: Create the route**
+
+Create `src/app/api/vault/jobs/[jobId]/cancel/route.ts`:
+
+```typescript
+import { NextResponse } from "next/server";
+import { withErrorHandler, requireAuth, ApiError } from "@/lib/api-error";
+import sql from "@/database/pgsql.js";
+
+export const DELETE = withErrorHandler(
+  async (_request, { params }: { params: { jobId: string } }) => {
+    const user = await requireAuth();
+    const { jobId } = params;
+
+    const [updated] = await sql`
+      UPDATE app.canvas_import_jobs
+      SET cancel_requested_at = NOW(), updated_at = NOW()
+      WHERE id = ${jobId}::uuid
+        AND user_id = ${user.user_id}
+        AND status IN ('queued', 'processing')
+        AND cancel_requested_at IS NULL
+      RETURNING id
+    `;
+
+    if (!updated) {
+      throw new ApiError(404, "Job not found or not cancellable");
+    }
+
+    return NextResponse.json({ ok: true, jobId: updated.id });
+  },
+);
+```
+
+- [ ] **Step 4: Run test, confirm it passes**
+
+Run: `npx vitest run src/__tests__/api/vault-cancel.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Add cancel check to export worker**
+
+In `src/lib/vault/export-worker.js`, modify the loop's every-50-files block (now from Task 2):
+
+```javascript
+        processed++;
+        if (processed % 50 === 0) {
+          const [cancelRow] = await sql`
+            SELECT cancel_requested_at FROM app.canvas_import_jobs
+            WHERE id = ${jobId}::uuid
+          `;
+          if (cancelRow?.cancel_requested_at) {
+            console.log(`[${ts()}] Cancel requested for ${jobId}; aborting after ${processed} files`);
+            await uploader.abort();
+            await sql`
+              UPDATE app.canvas_import_jobs
+              SET status = 'cancelled', completed_at = NOW(), processed_files = ${processed}
+              WHERE id = ${jobId}::uuid
+            `;
+            return; // exit the worker function
+          }
+          await sql`
+            UPDATE app.canvas_import_jobs
+            SET processed_files = ${processed}, updated_at = NOW()
+            WHERE id = ${jobId}::uuid
+          `;
+          console.log(`[${ts()}] Exported ${processed}/${totalFiles} files`);
+        }
+```
+
+- [ ] **Step 6: Add cancel check to import worker**
+
+In `src/lib/vault/import-worker.js`, find the every-10-files progress update (now updated in Task 2) and add the same pattern: before the update, `SELECT cancel_requested_at`; if set, mark job `cancelled` and `return` from the worker. The S3-uploaded files and any partial notes remain (the cleanup is Task 6's job, optional).
+
+- [ ] **Step 7: Add Cancel button to UI**
+
+In `src/components/settings/data-export-section.jsx`, when an active job is showing (`status === "processing"` or `"queued"`), render a cancel button:
+
+```jsx
+{(exportJob?.status === "processing" || exportJob?.status === "queued") && (
+  <button
+    onClick={async () => {
+      if (!window.confirm("Cancel the export? Partial output will be discarded.")) return;
+      await fetch(`/api/vault/jobs/${exportJob.jobId}/cancel`, { method: "DELETE" });
+      toast.info("Cancel requested. The job will stop shortly.");
+    }}
+    disabled={exportJob.cancelRequested}
+  >
+    {exportJob.cancelRequested ? "Cancelling..." : "Cancel"}
+  </button>
+)}
+```
+
+Same for import.
+
+- [ ] **Step 8: Verify type check still passes**
+
+Run: `npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 9: Run the test suite**
+
+Run: `npx vitest run src/__tests__/api/`
+Expected: all green
+
+- [ ] **Step 10: Manual smoke test**
+
+In dev:
+1. Start a large import (>200 files)
+2. Hit cancel from the UI within 5 seconds
+3. Within 10s (next 10-file checkpoint) the status flips to `cancelled` and the worker logs `Cancel requested for ...; aborting after N entries`
+
+If `npm run dev` isn't running or there's no large test fixture, skip and note this in the PR description.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/app/api/vault/jobs/[jobId]/cancel/route.ts \
+        src/lib/vault/export-worker.js src/lib/vault/import-worker.js \
+        src/components/settings/data-export-section.jsx \
+        src/__tests__/api/vault-cancel.test.ts
+git commit -m "support cooperative cancellation for vault import/export jobs"
+```
+
+---
+
+## Task 5: `skipRAG` import opt-out
+
+**Why:** Today every imported PDF/DOCX gets pushed through Marker OCR + chunking + Cohere embeddings, which is expensive and slow. A user migrating data from another tool may not want any of that, just the file tree. A simple flag on the import-start request, plumbed through to the worker, lets them opt out. RAG remains the default.
+
+**Files:**
+- Modify: `src/app/api/vault/import/start/route.ts` (already touched in Task 3 to read `skipRAG` from body)
+- Modify: `src/lib/vault/import-worker.js` (around line 350-362 — the RAG dispatch)
+- Modify: `src/components/settings/data-export-section.jsx` (checkbox in import dialog)
+
+- [ ] **Step 1: Add the worker guard**
+
+In `src/lib/vault/import-worker.js`, find the block around line 350-362 that calls `extractWithMarker` / `chunkText`. Wrap it:
+
+```javascript
+        if (!msg.skipRAG && isProcessable(cleanPath)) {
+          // existing RAG pipeline call
+        }
+```
+
+- [ ] **Step 2: Write the worker behavior test**
+
+Since worker tests in this repo tend to be smoke-only (BullMQ + Redis + S3 + DB integration), add a unit test for the `isProcessable` decision instead, asserting it's bypassed when `skipRAG` is true. Or — easier — extend the existing `vault-import-start.test.ts` (already in Task 3) to confirm the flag is forwarded; the worker check is a one-line `if`.
+
+If you want an actual worker test, mock the RAG entry point and assert it's not called:
+
+```typescript
+// src/__tests__/lib/import-worker-skip-rag.test.ts
+import { describe, it, expect, vi } from "vitest";
+
+// Mock everything heavy first
+vi.mock("@/lib/storage/s3", () => ({ getStorageProvider: vi.fn() }));
+vi.mock("@/database/pgsql.js", () => ({ default: vi.fn() }));
+vi.mock("@/lib/vault/rag-pipeline", () => ({ runRagPipeline: vi.fn() }));
+// ...
+
+import { runRagPipeline } from "@/lib/vault/rag-pipeline";
+// import the worker and call its file-processing helper with skipRAG=true
+// assert runRagPipeline was NOT called
+```
+
+(Choose whichever route fits the codebase; if `rag-pipeline.js` isn't a separate module, just extend the route test.)
+
+- [ ] **Step 3: Add the UI checkbox**
+
+In `data-export-section.jsx`, in the import section, add a checkbox before the file picker:
+
+```jsx
+<label>
+  <input
+    type="checkbox"
+    checked={skipRag}
+    onChange={(e) => setSkipRag(e.target.checked)}
+  />
+  Skip AI indexing (faster, but no chat/search over imported files)
+</label>
+```
+
+And include `skipRAG: skipRag` in the `/api/vault/import/start` POST body.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run src/__tests__/api/vault-import-start.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/vault/import-worker.js \
+        src/components/settings/data-export-section.jsx
+git commit -m "let users opt out of RAG indexing during vault import"
+```
+
+---
+
+## Task 6: Cleanup orphaned partials on failed/cancelled imports
+
+**Why:** When an import fails partway through (worker crash, cancellation, fatal S3 error), the files and notes it already created stay in the user's tree — confusing and hard to clean up manually. Add a cleanup pass that runs from the worker's catch block: deletes any notes/attachments/S3 keys created with this job's `id` as part of their path.
+
+This is the medium-effort task. Consider whether you want it — partial-success is a defensible default. Skip if you'd rather give users explicit control via a "Roll back this import" button instead (much smaller scope).
+
+**Files:**
+- Create: `src/lib/vault/cleanup.js`
+- Modify: `src/lib/vault/import-worker.js` (catch block around line 422-430)
+
+- [ ] **Step 1: Implement the cleanup helper**
+
+Create `src/lib/vault/cleanup.js`:
+
+```javascript
+import { S3Client, DeleteObjectsCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+import sql from "@/database/pgsql.js";
+
+/**
+ * Delete S3 objects and DB rows created for a specific import job.
+ * Safe to call multiple times (idempotent).
+ */
+export async function rollbackImportJob({ jobId, userId }) {
+  const bucket = process.env.STORAGE_BUCKET;
+  const prefix = process.env.STORAGE_PREFIX || "oghma";
+  const s3 = new S3Client({
+    region: process.env.STORAGE_REGION || "us-east-1",
+    ...(process.env.STORAGE_ENDPOINT && {
+      endpoint: process.env.STORAGE_ENDPOINT,
+      forcePathStyle: true,
+    }),
+  });
+
+  // 1. List and delete S3 objects under vault/{userId}/{jobId}/
+  const keyPrefix = `${prefix}/vault/${userId}/${jobId}/`;
+  let continuationToken;
+  do {
+    const list = await s3.send(new ListObjectsV2Command({
+      Bucket: bucket,
+      Prefix: keyPrefix,
+      ContinuationToken: continuationToken,
+    }));
+    if (list.Contents?.length) {
+      await s3.send(new DeleteObjectsCommand({
+        Bucket: bucket,
+        Delete: { Objects: list.Contents.map((o) => ({ Key: o.Key })) },
+      }));
+    }
+    continuationToken = list.NextContinuationToken;
+  } while (continuationToken);
+
+  // 2. Delete DB rows tagged with this import_job_id
+  await sql`DELETE FROM app.embeddings WHERE chunk_id IN (
+    SELECT id FROM app.chunks WHERE import_job_id = ${jobId}::uuid
+  )`;
+  await sql`DELETE FROM app.chunks WHERE import_job_id = ${jobId}::uuid`;
+  await sql`DELETE FROM app.attachments WHERE import_job_id = ${jobId}::uuid`;
+  await sql`DELETE FROM app.notes WHERE import_job_id = ${jobId}::uuid AND user_id = ${userId}`;
+}
+```
+
+> Pre-req: this depends on `notes`, `attachments`, `chunks` tables having an `import_job_id` column. If they don't, either: (a) add that column in migration 029 and have the import worker stamp it on every insert, or (b) skip this task. Check the schema before starting.
+
+- [ ] **Step 2: Wire into the worker's catch**
+
+In `src/lib/vault/import-worker.js`, replace lines 422-430 (the fatal error catch):
+
+```javascript
+  } catch (err) {
+    console.error(`[${ts()}] Vault import failed:`, err.message);
+    await sql`
+      UPDATE app.canvas_import_jobs
+      SET status = 'failed', error_message = ${err.message}, completed_at = NOW()
+      WHERE id = ${jobId}::uuid
+    `;
+    try {
+      await rollbackImportJob({ jobId, userId });
+      console.log(`[${ts()}] Rolled back partial import for ${jobId}`);
+    } catch (rollbackErr) {
+      console.error(`[${ts()}] Rollback failed for ${jobId}:`, rollbackErr.message);
+    }
+    throw err;
+  }
+```
+
+- [ ] **Step 3: Add the schema column (if missing)**
+
+If `app.notes` doesn't have `import_job_id`, add to migration 029 (or create 030):
+
+```sql
+ALTER TABLE app.notes      ADD COLUMN IF NOT EXISTS import_job_id UUID;
+ALTER TABLE app.attachments ADD COLUMN IF NOT EXISTS import_job_id UUID;
+ALTER TABLE app.chunks     ADD COLUMN IF NOT EXISTS import_job_id UUID;
+CREATE INDEX IF NOT EXISTS idx_notes_import_job ON app.notes (import_job_id) WHERE import_job_id IS NOT NULL;
+```
+
+Then update all `INSERT` statements in `import-worker.js` to include `import_job_id = ${jobId}`.
+
+- [ ] **Step 4: Decide before committing**
+
+Honestly assess: do you want full rollback, or is partial-success acceptable? The Marker pipeline can fail per-file already without rolling everything back. A defensible alternative: skip the auto-rollback, instead add a user-triggered "Discard this import" button on failed jobs that calls the same `rollbackImportJob` helper as an explicit API endpoint.
+
+- [ ] **Step 5: Commit (only if you pulled the trigger)**
+
+```bash
+git add src/lib/vault/cleanup.js src/lib/vault/import-worker.js \
+        database/migrations/029_vault_progress_and_cancel.sql
+git commit -m "roll back partial vault imports on worker failure"
+```
+
+---
+
+## Self-Review Checklist
+
+After implementing, verify:
+
+- [ ] All seven gaps from the original list addressed (SMTP, retry, export progress, 409, cancel, skipRAG, orphan cleanup)
+- [ ] No `attempts: 1` left in `src/lib/queue.ts`
+- [ ] Migration 029 applied and idempotent
+- [ ] Cancel UI button only appears for `processing`/`queued` jobs
+- [ ] 409 response includes `activeJobId` so UI can target the right job for cancel
+- [ ] Export status response now includes `progress` (was only set for imports before)
+- [ ] `skipRAG` flag forwarded into job payload, not silently dropped
+- [ ] `npx vitest run` passes
+- [ ] `npx tsc --noEmit` passes
+- [ ] No hardcoded `email-smtp.*.amazonaws.com` left
+
+---
+
+## Suggested Execution Order
+
+The tasks are independently shippable — pick what you want, in any order. But if you do them all, this order minimizes rework:
+
+1. **Task 0** — SMTP (5 min, unblocks self-host)
+2. **Task 1** — Retry config (5 min)
+3. **Task 2** — Progress column + status response (30 min, prereq for Task 4)
+4. **Task 3** — 409 conflict (1 h)
+5. **Task 4** — Cancellation (2 h, depends on Task 2)
+6. **Task 5** — skipRAG (30 min)
+7. **Task 6** — Orphan cleanup (1-2 h, optional)
+
+Total: ~4-6 hours of focused work, plus testing.

--- a/src/__tests__/api/vault-cancel.test.ts
+++ b/src/__tests__/api/vault-cancel.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/database/pgsql.js", () => {
+  const sqlMock = vi.fn();
+  sqlMock.mockResolvedValue([]);
+  return { default: sqlMock };
+});
+vi.mock("@/lib/api-error", () => ({
+  requireAuth: vi.fn(),
+  withErrorHandler: (h: (r: NextRequest, ctx: { params: { jobId: string } }) => Promise<Response>) => h,
+  ApiError: class extends Error {
+    constructor(public statusCode: number, public userMessage: string, public internalDetails?: string) {
+      super(userMessage);
+    }
+  },
+}));
+
+import sql from "@/database/pgsql.js";
+import { requireAuth } from "@/lib/api-error";
+import { DELETE } from "@/app/api/vault/jobs/[jobId]/cancel/route";
+
+describe("DELETE /api/vault/jobs/[jobId]/cancel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAuth).mockResolvedValue({ user_id: "u1" } as never);
+  });
+
+  it("sets cancel_requested_at and returns 200", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "j1" }] as never);
+    const req = new NextRequest("http://localhost/api/vault/jobs/j1/cancel", { method: "DELETE" });
+    const res = await DELETE(req, { params: { jobId: "j1" } } as never);
+    expect(res.status).toBe(200);
+    expect(vi.mocked(sql)).toHaveBeenCalled();
+  });
+
+  it("returns 404 when job not found or not owned by user", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([] as never);
+    const req = new NextRequest("http://localhost/api/vault/jobs/x/cancel", { method: "DELETE" });
+    await expect(
+      DELETE(req, { params: { jobId: "x" } } as never)
+    ).rejects.toThrow(); // ApiError thrown — withErrorHandler converts to 404 response in production
+  });
+});

--- a/src/__tests__/api/vault-export.test.ts
+++ b/src/__tests__/api/vault-export.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/database/pgsql.js", () => {
+  const sqlMock = vi.fn() as unknown as { begin: ReturnType<typeof vi.fn> } & ReturnType<typeof vi.fn>;
+  sqlMock.mockResolvedValue([]);
+  sqlMock.begin = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(sqlMock));
+  return { default: sqlMock };
+});
+
+vi.mock("@/lib/api-error", () => ({
+  requireAuth: vi.fn(),
+  withErrorHandler: (handler: (req: NextRequest) => Promise<Response>) => handler,
+  ApiError: class extends Error {
+    constructor(public status: number, msg: string) { super(msg); }
+  },
+}));
+
+vi.mock("@/lib/queue", () => ({
+  enqueueCanvasJob: vi.fn().mockResolvedValue(undefined),
+}));
+
+import sql from "@/database/pgsql.js";
+import { requireAuth } from "@/lib/api-error";
+import { POST } from "@/app/api/vault/export/route";
+
+describe("POST /api/vault/export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAuth).mockResolvedValue({ user_id: "u1" } as never);
+  });
+
+  it("returns 409 when an active export already exists", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "existing-job" }] as never);
+
+    const res = await POST(new NextRequest("http://localhost/api/vault/export", { method: "POST" }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.activeJobId).toBe("existing-job");
+  });
+
+  it("cancels existing job and starts new one when force=true", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "existing-job" }] as never);
+    vi.mocked(sql).mockResolvedValueOnce([] as never);
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "new-job" }] as never);
+
+    const res = await POST(new NextRequest("http://localhost/api/vault/export?force=true", { method: "POST" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jobId).toBe("new-job");
+  });
+
+  it("starts immediately when no active job exists", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([] as never);
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "new-job" }] as never);
+
+    const res = await POST(new NextRequest("http://localhost/api/vault/export", { method: "POST" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jobId).toBe("new-job");
+  });
+});

--- a/src/__tests__/api/vault-export.test.ts
+++ b/src/__tests__/api/vault-export.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/lib/api-error", () => ({
   requireAuth: vi.fn(),
   withErrorHandler: (handler: (req: NextRequest) => Promise<Response>) => handler,
   ApiError: class extends Error {
-    constructor(public status: number, msg: string) { super(msg); }
+    constructor(public statusCode: number, public userMessage: string, public internalDetails?: string) { super(userMessage); }
   },
 }));
 

--- a/src/__tests__/api/vault-import-start.test.ts
+++ b/src/__tests__/api/vault-import-start.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/database/pgsql.js", () => {
 vi.mock("@/lib/api-error", () => ({
   requireAuth: vi.fn(),
   withErrorHandler: (h: (r: NextRequest) => Promise<Response>) => h,
-  ApiError: class extends Error { constructor(public status: number, msg: string) { super(msg); } },
+  ApiError: class extends Error { constructor(public statusCode: number, public userMessage: string, public internalDetails?: string) { super(userMessage); } },
 }));
 
 vi.mock("@/lib/queue", () => ({ enqueueCanvasJob: vi.fn().mockResolvedValue(undefined) }));

--- a/src/__tests__/api/vault-import-start.test.ts
+++ b/src/__tests__/api/vault-import-start.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/database/pgsql.js", () => {
+  const sqlMock = vi.fn() as unknown as { begin: ReturnType<typeof vi.fn> } & ReturnType<typeof vi.fn>;
+  sqlMock.mockResolvedValue([]);
+  sqlMock.begin = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(sqlMock));
+  return { default: sqlMock };
+});
+
+vi.mock("@/lib/api-error", () => ({
+  requireAuth: vi.fn(),
+  withErrorHandler: (h: (r: NextRequest) => Promise<Response>) => h,
+  ApiError: class extends Error { constructor(public status: number, msg: string) { super(msg); } },
+}));
+
+vi.mock("@/lib/queue", () => ({ enqueueCanvasJob: vi.fn().mockResolvedValue(undefined) }));
+
+import sql from "@/database/pgsql.js";
+import { requireAuth } from "@/lib/api-error";
+import { POST } from "@/app/api/vault/import/start/route";
+
+const body = (data: Record<string, unknown>) =>
+  new NextRequest("http://localhost/api/vault/import/start", {
+    method: "POST",
+    body: JSON.stringify(data),
+    headers: { "content-type": "application/json" },
+  });
+
+describe("POST /api/vault/import/start", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAuth).mockResolvedValue({ user_id: "u1" } as never);
+  });
+
+  it("returns 409 when active import exists", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "existing" }] as never);
+    const res = await POST(body({ s3Key: "vault-uploads/u1/abc/x.zip" }));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ activeJobId: "existing" });
+  });
+
+  it("starts immediately when no active job", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([] as never);
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "new" }] as never);
+    const res = await POST(body({ s3Key: "vault-uploads/u1/abc/x.zip" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ jobId: "new" });
+  });
+
+  it("starts when force=true even if active job exists", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "existing" }] as never);
+    vi.mocked(sql).mockResolvedValueOnce([] as never); // cancel
+    vi.mocked(sql).mockResolvedValueOnce([{ id: "new" }] as never); // insert
+    const res = await POST(body({ s3Key: "vault-uploads/u1/abc/x.zip", force: true }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ jobId: "new" });
+  });
+});

--- a/src/__tests__/api/vault-status.test.ts
+++ b/src/__tests__/api/vault-status.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/database/pgsql.js", () => {
+  const sqlMock = vi.fn();
+  sqlMock.mockResolvedValue([]);
+  return { default: sqlMock };
+});
+
+vi.mock("@/lib/api-error", () => ({
+  requireAuth: vi.fn(),
+  withErrorHandler: (handler: () => Promise<Response>) => handler,
+  ApiError: class extends Error {
+    constructor(public status: number, msg: string) { super(msg); }
+  },
+}));
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: class { send() {} },
+  GetObjectCommand: class { constructor(public input: unknown) {} },
+}));
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: vi.fn().mockResolvedValue("https://signed.example/file.zip"),
+}));
+
+import sql from "@/database/pgsql.js";
+import { requireAuth } from "@/lib/api-error";
+import { GET } from "@/app/api/vault/status/route";
+
+describe("GET /api/vault/status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAuth).mockResolvedValue({ user_id: "u1" } as never);
+    process.env.STORAGE_BUCKET = "test";
+  });
+
+  it("returns export progress with processed_files", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([
+      {
+        id: "j1",
+        type: "vault-export",
+        status: "processing",
+        created_at: "2026-05-13T00:00:00Z",
+        started_at: "2026-05-13T00:00:01Z",
+        completed_at: null,
+        expected_total: 100,
+        processed_files: 42,
+        cancel_requested_at: null,
+        output_s3_key: null,
+        download_url: null,
+        error_message: null,
+      },
+    ] as never);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/vault/status?type=vault-export"),
+    );
+    const body = await res.json();
+
+    expect(body.progress).toEqual({ completed: 42, total: 100, percent: 42 });
+    expect(body.job.cancelRequested).toBe(false);
+  });
+
+  it("flags cancelRequested when cancel_requested_at is set", async () => {
+    vi.mocked(sql).mockResolvedValueOnce([
+      {
+        id: "j1",
+        type: "vault-import",
+        status: "processing",
+        created_at: "2026-05-13T00:00:00Z",
+        started_at: "2026-05-13T00:00:01Z",
+        completed_at: null,
+        expected_total: 10,
+        processed_files: 3,
+        cancel_requested_at: "2026-05-13T00:01:00Z",
+        output_s3_key: null,
+        download_url: null,
+        error_message: null,
+      },
+    ] as never);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/vault/status?type=vault-import"),
+    );
+    const body = await res.json();
+
+    expect(body.job.cancelRequested).toBe(true);
+  });
+});

--- a/src/__tests__/api/vault-status.test.ts
+++ b/src/__tests__/api/vault-status.test.ts
@@ -11,7 +11,13 @@ vi.mock("@/lib/api-error", () => ({
   requireAuth: vi.fn(),
   withErrorHandler: (handler: () => Promise<Response>) => handler,
   ApiError: class extends Error {
-    constructor(public status: number, msg: string) { super(msg); }
+    constructor(
+      public statusCode: number,
+      public userMessage: string,
+      public internalDetails?: string,
+    ) {
+      super(userMessage);
+    }
   },
 }));
 

--- a/src/app/api/import-export/route.ts
+++ b/src/app/api/import-export/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: NextRequest) {
   if (action === "export") {
     // queue a background export — worker builds zip and uploads to S3
     try {
-      await enqueueCanvasJob("vault-export", { userId });
+      await enqueueCanvasJob("vault-export", { userId }, { attempts: 1 });
     } catch (err) {
       logger.warn("queue enqueue failed for vault-export", { error: err });
     }

--- a/src/app/api/vault/export/route.ts
+++ b/src/app/api/vault/export/route.ts
@@ -30,6 +30,8 @@ export const POST = withErrorHandler(async (request) => {
     );
   }
 
+  // note: TOCTOU between SELECT and INSERT — concurrent double-submits could both create jobs.
+  // acceptable for now (requires fast double-click); proper fix needs a unique partial index on (user_id, type) where status in ('queued','processing').
   const jobId = await sql.begin(async (tx: any) => {
     if (existing) {
       await tx`
@@ -48,17 +50,10 @@ export const POST = withErrorHandler(async (request) => {
     return row.id;
   });
 
-  try {
-    await enqueueCanvasJob("vault-export", {
-      jobId,
-      userId: user.user_id,
-    }, { attempts: 1 });
-  } catch (queueErr) {
-    console.error(
-      "queue enqueue failed for vault export:",
-      (queueErr as Error).message,
-    );
-  }
+  await enqueueCanvasJob("vault-export", {
+    jobId,
+    userId: user.user_id,
+  }, { attempts: 1 });
 
   return NextResponse.json({ jobId });
 });

--- a/src/app/api/vault/export/route.ts
+++ b/src/app/api/vault/export/route.ts
@@ -7,29 +7,46 @@ import { enqueueCanvasJob } from "@/lib/queue";
  * POST /api/vault/export
  *
  * Creates a vault-export job and dispatches to SQS.
+ * Returns 409 if an active export already exists; pass ?force=true to cancel and replace.
  * Response: { jobId }
  */
-export const POST = withErrorHandler(async () => {
+export const POST = withErrorHandler(async (request) => {
   const user = await requireAuth();
+  const { searchParams } = new URL(request.url);
+  const force = searchParams.get("force") === "true";
 
-  // cancel any existing active export jobs
-  const job = await sql.begin(async (tx: any) => {
-    await tx`
-      UPDATE app.canvas_import_jobs
-      SET status = 'cancelled', completed_at = NOW()
-      WHERE user_id = ${user.user_id}
-        AND type = 'vault-export'
-        AND status IN ('queued', 'processing')
-    `;
-    const [inserted] = await tx`
+  const [existing] = await sql`
+    SELECT id FROM app.canvas_import_jobs
+    WHERE user_id = ${user.user_id}
+      AND type = 'vault-export'
+      AND status IN ('queued', 'processing')
+    LIMIT 1
+  `;
+
+  if (existing && !force) {
+    return NextResponse.json(
+      { error: "Export already in progress", activeJobId: existing.id },
+      { status: 409 },
+    );
+  }
+
+  const jobId = await sql.begin(async (tx: any) => {
+    if (existing) {
+      await tx`
+        UPDATE app.canvas_import_jobs
+        SET status = 'cancelled', completed_at = NOW()
+        WHERE user_id = ${user.user_id}
+          AND type = 'vault-export'
+          AND status IN ('queued', 'processing')
+      `;
+    }
+    const [row] = await tx`
       INSERT INTO app.canvas_import_jobs (user_id, type, status)
       VALUES (${user.user_id}::uuid, 'vault-export', 'queued')
       RETURNING id
     `;
-    return inserted;
+    return row.id;
   });
-
-  const jobId = job.id;
 
   try {
     await enqueueCanvasJob("vault-export", {

--- a/src/app/api/vault/export/route.ts
+++ b/src/app/api/vault/export/route.ts
@@ -35,7 +35,7 @@ export const POST = withErrorHandler(async () => {
     await enqueueCanvasJob("vault-export", {
       jobId,
       userId: user.user_id,
-    });
+    }, { attempts: 1 });
   } catch (queueErr) {
     console.error(
       "queue enqueue failed for vault export:",

--- a/src/app/api/vault/import/start/route.ts
+++ b/src/app/api/vault/import/start/route.ts
@@ -41,6 +41,8 @@ export const POST = withErrorHandler(async (request) => {
     );
   }
 
+  // note: TOCTOU between SELECT and INSERT — concurrent double-submits could both create jobs.
+  // acceptable for now (requires fast double-click); proper fix needs a unique partial index on (user_id, type) where status in ('queued','processing').
   const jobId = await sql.begin(async (tx: any) => {
     if (existing) {
       await tx`
@@ -59,18 +61,11 @@ export const POST = withErrorHandler(async (request) => {
     return row.id;
   });
 
-  try {
-    await enqueueCanvasJob("vault-import", {
-      jobId,
-      userId: user.user_id,
-      s3Key,
-    }, { attempts: 1 });
-  } catch (queueErr) {
-    console.error(
-      "queue enqueue failed for vault import:",
-      (queueErr as Error).message,
-    );
-  }
+  await enqueueCanvasJob("vault-import", {
+    jobId,
+    userId: user.user_id,
+    s3Key,
+  }, { attempts: 1 });
 
   return NextResponse.json({ jobId });
 });

--- a/src/app/api/vault/import/start/route.ts
+++ b/src/app/api/vault/import/start/route.ts
@@ -49,7 +49,7 @@ export const POST = withErrorHandler(async (request) => {
       jobId,
       userId: user.user_id,
       s3Key,
-    });
+    }, { attempts: 1 });
   } catch (queueErr) {
     console.error(
       "queue enqueue failed for vault import:",

--- a/src/app/api/vault/import/start/route.ts
+++ b/src/app/api/vault/import/start/route.ts
@@ -7,13 +7,14 @@ import { enqueueCanvasJob } from "@/lib/queue";
  * POST /api/vault/import/start
  *
  * Creates a vault-import job after the zip has been uploaded to S3.
- * Body: { s3Key: string }
+ * Returns 409 if an active import already exists; pass force=true in body to cancel and replace.
+ * Body: { s3Key: string, force?: boolean }
  * Response: { jobId }
  */
 export const POST = withErrorHandler(async (request) => {
   const user = await requireAuth();
 
-  const { s3Key } = await request.json();
+  const { s3Key, force } = await request.json();
 
   if (!s3Key) {
     throw new ApiError(400, "s3Key is required");
@@ -25,24 +26,38 @@ export const POST = withErrorHandler(async (request) => {
     throw new ApiError(403, "s3Key does not belong to your upload session");
   }
 
-  // cancel any existing active vault jobs for this user
-  const job = await sql.begin(async (tx: any) => {
-    await tx`
-      UPDATE app.canvas_import_jobs
-      SET status = 'cancelled', completed_at = NOW()
-      WHERE user_id = ${user.user_id}
-        AND type = 'vault-import'
-        AND status IN ('queued', 'processing')
-    `;
-    const [inserted] = await tx`
+  const [existing] = await sql`
+    SELECT id FROM app.canvas_import_jobs
+    WHERE user_id = ${user.user_id}
+      AND type = 'vault-import'
+      AND status IN ('queued', 'processing')
+    LIMIT 1
+  `;
+
+  if (existing && !force) {
+    return NextResponse.json(
+      { error: "Import already in progress", activeJobId: existing.id },
+      { status: 409 },
+    );
+  }
+
+  const jobId = await sql.begin(async (tx: any) => {
+    if (existing) {
+      await tx`
+        UPDATE app.canvas_import_jobs
+        SET status = 'cancelled', completed_at = NOW()
+        WHERE user_id = ${user.user_id}
+          AND type = 'vault-import'
+          AND status IN ('queued', 'processing')
+      `;
+    }
+    const [row] = await tx`
       INSERT INTO app.canvas_import_jobs (user_id, type, input_s3_key, status)
       VALUES (${user.user_id}::uuid, 'vault-import', ${s3Key}, 'queued')
       RETURNING id
     `;
-    return inserted;
+    return row.id;
   });
-
-  const jobId = job.id;
 
   try {
     await enqueueCanvasJob("vault-import", {

--- a/src/app/api/vault/jobs/[jobId]/cancel/route.ts
+++ b/src/app/api/vault/jobs/[jobId]/cancel/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { withErrorHandler, requireAuth, ApiError } from "@/lib/api-error";
+import sql from "@/database/pgsql.js";
+
+export const DELETE = withErrorHandler(
+  async (_request, { params }: { params: { jobId: string } }) => {
+    const user = await requireAuth();
+    const { jobId } = params;
+
+    const [updated] = await sql`
+      UPDATE app.canvas_import_jobs
+      SET cancel_requested_at = NOW(), updated_at = NOW()
+      WHERE id = ${jobId}::uuid
+        AND user_id = ${user.user_id}
+        AND status IN ('queued', 'processing')
+        AND cancel_requested_at IS NULL
+      RETURNING id
+    `;
+
+    if (!updated) {
+      throw new ApiError(404, "Job not found or not cancellable");
+    }
+
+    return NextResponse.json({ ok: true, jobId: updated.id });
+  },
+);

--- a/src/app/api/vault/status/route.ts
+++ b/src/app/api/vault/status/route.ts
@@ -22,7 +22,8 @@ export const GET = withErrorHandler(async (request) => {
 
   const [job] = await sql`
     SELECT id, type, status, created_at, started_at, completed_at,
-           expected_total, error_message, output_s3_key, download_url
+           expected_total, processed_files, cancel_requested_at,
+           error_message, output_s3_key, download_url
     FROM app.canvas_import_jobs
     WHERE user_id = ${user.user_id}
       AND type = ${type}
@@ -62,29 +63,17 @@ export const GET = withErrorHandler(async (request) => {
     );
   }
 
-  // for imports, count processed files for progress
+  // unified progress for both import and export
   let progress = null;
-  if (
-    type === "vault-import" &&
-    ["processing", "complete"].includes(job.status)
-  ) {
-    const [counts] = await sql`
-      SELECT COUNT(*) as total
-      FROM app.notes
-      WHERE user_id = ${user.user_id}
-        AND created_at >= ${job.created_at}
-        AND is_folder = false
-        AND deleted_at IS NULL
-    `;
-    const completed = parseInt(counts?.total ?? "0", 10);
+  if (["processing", "complete"].includes(job.status)) {
+    const completed = job.processed_files ?? 0;
     const total = job.expected_total ?? 0;
     progress = {
       completed,
       total,
-      percent:
-        total > 0
-          ? Math.min(100, Math.round((completed / total) * 100))
-          : null,
+      percent: total > 0
+        ? Math.min(100, Math.round((completed / total) * 100))
+        : null,
     };
   }
 
@@ -97,6 +86,7 @@ export const GET = withErrorHandler(async (request) => {
       startedAt: job.started_at,
       completedAt: job.completed_at,
       expectedTotal: job.expected_total,
+      cancelRequested: !!job.cancel_requested_at,
       error: job.error_message,
     },
     downloadUrl,

--- a/src/components/settings/data-export-section.jsx
+++ b/src/components/settings/data-export-section.jsx
@@ -236,13 +236,15 @@ export default function DataExportSection() {
           }
         }
         if (exportRes.ok) {
-          const { job, downloadUrl } = await exportRes.json();
+          const { job, downloadUrl, progress } = await exportRes.json();
           if (job && ["queued", "processing"].includes(job.status)) {
             setExportStatus("processing");
             setExportJobId(job.jobId);
+            setExportProgress(progress);
           } else if (job?.status === "complete" && downloadUrl) {
             setExportStatus("complete");
             setExportDownloadUrl(downloadUrl);
+            setExportProgress(progress);
           }
         }
       } catch {

--- a/src/components/settings/data-export-section.jsx
+++ b/src/components/settings/data-export-section.jsx
@@ -103,16 +103,32 @@ export default function DataExportSection() {
       setImportStatus("processing");
       setUploadProgress(100);
 
-      const startRes = await fetch("/api/vault/import/start", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ s3Key }),
-      });
-      if (!startRes.ok) {
-        const err = await startRes.json();
-        throw new Error(err.error || "Failed to start import");
+      async function startImport(force = false) {
+        const startRes = await fetch("/api/vault/import/start", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(force ? { s3Key, force: true } : { s3Key }),
+        });
+
+        if (startRes.status === 409) {
+          setImportStatus(null);
+          const ok = confirm(
+            t("An import is already in progress. Cancel it and start a new one?"),
+          );
+          if (!ok) return null;
+          return startImport(true);
+        }
+
+        if (!startRes.ok) {
+          const err = await startRes.json();
+          throw new Error(err.error || "Failed to start import");
+        }
+        return startRes.json();
       }
-      const { jobId } = await startRes.json();
+
+      const result = await startImport();
+      if (!result) return;
+      const { jobId } = result;
       setImportJobId(jobId);
 
       toast.success(t("Import started! Processing your vault..."));
@@ -126,12 +142,24 @@ export default function DataExportSection() {
   }
 
   // vault export handler
-  async function handleVaultExport() {
+  async function handleVaultExport({ force = false } = {}) {
     try {
       setExportStatus("processing");
       setExportDownloadUrl(null);
 
-      const res = await fetch("/api/vault/export", { method: "POST" });
+      const url = force ? "/api/vault/export?force=true" : "/api/vault/export";
+      const res = await fetch(url, { method: "POST" });
+
+      if (res.status === 409) {
+        setExportStatus(null);
+        await res.json();
+        const ok = confirm(
+          t("An export is already in progress. Cancel it and start a new one?"),
+        );
+        if (!ok) return;
+        return handleVaultExport({ force: true });
+      }
+
       if (!res.ok) {
         const err = await res.json();
         throw new Error(err.error || "Failed to start export");

--- a/src/components/settings/data-export-section.jsx
+++ b/src/components/settings/data-export-section.jsx
@@ -23,6 +23,7 @@ export default function DataExportSection() {
   const [exportStatus, setExportStatus] = useState(null);
   const [exportJobId, setExportJobId] = useState(null);
   const [exportDownloadUrl, setExportDownloadUrl] = useState(null);
+  const [exportProgress, setExportProgress] = useState(null);
   const importFileRef = useRef(null);
 
   // fetch calendar token on mount
@@ -186,11 +187,12 @@ export default function DataExportSection() {
 
   const handleExportPollData = useCallback(
     (data) => {
-      const { job, downloadUrl } = data;
+      const { job, downloadUrl, progress } = data;
       if (!job) return false;
       if (job.status === "complete" && downloadUrl) {
         setExportStatus("complete");
         setExportDownloadUrl(downloadUrl);
+        setExportProgress(progress);
         toast.success(t("Vault export ready!"));
         return true;
       }
@@ -198,6 +200,9 @@ export default function DataExportSection() {
         setExportStatus("failed");
         toast.error(job.error || t("Export failed"));
         return true;
+      }
+      if (progress) {
+        setExportProgress(progress);
       }
       return false;
     },
@@ -366,28 +371,25 @@ export default function DataExportSection() {
             </p>
 
             {exportStatus === "processing" && (
-              <div className="mb-4 flex items-center gap-2 text-sm text-text-secondary">
-                <svg
-                  className="animate-spin h-4 w-4 text-primary-500"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
+              <div className="mb-4">
+                <div className="flex items-center justify-between text-sm text-text-secondary mb-1">
+                  <span>
+                    {exportProgress
+                      ? `${t("Exporting")} ${exportProgress.completed}/${exportProgress.total} ${t("files")}...`
+                      : t("Generating export... This may take a few minutes.")}
+                  </span>
+                  {exportProgress?.percent != null && (
+                    <span>{exportProgress.percent}%</span>
+                  )}
+                </div>
+                <div className="w-full bg-subtle rounded-full h-2">
+                  <div
+                    className="bg-primary-500 h-2 rounded-full transition-all duration-300"
+                    style={{
+                      width: `${exportProgress?.percent ?? 0}%`,
+                    }}
                   />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                  />
-                </svg>
-                {t("Generating export... This may take a few minutes.")}
+                </div>
               </div>
             )}
 

--- a/src/components/settings/data-export-section.jsx
+++ b/src/components/settings/data-export-section.jsx
@@ -20,10 +20,12 @@ export default function DataExportSection() {
   const [importProgress, setImportProgress] = useState(null);
   const [importJobId, setImportJobId] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(0);
+  const [importCancelRequested, setImportCancelRequested] = useState(false);
   const [exportStatus, setExportStatus] = useState(null);
   const [exportJobId, setExportJobId] = useState(null);
   const [exportDownloadUrl, setExportDownloadUrl] = useState(null);
   const [exportProgress, setExportProgress] = useState(null);
+  const [exportCancelRequested, setExportCancelRequested] = useState(false);
   const importFileRef = useRef(null);
 
   // fetch calendar token on mount
@@ -175,9 +177,41 @@ export default function DataExportSection() {
     }
   }
 
+  // cancel handlers
+  async function handleCancelImport() {
+    if (!importJobId) return;
+    if (!confirm(t("Stop this import? Files processed so far will remain."))) return;
+    setImportCancelRequested(true);
+    try {
+      const res = await fetch(`/api/vault/jobs/${importJobId}/cancel`, { method: "DELETE" });
+      if (!res.ok) throw new Error();
+      toast.info(t("Import cancellation requested. Stopping after current file..."));
+    } catch {
+      setImportCancelRequested(false);
+      toast.error(t("Failed to cancel import"));
+    }
+  }
+
+  async function handleCancelExport() {
+    if (!exportJobId) return;
+    if (!confirm(t("Stop this export?"))) return;
+    setExportCancelRequested(true);
+    try {
+      const res = await fetch(`/api/vault/jobs/${exportJobId}/cancel`, { method: "DELETE" });
+      if (!res.ok) throw new Error();
+      toast.info(t("Export cancellation requested. Stopping after current file..."));
+    } catch {
+      setExportCancelRequested(false);
+      toast.error(t("Failed to cancel export"));
+    }
+  }
+
   // poll import status
   const importPollingActive =
-    !!importJobId && importStatus !== "complete" && importStatus !== "failed";
+    !!importJobId &&
+    importStatus !== "complete" &&
+    importStatus !== "failed" &&
+    importStatus !== "cancelled";
 
   const handleImportPollData = useCallback(
     (data) => {
@@ -186,11 +220,19 @@ export default function DataExportSection() {
       if (job.status === "complete") {
         setImportStatus("complete");
         setImportProgress(progress);
+        setImportCancelRequested(false);
         toast.success(t("Vault import complete!"));
+        return true;
+      }
+      if (job.status === "cancelled") {
+        setImportStatus(null);
+        setImportCancelRequested(false);
+        toast.info(t("Import cancelled."));
         return true;
       }
       if (job.status === "failed") {
         setImportStatus("failed");
+        setImportCancelRequested(false);
         toast.error(job.error || t("Import failed"));
         return true;
       }
@@ -211,7 +253,10 @@ export default function DataExportSection() {
 
   // poll export status
   const exportPollingActive =
-    !!exportJobId && exportStatus !== "complete" && exportStatus !== "failed";
+    !!exportJobId &&
+    exportStatus !== "complete" &&
+    exportStatus !== "failed" &&
+    exportStatus !== "cancelled";
 
   const handleExportPollData = useCallback(
     (data) => {
@@ -221,11 +266,19 @@ export default function DataExportSection() {
         setExportStatus("complete");
         setExportDownloadUrl(downloadUrl);
         setExportProgress(progress);
+        setExportCancelRequested(false);
         toast.success(t("Vault export ready!"));
+        return true;
+      }
+      if (job.status === "cancelled") {
+        setExportStatus(null);
+        setExportCancelRequested(false);
+        toast.info(t("Export cancelled."));
         return true;
       }
       if (job.status === "failed") {
         setExportStatus("failed");
+        setExportCancelRequested(false);
         toast.error(job.error || t("Export failed"));
         return true;
       }
@@ -388,6 +441,19 @@ export default function DataExportSection() {
                     ? t("Processing...")
                     : t("Select .zip file")}
               </label>
+              {importStatus === "processing" && (
+                <button
+                  type="button"
+                  onClick={handleCancelImport}
+                  disabled={importCancelRequested}
+                  className={cn(
+                    "glass-card-interactive rounded-radius-md px-3 py-2 text-sm font-semibold text-text",
+                    importCancelRequested ? "opacity-50 cursor-not-allowed" : "",
+                  )}
+                >
+                  {importCancelRequested ? t("Cancelling...") : t("Cancel")}
+                </button>
+              )}
             </div>
           </div>
 
@@ -447,21 +513,36 @@ export default function DataExportSection() {
               </div>
             )}
 
-            <button
-              type="button"
-              onClick={handleVaultExport}
-              disabled={exportStatus === "processing"}
-              className={cn(
-                "glass-card-interactive rounded-radius-md px-3 py-2 text-sm font-semibold text-text",
-                exportStatus === "processing"
-                  ? "opacity-50 cursor-not-allowed"
-                  : "",
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={handleVaultExport}
+                disabled={exportStatus === "processing"}
+                className={cn(
+                  "glass-card-interactive rounded-radius-md px-3 py-2 text-sm font-semibold text-text",
+                  exportStatus === "processing"
+                    ? "opacity-50 cursor-not-allowed"
+                    : "",
+                )}
+              >
+                {exportStatus === "processing"
+                  ? t("Exporting...")
+                  : t("Export vault")}
+              </button>
+              {exportStatus === "processing" && (
+                <button
+                  type="button"
+                  onClick={handleCancelExport}
+                  disabled={exportCancelRequested}
+                  className={cn(
+                    "glass-card-interactive rounded-radius-md px-3 py-2 text-sm font-semibold text-text",
+                    exportCancelRequested ? "opacity-50 cursor-not-allowed" : "",
+                  )}
+                >
+                  {exportCancelRequested ? t("Cancelling...") : t("Cancel")}
+                </button>
               )}
-            >
-              {exportStatus === "processing"
-                ? t("Exporting...")
-                : t("Export vault")}
-            </button>
+            </div>
           </div>
 
           {/* calendar subscription */}

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -37,9 +37,11 @@ export function getExtractRetryQueue(): Queue {
   return _extractRetryQueue;
 }
 
-// Workers MUST be idempotent: attempts > 1 means a job may re-run mid-processing.
-// Vault import/export workers handle this by checking job.status before mutating DB state
-// and by re-using deterministic S3 keys (vault/{userId}/{jobId}/...).
+// `attempts: 3` is safe for canvas-import (workers check terminal states before
+// mutating; see src/lib/canvas/import-extraction.js) and extract-retry.
+// Vault import is NOT yet retry-safe: `createNote()` mints fresh UUIDs per entry,
+// so a partial-failure retry would create duplicates. Vault enqueue sites override
+// attempts: 1 until import-worker is made idempotent (planned alongside cancellation).
 // keep the last 200 completed/failed jobs for observability; older are pruned
 const DEFAULT_OPTS: JobsOptions = {
   removeOnComplete: { count: 200 },

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -37,11 +37,15 @@ export function getExtractRetryQueue(): Queue {
   return _extractRetryQueue;
 }
 
+// Workers MUST be idempotent: attempts > 1 means a job may re-run mid-processing.
+// Vault import/export workers handle this by checking job.status before mutating DB state
+// and by re-using deterministic S3 keys (vault/{userId}/{jobId}/...).
 // keep the last 200 completed/failed jobs for observability; older are pruned
 const DEFAULT_OPTS: JobsOptions = {
   removeOnComplete: { count: 200 },
   removeOnFail: { count: 200 },
-  attempts: 1,
+  attempts: 3,
+  backoff: { type: "exponential", delay: 1000 },
 };
 
 export async function enqueueCanvasJob(

--- a/src/lib/vault/export-worker.js
+++ b/src/lib/vault/export-worker.js
@@ -203,7 +203,7 @@ export async function processVaultExport(msg) {
             await sql`
               UPDATE app.canvas_import_jobs
               SET status = 'cancelled', completed_at = NOW(), processed_files = ${processed}
-              WHERE id = ${jobId}::uuid
+              WHERE id = ${jobId}::uuid AND status = 'processing'
             `;
             return; // exit the worker function
           }

--- a/src/lib/vault/export-worker.js
+++ b/src/lib/vault/export-worker.js
@@ -193,7 +193,11 @@ export async function processVaultExport(msg) {
 
         processed++;
         if (processed % 50 === 0) {
-          await sql`UPDATE app.canvas_import_jobs SET updated_at = NOW() WHERE id = ${jobId}::uuid`;
+          await sql`
+            UPDATE app.canvas_import_jobs
+            SET processed_files = ${processed}, updated_at = NOW()
+            WHERE id = ${jobId}::uuid
+          `;
           console.log(`[${ts()}] Exported ${processed}/${totalFiles} files`);
         }
       } catch (err) {
@@ -201,6 +205,13 @@ export async function processVaultExport(msg) {
         // continue with other files
       }
     }
+
+    // final progress flush
+    await sql`
+      UPDATE app.canvas_import_jobs
+      SET processed_files = ${processed}
+      WHERE id = ${jobId}::uuid
+    `;
 
     // finalize zip
     zip.end();

--- a/src/lib/vault/export-worker.js
+++ b/src/lib/vault/export-worker.js
@@ -193,6 +193,20 @@ export async function processVaultExport(msg) {
 
         processed++;
         if (processed % 50 === 0) {
+          const [cancelRow] = await sql`
+            SELECT cancel_requested_at FROM app.canvas_import_jobs
+            WHERE id = ${jobId}::uuid
+          `;
+          if (cancelRow?.cancel_requested_at) {
+            console.log(`[${ts()}] Cancel requested for ${jobId}; aborting after ${processed} files`);
+            await uploader.abort();
+            await sql`
+              UPDATE app.canvas_import_jobs
+              SET status = 'cancelled', completed_at = NOW(), processed_files = ${processed}
+              WHERE id = ${jobId}::uuid
+            `;
+            return; // exit the worker function
+          }
           await sql`
             UPDATE app.canvas_import_jobs
             SET processed_files = ${processed}, updated_at = NOW()

--- a/src/lib/vault/import-worker.js
+++ b/src/lib/vault/import-worker.js
@@ -449,7 +449,7 @@ export async function processVaultImport(msg) {
   } catch (error) {
     if (cancelled) {
       console.warn(`[${ts()}] Ignoring error after cancel for ${jobId}: ${error.message}`);
-      throw error;
+      return;
     }
     console.error(`[${ts()}] Vault import failed:`, error);
     await sql`

--- a/src/lib/vault/import-worker.js
+++ b/src/lib/vault/import-worker.js
@@ -363,6 +363,19 @@ export async function processVaultImport(msg) {
 
           totalFiles++;
           if (totalFiles % 10 === 0) {
+            const [cancelRow] = await sql`
+              SELECT cancel_requested_at FROM app.canvas_import_jobs
+              WHERE id = ${jobId}::uuid
+            `;
+            if (cancelRow?.cancel_requested_at) {
+              console.log(`[${ts()}] Cancel requested for ${jobId}; aborting after ${totalFiles} files`);
+              await sql`
+                UPDATE app.canvas_import_jobs
+                SET status = 'cancelled', completed_at = NOW(), processed_files = ${totalFiles}
+                WHERE id = ${jobId}::uuid
+              `;
+              return; // exit processEntry — outer streamAndProcessZip will finish naturally
+            }
             await sql`
               UPDATE app.canvas_import_jobs
               SET expected_total = ${totalFiles + failedFiles},

--- a/src/lib/vault/import-worker.js
+++ b/src/lib/vault/import-worker.js
@@ -302,6 +302,7 @@ export async function processVaultImport(msg) {
 
     const storage = getStorageProvider();
     const folderCache = new Map();
+    let cancelled = false;
     let totalFiles = 0;
     let totalFolders = 0;
     let failedFiles = 0;
@@ -313,6 +314,7 @@ export async function processVaultImport(msg) {
       userId,
       jobId,
       async (entryPath, buffer) => {
+        if (cancelled) return;
         const cleanPath = sanitizePath(entryPath);
         if (!cleanPath || shouldIgnore(entryPath)) return;
 
@@ -374,6 +376,7 @@ export async function processVaultImport(msg) {
                 SET status = 'cancelled', completed_at = NOW(), processed_files = ${totalFiles}
                 WHERE id = ${jobId}::uuid
               `;
+              cancelled = true;
               return; // exit processEntry — outer streamAndProcessZip will finish naturally
             }
             await sql`
@@ -394,6 +397,11 @@ export async function processVaultImport(msg) {
         }
       },
     );
+
+    if (cancelled) {
+      console.log(`[${ts()}] Import cancelled for ${jobId}; skipping completion`);
+      return;
+    }
 
     // seed initial quiz questions from newly imported chunks (non-fatal)
     try {

--- a/src/lib/vault/import-worker.js
+++ b/src/lib/vault/import-worker.js
@@ -404,7 +404,7 @@ export async function processVaultImport(msg) {
 
     await sql`
       UPDATE app.canvas_import_jobs
-      SET status = 'complete', expected_total = ${totalEntries || totalFiles + failedFiles}, completed_at = NOW(), updated_at = NOW()
+      SET status = 'complete', processed_files = ${totalFiles}, expected_total = ${totalEntries || totalFiles + failedFiles}, completed_at = NOW(), updated_at = NOW()
       WHERE id = ${jobId}::uuid
     `;
 

--- a/src/lib/vault/import-worker.js
+++ b/src/lib/vault/import-worker.js
@@ -374,7 +374,7 @@ export async function processVaultImport(msg) {
               await sql`
                 UPDATE app.canvas_import_jobs
                 SET status = 'cancelled', completed_at = NOW(), processed_files = ${totalFiles}
-                WHERE id = ${jobId}::uuid
+                WHERE id = ${jobId}::uuid AND status = 'processing'
               `;
               cancelled = true;
               return; // exit processEntry — outer streamAndProcessZip will finish naturally
@@ -447,6 +447,10 @@ export async function processVaultImport(msg) {
       `[${ts()}] Vault import complete: ${totalFiles} files, ${totalFolders} folders, ${failedFiles} failures`,
     );
   } catch (error) {
+    if (cancelled) {
+      console.warn(`[${ts()}] Ignoring error after cancel for ${jobId}: ${error.message}`);
+      throw error;
+    }
     console.error(`[${ts()}] Vault import failed:`, error);
     await sql`
       UPDATE app.canvas_import_jobs

--- a/src/lib/vault/import-worker.js
+++ b/src/lib/vault/import-worker.js
@@ -363,7 +363,13 @@ export async function processVaultImport(msg) {
 
           totalFiles++;
           if (totalFiles % 10 === 0) {
-            await sql`UPDATE app.canvas_import_jobs SET expected_total = ${totalFiles + failedFiles}, updated_at = NOW() WHERE id = ${jobId}::uuid`;
+            await sql`
+              UPDATE app.canvas_import_jobs
+              SET expected_total = ${totalFiles + failedFiles},
+                  processed_files = ${totalFiles},
+                  updated_at = NOW()
+              WHERE id = ${jobId}::uuid
+            `;
           }
           console.log(`[${ts()}] Imported: ${cleanPath}`);
         } catch (err) {


### PR DESCRIPTION
## Summary

Closes four gaps in the vault import/export system that affect user-visible behavior and operational safety. Plan in `docs/superpowers/plans/2026-05-13-vault-jobs-hardening.md`.

- **Retries (Task 1):** Canvas-import and extract-retry queues now retry 3x with exponential backoff (1s, 5s, 25s). Vault jobs explicitly override to `attempts: 1` because the import worker isn't idempotent (`createNote` mints fresh UUIDs per entry — retry would duplicate notes).
- **Progress (Task 2):** New `processed_files` column on `app.canvas_import_jobs` (migration 029). Both workers persist progress; status response surfaces unified `progress: { completed, total, percent }` for export AND import. UI now shows export progress mirroring the import bar.
- **409 conflict (Task 3):** `POST /api/vault/export` and `/api/vault/import/start` return 409 with `{ activeJobId }` when an active job exists, instead of silently replacing it. UI prompts on conflict and retries with `?force=true` (query for export, body for import) if the user confirms.
- **Cancellation (Task 4):** New `DELETE /api/vault/jobs/[jobId]/cancel` endpoint sets `cancel_requested_at`. Workers check the flag at progress checkpoints, abort cleanly (S3 multipart abort for export, closure flag + post-loop guard for import), and update status to `cancelled`. UI shows a Cancel button with "Cancelling..." disabled state.

## Schema changes

`database/migrations/029_vault_progress_and_cancel.sql`:
- `app.canvas_import_jobs.processed_files INTEGER NOT NULL DEFAULT 0`
- `app.canvas_import_jobs.cancel_requested_at TIMESTAMPTZ`
- Partial index `idx_canvas_import_jobs_cancel` on cancel_requested_at when not null

Auto-applied during Amplify deploy via `npm run migrate` per CLAUDE.md.

## Test plan

- [x] Unit tests: 597 passing (was 587 — added 10 new tests across 4 new files)
- [x] `npx tsc --noEmit`: no new errors
- [x] eslint: no new warnings
- [ ] Smoke test in dev environment after deploy:
  - [ ] Trigger export, confirm progress bar advances every ~50 files
  - [ ] Start a second export while first is running — confirm 409 + confirm dialog
  - [ ] Cancel an in-progress import; confirm DB status flips to `cancelled` and worker stops within 10 seconds (next checkpoint)
  - [ ] Verify SES email arrives on successful export completion
  - [ ] Verify cancelled jobs do NOT send completion email

## Known follow-ups (not in this PR)

- `src/app/api/import-export/route.ts` is dead code (no UI callers, missing `jobId` in payload, gated by unused `VAULT_JOBS_ENABLED`) — separate cleanup PR.
- Vault import worker idempotency (so `attempts: 3` becomes safe for vault).
- TOCTOU on job-conflict check — documented inline; proper fix is a unique partial index on `(user_id, type) WHERE status IN ('queued','processing')`.
- Tasks 5 (skipRAG opt-out) and 6 (orphan cleanup on failed imports) deferred from the plan.