### PR TITLE
Migrate storage and queues to Cloudflare

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ GITHUB_ID=
 GITHUB_SECRET=
 
 # Storage: S3-compatible (RustFS locally/currently; Cloudflare R2 target)
+# R2: STORAGE_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com, STORAGE_REGION=auto,
+# STORAGE_PATH_STYLE=true, and R2 S3 API credentials in STORAGE_ACCESS_KEY/STORAGE_SECRET_KEY.
 STORAGE_ENDPOINT=http://localhost:9000
 STORAGE_BUCKET=oghma-notes
 STORAGE_REGION=us-east-1
@@ -41,10 +43,21 @@ STORAGE_SECRET_KEY=your-secret-key
 STORAGE_PATH_STYLE=true
 STORAGE_PREFIX=oghma-dev
 
+# Queue provider: bullmq for local/current homelab, cloudflare for Cloudflare Queues HTTP pull.
+QUEUE_PROVIDER=bullmq
+
 # Redis / BullMQ
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_TLS=false
+
+# Cloudflare Queues (required when QUEUE_PROVIDER=cloudflare)
+CLOUDFLARE_QUEUES_API_TOKEN=
+CLOUDFLARE_CANVAS_IMPORT_QUEUE_ID=
+CLOUDFLARE_EXTRACT_RETRY_QUEUE_ID=
+CLOUDFLARE_QUEUE_VISIBILITY_TIMEOUT_MS=43200000
+CLOUDFLARE_QUEUE_RETRY_DELAY_SECONDS=60
+CLOUDFLARE_QUEUE_EMPTY_POLL_INTERVAL_MS=5000
 
 # Import/indexing controls
 CANVAS_GLOBAL_FILE_CONCURRENCY=6

--- a/.env.production.template
+++ b/.env.production.template
@@ -34,6 +34,8 @@ DATABASE_URL=postgresql://oghma_app:PASSWORD@oghma-postgres:5432/oghma?search_pa
 MIGRATION_DATABASE_URL=postgresql://oghma_admin:PASSWORD@oghma-postgres:5432/oghma?search_path=app,public
 
 # Storage: S3-compatible (RustFS currently; Cloudflare R2 launch target)
+# R2: STORAGE_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com, STORAGE_REGION=auto,
+# STORAGE_PATH_STYLE=true, and R2 S3 API credentials in STORAGE_ACCESS_KEY/STORAGE_SECRET_KEY.
 STORAGE_ENDPOINT=http://oghma-rustfs:9000
 STORAGE_BUCKET=oghma-notes
 STORAGE_REGION=us-east-1
@@ -42,10 +44,21 @@ STORAGE_SECRET_KEY=your-secret
 STORAGE_PATH_STYLE=true
 STORAGE_PREFIX=oghma
 
+# Queue provider: bullmq for current homelab, cloudflare for Cloudflare Queues HTTP pull.
+QUEUE_PROVIDER=bullmq
+
 # Redis / BullMQ
 REDIS_HOST=oghma-redis
 REDIS_PORT=6379
 REDIS_TLS=false
+
+# Cloudflare Queues (required when QUEUE_PROVIDER=cloudflare)
+CLOUDFLARE_QUEUES_API_TOKEN=
+CLOUDFLARE_CANVAS_IMPORT_QUEUE_ID=
+CLOUDFLARE_EXTRACT_RETRY_QUEUE_ID=
+CLOUDFLARE_QUEUE_VISIBILITY_TIMEOUT_MS=43200000
+CLOUDFLARE_QUEUE_RETRY_DELAY_SECONDS=60
+CLOUDFLARE_QUEUE_EMPTY_POLL_INTERVAL_MS=5000
 
 # Import/indexing controls
 CANVAS_GLOBAL_FILE_CONCURRENCY=2

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -10,9 +10,9 @@ Launch hosting target: [../infra/TARGET_HOSTING.md](../infra/TARGET_HOSTING.md).
 |---|---|
 | App | `oghma-dev` / `oghma-prod` Next.js containers |
 | Worker | `oghma-dev-worker` / `oghma-prod-worker` running `npm run worker` |
-| Queue | BullMQ on `oghma-redis:6379` |
+| Queue | BullMQ on `oghma-redis:6379`, or Cloudflare Queues HTTP pull when `QUEUE_PROVIDER=cloudflare` |
 | Job table | `app.canvas_import_jobs` |
-| Storage | RustFS/S3-compatible bucket |
+| Storage | RustFS/S3-compatible bucket, or Cloudflare R2 via S3 API |
 | OCR | Optional `MARKER_API_URL`; fallback extraction when unset or unavailable |
 
 Worker job names live on the `canvas-import` and `extract-retry` queues. Current names include `canvas-discover`, `canvas-file`, `extract`, `marker-complete`, `vault-import`, `vault-export`, and the legacy `canvas-import` handler for in-flight compatibility.
@@ -40,11 +40,40 @@ Set these in `/home/semyon/jenkins/env/oghma-dev.env` and `/home/semyon/jenkins/
 | `CANVAS_EMBED_CONCURRENCY` | `3` | Concurrent embedding writes |
 | `CANVAS_FILE_TIMEOUT_MS` | `600000` in import worker | Per-file import timeout |
 | `CANVAS_POLL_INTERVAL_MS` | `3000` | Client/status polling interval |
+| `QUEUE_PROVIDER` | `bullmq` | `bullmq` or `cloudflare` |
 | `REDIS_HOST`, `REDIS_PORT` | `localhost`, `6379` | BullMQ connection |
+| `CLOUDFLARE_CANVAS_IMPORT_QUEUE_ID`, `CLOUDFLARE_EXTRACT_RETRY_QUEUE_ID` | unset | Cloudflare queue IDs for HTTP publish/pull |
+| `CLOUDFLARE_QUEUES_API_TOKEN` | unset | Cloudflare token with Account Queues Edit |
+| `CLOUDFLARE_QUEUE_VISIBILITY_TIMEOUT_MS` | `43200000` | HTTP pull lease duration |
 | `MARKER_API_URL` | unset | Enables Marker OCR |
 | `DATALAB_API_KEY` | unset | Historical/emergency external extraction fallback; not steady-state launch processing |
 
 Also keep `DATABASE_URL`, `MIGRATION_DATABASE_URL`, storage keys, email transport keys, auth secrets, and AI provider keys in sync with [../SETUP.md](../SETUP.md).
+
+Cloudflare resource setup is scripted:
+
+```bash
+CLOUDFLARE_ACCOUNT_ID=<account-id> CLOUDFLARE_API_TOKEN=<token> npm run cf:setup
+```
+
+Object storage migration to R2 is also scripted. It copies keys under the existing prefix unchanged:
+
+```bash
+SOURCE_STORAGE_ENDPOINT=http://oghma-rustfs:9000 \
+SOURCE_STORAGE_BUCKET=oghma-notes \
+SOURCE_STORAGE_REGION=us-east-1 \
+SOURCE_STORAGE_ACCESS_KEY=<rustfs-key> \
+SOURCE_STORAGE_SECRET_KEY=<rustfs-secret> \
+SOURCE_STORAGE_PATH_STYLE=true \
+SOURCE_STORAGE_PREFIX=oghma \
+DEST_STORAGE_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com \
+DEST_STORAGE_BUCKET=oghma-notes \
+DEST_STORAGE_REGION=auto \
+DEST_STORAGE_ACCESS_KEY=<r2-key> \
+DEST_STORAGE_SECRET_KEY=<r2-secret> \
+DEST_STORAGE_PATH_STYLE=true \
+npm run cf:migrate-storage
+```
 
 ## Verification
 
@@ -97,7 +126,7 @@ Do not use managed document APIs such as Datalab as the steady-state import path
 
 ## Troubleshooting
 
-**Worker not picking up jobs:** confirm `REDIS_HOST`/`REDIS_PORT`, worker container health, and `docker logs oghma-*-worker`.
+**Worker not picking up jobs:** for BullMQ, confirm `REDIS_HOST`/`REDIS_PORT`, worker container health, and `docker logs oghma-*-worker`. For Cloudflare Queues, confirm `QUEUE_PROVIDER=cloudflare`, queue IDs, `CLOUDFLARE_QUEUES_API_TOKEN`, and that HTTP pull consumers are enabled.
 
 **Files stuck in `queued` or `discovering`:** the worker has a DB safety-net that re-enqueues orphans. If rows stay stuck, check worker errors and Redis connectivity.
 

--- a/infra/TARGET_HOSTING.md
+++ b/infra/TARGET_HOSTING.md
@@ -14,7 +14,7 @@ Use Cloudflare for the edge and platform-adjacent services, but keep a normal No
 | DNS, CDN, TLS, WAF/bot basics | Cloudflare |
 | Web app trial | Cloudflare Workers + OpenNext, if compatibility is acceptable |
 | Production fallback app runtime | Small Node/Docker host such as Railway, Fly, Render, or Hetzner/Coolify |
-| Background worker | Node/Docker worker service, not Cloudflare Workers for the first migration |
+| Background worker | Node/Docker worker service consuming Cloudflare Queues over HTTP pull |
 | Database | Neon Postgres with pgvector |
 | Object storage | Cloudflare R2 via S3-compatible API |
 | Transactional email | Cloudflare Email Sending |
@@ -41,7 +41,7 @@ Code reality:
 - Upload, Canvas, and vault routes enqueue BullMQ work directly.
 - Production logging, PDF parsing, and storage proxying use Node-shaped libraries and streams in several paths.
 
-That means Cloudflare Workers/OpenNext is a trial for the web app surface first. The worker stays Node/Docker unless the queue system is deliberately redesigned around Cloudflare Queues or a Node API sidecar.
+That means Cloudflare Workers/OpenNext is a trial for the web app surface first. The worker stays Node/Docker; Cloudflare Queues can replace Redis/BullMQ through HTTP publish/pull without moving the long-running worker into Workers.
 
 ## OpenNext Trial Policy
 
@@ -94,9 +94,9 @@ Use Cloudflare R2 as the launch object store.
 
 R2 is a good fit because the app already uses S3-compatible storage and user file downloads can become expensive on egress-charging providers.
 
-Migration caveat: not all code paths use the shared storage abstraction yet. Before switching production storage to R2, centralize vault import/export S3 clients through the same storage configuration used by the main app.
+Migration caveat: keep object keys under the same `STORAGE_PREFIX` during copy, because database rows store logical keys below that prefix.
 
-Specific code caveat: the main storage provider is already S3-compatible, but vault import/export still has direct `S3Client` usage that must be checked against `STORAGE_ENDPOINT`, R2 credentials, and path-style settings before cutover.
+The main storage provider and vault import/export paths now use the same S3-compatible configuration: `STORAGE_ENDPOINT`, `STORAGE_REGION`, `STORAGE_ACCESS_KEY`, `STORAGE_SECRET_KEY`, `STORAGE_PATH_STYLE`, and `STORAGE_PREFIX`.
 
 References:
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "worker": "tsx src/lib/canvas/worker-entry.js",
     "build": "next build",
     "migrate": "node scripts/prebuild-migrate.mjs",
+    "cf:setup": "node scripts/cloudflare/setup-r2-queues.mjs",
+    "cf:migrate-storage": "node scripts/cloudflare/migrate-storage-to-r2.mjs",
     "start": "next start",
     "start:next": "next start",
     "lint": "eslint",

--- a/scripts/cloudflare/migrate-storage-to-r2.mjs
+++ b/scripts/cloudflare/migrate-storage-to-r2.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
+  CreateMultipartUploadCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+  UploadPartCommand,
+} from "@aws-sdk/client-s3";
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run");
+const overwrite = args.has("--overwrite");
+const partSize = parseInt(process.env.MIGRATION_PART_SIZE_BYTES ?? `${64 * 1024 * 1024}`, 10);
+
+function required(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
+function clientFrom(prefix) {
+  const endpoint = process.env[`${prefix}_STORAGE_ENDPOINT`];
+  const accessKey = process.env[`${prefix}_STORAGE_ACCESS_KEY`];
+  const secretKey = process.env[`${prefix}_STORAGE_SECRET_KEY`];
+
+  return new S3Client({
+    region: process.env[`${prefix}_STORAGE_REGION`] ?? "us-east-1",
+    ...(endpoint && { endpoint }),
+    forcePathStyle: process.env[`${prefix}_STORAGE_PATH_STYLE`] === "true",
+    ...(accessKey && secretKey && {
+      credentials: {
+        accessKeyId: accessKey,
+        secretAccessKey: secretKey,
+      },
+    }),
+  });
+}
+
+async function destinationHasObject(s3, bucket, key) {
+  try {
+    await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+    return true;
+  } catch (error) {
+    const status = error?.$metadata?.httpStatusCode;
+    if (status === 404 || error?.name === "NotFound" || error?.name === "NoSuchKey") return false;
+    throw error;
+  }
+}
+
+async function putSmallObject(dest, bucket, key, chunks, meta) {
+  await dest.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: Buffer.concat(chunks),
+      ContentType: meta.contentType,
+      Metadata: meta.metadata,
+      CacheControl: meta.cacheControl,
+      ContentDisposition: meta.contentDisposition,
+      ContentEncoding: meta.contentEncoding,
+    }),
+  );
+}
+
+async function uploadPart(dest, bucket, key, uploadId, partNumber, chunks) {
+  const body = Buffer.concat(chunks);
+  const result = await dest.send(
+    new UploadPartCommand({
+      Bucket: bucket,
+      Key: key,
+      UploadId: uploadId,
+      PartNumber: partNumber,
+      Body: body,
+    }),
+  );
+  return { PartNumber: partNumber, ETag: result.ETag };
+}
+
+async function copyObject(source, dest, sourceBucket, destBucket, key) {
+  const object = await source.send(new GetObjectCommand({ Bucket: sourceBucket, Key: key }));
+  if (!object.Body) throw new Error(`Source object has no body: ${key}`);
+
+  const meta = {
+    contentType: object.ContentType,
+    metadata: object.Metadata,
+    cacheControl: object.CacheControl,
+    contentDisposition: object.ContentDisposition,
+    contentEncoding: object.ContentEncoding,
+  };
+
+  let uploadId = null;
+  let partNumber = 1;
+  let buffered = [];
+  let bufferedSize = 0;
+  const parts = [];
+
+  try {
+    for await (const chunk of object.Body) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      buffered.push(buffer);
+      bufferedSize += buffer.length;
+
+      if (bufferedSize < partSize) continue;
+
+      if (!uploadId) {
+        const multipart = await dest.send(
+          new CreateMultipartUploadCommand({
+            Bucket: destBucket,
+            Key: key,
+            ContentType: meta.contentType,
+            Metadata: meta.metadata,
+            CacheControl: meta.cacheControl,
+            ContentDisposition: meta.contentDisposition,
+            ContentEncoding: meta.contentEncoding,
+          }),
+        );
+        uploadId = multipart.UploadId;
+      }
+
+      parts.push(await uploadPart(dest, destBucket, key, uploadId, partNumber, buffered));
+      partNumber += 1;
+      buffered = [];
+      bufferedSize = 0;
+    }
+
+    if (!uploadId) {
+      await putSmallObject(dest, destBucket, key, buffered, meta);
+      return;
+    }
+
+    if (bufferedSize > 0) {
+      parts.push(await uploadPart(dest, destBucket, key, uploadId, partNumber, buffered));
+    }
+
+    await dest.send(
+      new CompleteMultipartUploadCommand({
+        Bucket: destBucket,
+        Key: key,
+        UploadId: uploadId,
+        MultipartUpload: { Parts: parts },
+      }),
+    );
+  } catch (error) {
+    if (uploadId) {
+      await dest
+        .send(new AbortMultipartUploadCommand({ Bucket: destBucket, Key: key, UploadId: uploadId }))
+        .catch(() => {});
+    }
+    throw error;
+  }
+}
+
+async function* listKeys(source, bucket, prefix) {
+  let ContinuationToken;
+  do {
+    const page = await source.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        ContinuationToken,
+      }),
+    );
+    for (const object of page.Contents ?? []) {
+      if (object.Key) yield object.Key;
+    }
+    ContinuationToken = page.NextContinuationToken;
+  } while (ContinuationToken);
+}
+
+async function main() {
+  const sourceBucket = required("SOURCE_STORAGE_BUCKET");
+  const destBucket = required("DEST_STORAGE_BUCKET");
+  const sourcePrefix = process.env.SOURCE_STORAGE_PREFIX ?? "oghma";
+  const source = clientFrom("SOURCE");
+  const dest = clientFrom("DEST");
+
+  let copied = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  console.log(
+    `${dryRun ? "Dry-run copying" : "Copying"} s3://${sourceBucket}/${sourcePrefix}/ -> s3://${destBucket}/${sourcePrefix}/`,
+  );
+
+  for await (const key of listKeys(source, sourceBucket, `${sourcePrefix}/`)) {
+    try {
+      if (!overwrite && (await destinationHasObject(dest, destBucket, key))) {
+        skipped += 1;
+        continue;
+      }
+
+      if (dryRun) {
+        console.log(`[dry-run] ${key}`);
+        copied += 1;
+        continue;
+      }
+
+      await copyObject(source, dest, sourceBucket, destBucket, key);
+      copied += 1;
+      if (copied % 25 === 0) {
+        console.log(`Copied ${copied} object(s), skipped ${skipped}, failed ${failed}`);
+      }
+    } catch (error) {
+      failed += 1;
+      console.error(`Failed ${key}: ${error.message}`);
+    }
+  }
+
+  console.log(`Done. copied=${copied} skipped=${skipped} failed=${failed}`);
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/cloudflare/setup-r2-queues.mjs
+++ b/scripts/cloudflare/setup-r2-queues.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? process.env.CF_ACCOUNT_ID;
+const expectedEmail = process.env.CLOUDFLARE_EXPECTED_EMAIL ?? "cloudflare@oghmanotes.ie";
+const r2Bucket = process.env.R2_BUCKET_NAME ?? process.env.STORAGE_BUCKET ?? "oghma-notes";
+const queuePrefix = process.env.CLOUDFLARE_QUEUE_PREFIX ?? "oghma";
+const canvasQueue = process.env.CLOUDFLARE_CANVAS_IMPORT_QUEUE_NAME ?? `${queuePrefix}-canvas-import`;
+const retryQueue = process.env.CLOUDFLARE_EXTRACT_RETRY_QUEUE_NAME ?? `${queuePrefix}-extract-retry`;
+
+function runWrangler(args, options = {}) {
+  const fullArgs = ["wrangler", ...args];
+  console.log(`$ npx ${fullArgs.join(" ")}`);
+  return execFileSync("npx", fullArgs, {
+    encoding: "utf8",
+    stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    env: process.env,
+  });
+}
+
+function runWranglerAllowExists(args) {
+  try {
+    runWrangler(args, { capture: true });
+    return true;
+  } catch (error) {
+    const output = `${error.stdout ?? ""}\n${error.stderr ?? ""}`;
+    if (/already exists|already (?:been )?taken|already has a consumer|exists/i.test(output)) {
+      console.log("Resource already exists; continuing.");
+      return true;
+    }
+    if (/Please enable R2 through the Cloudflare Dashboard|code: 10042/i.test(output)) {
+      console.warn("R2 is not enabled on this account yet; skipping bucket creation.");
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function cfApi(path, init = {}) {
+  const token = process.env.CLOUDFLARE_API_TOKEN ?? process.env.CLOUDFLARE_QUEUES_API_TOKEN;
+  if (!token) {
+    throw new Error("Set CLOUDFLARE_API_TOKEN to look up created queue IDs.");
+  }
+
+  const response = await fetch(`https://api.cloudflare.com/client/v4${path}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      ...init.headers,
+    },
+  });
+  const payload = await response.json();
+  if (!response.ok || payload.success === false) {
+    const detail = payload.errors?.map((err) => err.message).join("; ") || response.statusText;
+    throw new Error(`Cloudflare API failed (${response.status}): ${detail}`);
+  }
+  return payload.result;
+}
+
+async function queueIdByName(name) {
+  if (!process.env.CLOUDFLARE_API_TOKEN && !process.env.CLOUDFLARE_QUEUES_API_TOKEN) {
+    const list = runWrangler(["queues", "list"], { capture: true });
+    const row = list
+      .split("\n")
+      .map((line) => line.match(/│\s*([a-f0-9]{32})\s*│\s*([^│]+?)\s*│/))
+      .find((match) => match?.[2]?.trim() === name);
+    if (row?.[1]) return row[1];
+    throw new Error(`Queue not found after creation: ${name}`);
+  }
+
+  const queues = await cfApi(`/accounts/${accountId}/queues`);
+  const queue = queues.find((item) => item.queue_name === name || item.name === name);
+  if (!queue) throw new Error(`Queue not found after creation: ${name}`);
+  return queue.queue_id ?? queue.id;
+}
+
+async function main() {
+  if (!accountId) {
+    throw new Error("Set CLOUDFLARE_ACCOUNT_ID or CF_ACCOUNT_ID before running this script.");
+  }
+
+  let whoami = "";
+  try {
+    whoami = runWrangler(["whoami"], { capture: true });
+    process.stdout.write(whoami);
+  } catch (error) {
+    console.error(error.stderr || error.message);
+    throw new Error("Wrangler is not authenticated. Run `npx wrangler login` or set CLOUDFLARE_API_TOKEN.");
+  }
+
+  if (expectedEmail && !whoami.includes(expectedEmail) && !process.env.CLOUDFLARE_API_TOKEN) {
+    throw new Error(
+      `Wrangler is not authenticated as ${expectedEmail}. Set CLOUDFLARE_EXPECTED_EMAIL to override this guard.`,
+    );
+  }
+
+  const r2Ready = runWranglerAllowExists(["r2", "bucket", "create", r2Bucket]);
+  runWranglerAllowExists(["queues", "create", canvasQueue]);
+  runWranglerAllowExists(["queues", "create", retryQueue]);
+  runWranglerAllowExists([
+    "queues",
+    "consumer",
+    "http",
+    "add",
+    canvasQueue,
+    "--batch-size",
+    process.env.CLOUDFLARE_QUEUE_BATCH_SIZE ?? "10",
+    "--message-retries",
+    process.env.CLOUDFLARE_QUEUE_MESSAGE_RETRIES ?? "3",
+    "--visibility-timeout-secs",
+    process.env.CLOUDFLARE_QUEUE_VISIBILITY_TIMEOUT_SECS ?? `${12 * 60 * 60}`,
+    "--retry-delay-secs",
+    process.env.CLOUDFLARE_QUEUE_RETRY_DELAY_SECONDS ?? "60",
+  ]);
+  runWranglerAllowExists([
+    "queues",
+    "consumer",
+    "http",
+    "add",
+    retryQueue,
+    "--batch-size",
+    process.env.CLOUDFLARE_QUEUE_BATCH_SIZE ?? "10",
+    "--message-retries",
+    process.env.CLOUDFLARE_QUEUE_MESSAGE_RETRIES ?? "3",
+    "--visibility-timeout-secs",
+    process.env.CLOUDFLARE_QUEUE_VISIBILITY_TIMEOUT_SECS ?? `${12 * 60 * 60}`,
+    "--retry-delay-secs",
+    process.env.CLOUDFLARE_QUEUE_RETRY_DELAY_SECONDS ?? "60",
+  ]);
+
+  const canvasQueueId = await queueIdByName(canvasQueue);
+  const retryQueueId = await queueIdByName(retryQueue);
+
+  console.log("\nCloudflare resources ready. Add these to the Jenkins env files:");
+  if (r2Ready) {
+    console.log(`STORAGE_ENDPOINT=https://${accountId}.r2.cloudflarestorage.com`);
+    console.log(`STORAGE_BUCKET=${r2Bucket}`);
+    console.log("STORAGE_REGION=auto");
+    console.log("STORAGE_PATH_STYLE=true");
+  } else {
+    console.log("# R2 bucket was not created. Enable R2 in the Cloudflare dashboard, then rerun this script.");
+  }
+  console.log("QUEUE_PROVIDER=cloudflare");
+  console.log(`CLOUDFLARE_CANVAS_IMPORT_QUEUE_ID=${canvasQueueId}`);
+  console.log(`CLOUDFLARE_EXTRACT_RETRY_QUEUE_ID=${retryQueueId}`);
+  console.log("CLOUDFLARE_QUEUES_API_TOKEN=<token with Account Queues Edit>");
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/src/__tests__/lib/queue-cloudflare.test.ts
+++ b/src/__tests__/lib/queue-cloudflare.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  enqueueCanvasJob,
+  enqueueExtractRetryJob,
+  parseCloudflareQueueBody,
+} from "@/lib/queue";
+
+function setCloudflareQueueEnv() {
+  process.env.QUEUE_PROVIDER = "cloudflare";
+  process.env.CLOUDFLARE_ACCOUNT_ID = "account-1";
+  process.env.CLOUDFLARE_QUEUES_API_TOKEN = "queue-token";
+  process.env.CLOUDFLARE_CANVAS_IMPORT_QUEUE_ID = "canvas-queue-id";
+  process.env.CLOUDFLARE_EXTRACT_RETRY_QUEUE_ID = "retry-queue-id";
+}
+
+describe("Cloudflare queue adapter", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.QUEUE_PROVIDER;
+    delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    delete process.env.CLOUDFLARE_QUEUES_API_TOKEN;
+    delete process.env.CLOUDFLARE_CANVAS_IMPORT_QUEUE_ID;
+    delete process.env.CLOUDFLARE_EXTRACT_RETRY_QUEUE_ID;
+  });
+
+  it("publishes canvas jobs with the existing message envelope", async () => {
+    setCloudflareQueueEnv();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ success: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await enqueueCanvasJob("canvas-discover", { jobId: "job-1", userId: "user-1" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.cloudflare.com/client/v4/accounts/account-1/queues/canvas-queue-id/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          body: { type: "canvas-discover", jobId: "job-1", userId: "user-1" },
+          contentType: "json",
+        }),
+      }),
+    );
+  });
+
+  it("publishes delayed extraction retries to the retry queue", async () => {
+    setCloudflareQueueEnv();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ success: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await enqueueExtractRetryJob({ noteId: "note-1" }, 120);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.cloudflare.com/client/v4/accounts/account-1/queues/retry-queue-id/messages",
+      expect.objectContaining({
+        body: JSON.stringify({
+          body: { type: "extract-retry", noteId: "note-1" },
+          contentType: "json",
+          delaySeconds: 120,
+        }),
+      }),
+    );
+  });
+
+  it("decodes base64 JSON bodies returned by HTTP pull", () => {
+    const body = Buffer.from(JSON.stringify({ type: "extract", noteId: "note-1" })).toString("base64");
+
+    expect(
+      parseCloudflareQueueBody({
+        id: "msg-1",
+        lease_id: "lease-1",
+        attempts: 1,
+        body,
+        metadata: { "CF-Content-Type": "json" },
+      }),
+    ).toEqual({ type: "extract", noteId: "note-1" });
+  });
+});

--- a/src/app/api/vault/import/route.ts
+++ b/src/app/api/vault/import/route.ts
@@ -3,6 +3,7 @@ import { withErrorHandler, requireAuth, ApiError } from "@/lib/api-error";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { v4 as uuidv4 } from "uuid";
+import { createS3ClientConfig, createS3ConfigFromEnv } from "@/lib/storage/s3";
 
 /**
  * POST /api/vault/import
@@ -34,14 +35,7 @@ export const POST = withErrorHandler(async (request) => {
   const fullKey = `${prefix}/${s3Key}`;
 
   const s3 = new S3Client({
-    region: process.env.STORAGE_REGION || "us-east-1",
-    ...(process.env.STORAGE_ENDPOINT && { endpoint: process.env.STORAGE_ENDPOINT }),
-    ...(process.env.STORAGE_ACCESS_KEY && process.env.STORAGE_SECRET_KEY && {
-      credentials: {
-        accessKeyId: process.env.STORAGE_ACCESS_KEY,
-        secretAccessKey: process.env.STORAGE_SECRET_KEY,
-      },
-    }),
+    ...createS3ClientConfig(createS3ConfigFromEnv()),
   });
 
   const uploadUrl = await getSignedUrl(

--- a/src/app/api/vault/status/route.ts
+++ b/src/app/api/vault/status/route.ts
@@ -3,6 +3,7 @@ import { withErrorHandler, requireAuth, ApiError } from "@/lib/api-error";
 import sql from "@/database/pgsql.js";
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { createS3ClientConfig, createS3ConfigFromEnv } from "@/lib/storage/s3";
 
 /**
  * GET /api/vault/status?type=vault-import|vault-export
@@ -46,14 +47,7 @@ export const GET = withErrorHandler(async (request) => {
     const prefix = process.env.STORAGE_PREFIX || "oghma";
     const fullKey = `${prefix}/${job.output_s3_key}`;
     const s3 = new S3Client({
-      region: process.env.STORAGE_REGION || "us-east-1",
-      ...(process.env.STORAGE_ENDPOINT && { endpoint: process.env.STORAGE_ENDPOINT }),
-      ...(process.env.STORAGE_ACCESS_KEY && process.env.STORAGE_SECRET_KEY && {
-        credentials: {
-          accessKeyId: process.env.STORAGE_ACCESS_KEY,
-          secretAccessKey: process.env.STORAGE_SECRET_KEY,
-        },
-      }),
+      ...createS3ClientConfig(createS3ConfigFromEnv()),
     });
 
     downloadUrl = await getSignedUrl(

--- a/src/lib/canvas/worker-entry.js
+++ b/src/lib/canvas/worker-entry.js
@@ -1,19 +1,22 @@
 /**
  * Canvas Worker Entry Point
  *
- * BullMQ workers for canvas-import + extract-retry queues, plus a DB safety-net
+ * Queue workers for canvas-import + extract-retry queues, plus a DB safety-net
  * that reclaims jobs whose enqueue dropped (atomic UPDATE claims queued orphans).
  *
  * Run: npx tsx src/lib/canvas/worker-entry.js
  */
 
 import sql from "../../database/pgsql.js";
-import { Worker } from "bullmq";
 import {
   CANVAS_IMPORT_QUEUE,
   EXTRACT_RETRY_QUEUE,
+  ackCloudflareQueueMessages,
   enqueueCanvasJob,
+  getQueueProvider,
   getQueueConnection,
+  parseCloudflareQueueBody,
+  pullCloudflareQueueMessages,
 } from "../queue.ts";
 import {
   processImportJob,
@@ -30,6 +33,18 @@ const STUCK_JOB_THRESHOLD = "1 hour";
 const STUCK_JOB_CHECK_INTERVAL_MS = 5 * 60 * 1000;
 const DB_POLL_INTERVAL_MS = 30_000;
 const MAX_CONCURRENT_JOBS = 10;
+const CF_QUEUE_VISIBILITY_TIMEOUT_MS = parseInt(
+  process.env.CLOUDFLARE_QUEUE_VISIBILITY_TIMEOUT_MS ?? `${12 * 60 * 60 * 1000}`,
+  10,
+);
+const CF_QUEUE_RETRY_DELAY_SECONDS = parseInt(
+  process.env.CLOUDFLARE_QUEUE_RETRY_DELAY_SECONDS ?? "60",
+  10,
+);
+const CF_QUEUE_EMPTY_POLL_INTERVAL_MS = parseInt(
+  process.env.CLOUDFLARE_QUEUE_EMPTY_POLL_INTERVAL_MS ?? "5000",
+  10,
+);
 
 async function failStuckJobs() {
   const stuck = await sql`
@@ -83,7 +98,7 @@ async function claimOrphanedJobs() {
   return true;
 }
 
-async function processCanvasJob(job) {
+export async function processCanvasJob(job) {
   const ts = () => new Date().toISOString();
   const type = job.data?.type ?? job.name;
   console.log(
@@ -122,7 +137,7 @@ async function processCanvasJob(job) {
 }
 
 console.log(
-  `[${new Date().toISOString()}] Canvas Import Worker started (BullMQ + DB poll, concurrency=${MAX_CONCURRENT_JOBS})`,
+  `[${new Date().toISOString()}] Canvas Import Worker started (${getQueueProvider()} + DB poll, concurrency=${MAX_CONCURRENT_JOBS})`,
 );
 
 await failStuckJobs();
@@ -135,40 +150,123 @@ setInterval(async () => {
   }
 }, DB_POLL_INTERVAL_MS);
 
-const connection = getQueueConnection();
+let workers = [];
+let shuttingDown = false;
 
-const canvasWorker = new Worker(CANVAS_IMPORT_QUEUE, processCanvasJob, {
-  connection,
-  concurrency: MAX_CONCURRENT_JOBS,
-  // long-running jobs (canvas import) extend lock automatically while active
-  lockDuration: 60_000,
-  stalledInterval: 30_000,
-});
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
-const retryWorker = new Worker(EXTRACT_RETRY_QUEUE, processCanvasJob, {
-  connection,
-  concurrency: MAX_CONCURRENT_JOBS,
-  lockDuration: 60_000,
-  stalledInterval: 30_000,
-});
+function cloudflareJobFromMessage(message) {
+  const data = parseCloudflareQueueBody(message);
+  const type = data.type ?? "unknown";
+  return {
+    id: message.id,
+    name: type,
+    data,
+  };
+}
 
-for (const w of [canvasWorker, retryWorker]) {
-  w.on("failed", (job, err) => {
-    console.error(
-      `[${new Date().toISOString()}] Job ${job?.id} (${job?.name}) failed:`,
-      err?.message,
-    );
+async function processCloudflareQueueBatch(queueName) {
+  const batch = await pullCloudflareQueueMessages(queueName, {
+    batchSize: MAX_CONCURRENT_JOBS,
+    visibilityTimeoutMs: CF_QUEUE_VISIBILITY_TIMEOUT_MS,
   });
-  w.on("error", (err) => {
-    console.error(`[${new Date().toISOString()}] Worker error:`, err?.message);
+
+  if (batch.messages.length === 0) return false;
+
+  const acks = [];
+  const retries = [];
+  await Promise.all(
+    batch.messages.map(async (message) => {
+      try {
+        await processCanvasJob(cloudflareJobFromMessage(message));
+        acks.push(message.lease_id);
+      } catch (err) {
+        console.error(
+          `[${new Date().toISOString()}] Cloudflare queue job ${message.id} failed:`,
+          err?.message,
+        );
+        retries.push({
+          lease_id: message.lease_id,
+          delay_seconds: CF_QUEUE_RETRY_DELAY_SECONDS,
+        });
+      }
+    }),
+  );
+
+  await ackCloudflareQueueMessages(queueName, acks, retries);
+  return true;
+}
+
+async function startCloudflarePullLoop(queueName) {
+  console.log(
+    `[${new Date().toISOString()}] Starting Cloudflare pull consumer for ${queueName}`,
+  );
+
+  while (!shuttingDown) {
+    try {
+      const hadMessages = await processCloudflareQueueBatch(queueName);
+      if (!hadMessages) {
+        await sleep(CF_QUEUE_EMPTY_POLL_INTERVAL_MS);
+      }
+    } catch (err) {
+      console.error(
+        `[${new Date().toISOString()}] Cloudflare pull error for ${queueName}:`,
+        err?.message,
+      );
+      await sleep(CF_QUEUE_EMPTY_POLL_INTERVAL_MS);
+    }
+  }
+}
+
+async function startBullMqWorkers() {
+  const { Worker } = await import("bullmq");
+  const connection = getQueueConnection();
+
+  const canvasWorker = new Worker(CANVAS_IMPORT_QUEUE, processCanvasJob, {
+    connection,
+    concurrency: MAX_CONCURRENT_JOBS,
+    // long-running jobs (canvas import) extend lock automatically while active
+    lockDuration: 60_000,
+    stalledInterval: 30_000,
   });
+
+  const retryWorker = new Worker(EXTRACT_RETRY_QUEUE, processCanvasJob, {
+    connection,
+    concurrency: MAX_CONCURRENT_JOBS,
+    lockDuration: 60_000,
+    stalledInterval: 30_000,
+  });
+
+  for (const w of [canvasWorker, retryWorker]) {
+    w.on("failed", (job, err) => {
+      console.error(
+        `[${new Date().toISOString()}] Job ${job?.id} (${job?.name}) failed:`,
+        err?.message,
+      );
+    });
+    w.on("error", (err) => {
+      console.error(`[${new Date().toISOString()}] Worker error:`, err?.message);
+    });
+  }
+
+  workers = [canvasWorker, retryWorker];
+}
+
+if (getQueueProvider() === "cloudflare") {
+  void startCloudflarePullLoop(CANVAS_IMPORT_QUEUE);
+  void startCloudflarePullLoop(EXTRACT_RETRY_QUEUE);
+} else {
+  await startBullMqWorkers();
 }
 
 const shutdown = async (signal) => {
+  shuttingDown = true;
   console.log(
     `[${new Date().toISOString()}] received ${signal}, draining workers`,
   );
-  await Promise.allSettled([canvasWorker.close(), retryWorker.close()]);
+  await Promise.allSettled(workers.map((worker) => worker.close()));
   await sql.end({ timeout: 5 });
   process.exit(0);
 };

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -1,7 +1,23 @@
-// BullMQ queues — replaces SQS for canvas-import + extract-retry pipelines
-// connection: REDIS_HOST/REDIS_PORT (defaults to localhost:6379)
+// Queue facade for canvas-import + extract-retry pipelines.
+// Defaults to BullMQ for local/current homelab compatibility. Set
+// QUEUE_PROVIDER=cloudflare to publish to Cloudflare Queues over HTTP.
 import { Queue, type JobsOptions } from "bullmq";
 import IORedis from "ioredis";
+
+export type QueueProvider = "bullmq" | "cloudflare";
+
+interface CloudflareQueueMessage {
+  body: Record<string, unknown>;
+  contentType?: "json";
+  delaySeconds?: number;
+}
+
+interface CloudflareQueueConfig {
+  accountId: string;
+  apiToken: string;
+  canvasQueueId: string;
+  extractRetryQueueId: string;
+}
 
 let _connection: IORedis | null = null;
 
@@ -17,6 +33,13 @@ function getConnection(): IORedis {
 
 export const CANVAS_IMPORT_QUEUE = "canvas-import";
 export const EXTRACT_RETRY_QUEUE = "extract-retry";
+
+export function getQueueProvider(): QueueProvider {
+  const provider = process.env.QUEUE_PROVIDER?.toLowerCase();
+  if (!provider || provider === "bullmq") return "bullmq";
+  if (provider === "cloudflare" || provider === "cf") return "cloudflare";
+  throw new Error(`Unsupported QUEUE_PROVIDER: ${process.env.QUEUE_PROVIDER}`);
+}
 
 let _canvasImportQueue: Queue | null = null;
 let _extractRetryQueue: Queue | null = null;
@@ -50,11 +73,110 @@ const DEFAULT_OPTS: JobsOptions = {
   backoff: { type: "exponential", delay: 1000 },
 };
 
+function getCloudflareQueueConfig(): CloudflareQueueConfig {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? process.env.CF_ACCOUNT_ID;
+  const apiToken =
+    process.env.CLOUDFLARE_QUEUES_API_TOKEN ??
+    process.env.CLOUDFLARE_QUEUE_API_TOKEN ??
+    process.env.CF_QUEUES_API_TOKEN;
+  const canvasQueueId = process.env.CLOUDFLARE_CANVAS_IMPORT_QUEUE_ID;
+  const extractRetryQueueId = process.env.CLOUDFLARE_EXTRACT_RETRY_QUEUE_ID;
+
+  const missing = [
+    ["CLOUDFLARE_ACCOUNT_ID", accountId],
+    ["CLOUDFLARE_QUEUES_API_TOKEN", apiToken],
+    ["CLOUDFLARE_CANVAS_IMPORT_QUEUE_ID", canvasQueueId],
+    ["CLOUDFLARE_EXTRACT_RETRY_QUEUE_ID", extractRetryQueueId],
+  ]
+    .filter(([, value]) => !value)
+    .map(([name]) => name);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing Cloudflare Queues configuration for QUEUE_PROVIDER=cloudflare: ${missing.join(", ")}`,
+    );
+  }
+
+  return {
+    accountId: accountId!,
+    apiToken: apiToken!,
+    canvasQueueId: canvasQueueId!,
+    extractRetryQueueId: extractRetryQueueId!,
+  };
+}
+
+function getCloudflareQueueId(queueName: string): string {
+  const config = getCloudflareQueueConfig();
+  switch (queueName) {
+    case CANVAS_IMPORT_QUEUE:
+      return config.canvasQueueId;
+    case EXTRACT_RETRY_QUEUE:
+      return config.extractRetryQueueId;
+    default:
+      throw new Error(`Unknown Cloudflare queue name: ${queueName}`);
+  }
+}
+
+function cloudflareQueueUrl(queueId: string, action?: "messages" | "pull" | "ack"): string {
+  const { accountId } = getCloudflareQueueConfig();
+  const base = `https://api.cloudflare.com/client/v4/accounts/${accountId}/queues/${queueId}/messages`;
+  return action && action !== "messages" ? `${base}/${action}` : base;
+}
+
+async function cloudflareQueueRequest<T>(
+  queueId: string,
+  action: "messages" | "pull" | "ack",
+  body: unknown,
+): Promise<T> {
+  const { apiToken } = getCloudflareQueueConfig();
+  const response = await fetch(cloudflareQueueUrl(queueId, action), {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) : {};
+  if (!response.ok || payload.success === false) {
+    const message =
+      payload.errors?.map((err: { message?: string }) => err.message).filter(Boolean).join("; ") ||
+      payload.message ||
+      response.statusText;
+    throw new Error(`Cloudflare Queues request failed (${response.status}): ${message}`);
+  }
+
+  return payload as T;
+}
+
+async function sendCloudflareQueueMessage(
+  queueName: string,
+  message: CloudflareQueueMessage,
+): Promise<void> {
+  await cloudflareQueueRequest(getCloudflareQueueId(queueName), "messages", message);
+}
+
+function delayMillisToSeconds(delay?: number): number | undefined {
+  if (!delay || delay <= 0) return undefined;
+  return Math.ceil(delay / 1000);
+}
+
 export async function enqueueCanvasJob(
   type: string,
   data: Record<string, unknown>,
   opts: JobsOptions = {},
 ): Promise<void> {
+  if (getQueueProvider() === "cloudflare") {
+    await sendCloudflareQueueMessage(CANVAS_IMPORT_QUEUE, {
+      body: { type, ...data },
+      contentType: "json",
+      delaySeconds: delayMillisToSeconds(opts.delay),
+    });
+    return;
+  }
+
   await getCanvasImportQueue().add(type, { type, ...data }, { ...DEFAULT_OPTS, ...opts });
 }
 
@@ -63,6 +185,18 @@ export async function enqueueCanvasJobBatch(
   payloads: Record<string, unknown>[],
 ): Promise<void> {
   if (payloads.length === 0) return;
+  if (getQueueProvider() === "cloudflare") {
+    await Promise.all(
+      payloads.map((data) =>
+        sendCloudflareQueueMessage(CANVAS_IMPORT_QUEUE, {
+          body: { type, ...data },
+          contentType: "json",
+        }),
+      ),
+    );
+    return;
+  }
+
   await getCanvasImportQueue().addBulk(
     payloads.map((data) => ({
       name: type,
@@ -76,6 +210,15 @@ export async function enqueueExtractRetryJob(
   data: Record<string, unknown>,
   delaySeconds: number,
 ): Promise<void> {
+  if (getQueueProvider() === "cloudflare") {
+    await sendCloudflareQueueMessage(EXTRACT_RETRY_QUEUE, {
+      body: { type: "extract-retry", ...data },
+      contentType: "json",
+      delaySeconds,
+    });
+    return;
+  }
+
   await getExtractRetryQueue().add(
     "extract-retry",
     { type: "extract-retry", ...data },
@@ -85,4 +228,61 @@ export async function enqueueExtractRetryJob(
 
 export function getQueueConnection(): IORedis {
   return getConnection();
+}
+
+export interface CloudflarePulledMessage {
+  id: string;
+  lease_id: string;
+  attempts: number;
+  body: unknown;
+  metadata?: Record<string, string>;
+}
+
+export interface CloudflarePullResult {
+  messages: CloudflarePulledMessage[];
+}
+
+export async function pullCloudflareQueueMessages(
+  queueName: string,
+  options: { batchSize?: number; visibilityTimeoutMs?: number } = {},
+): Promise<CloudflarePullResult> {
+  const queueId = getCloudflareQueueId(queueName);
+  const payload = await cloudflareQueueRequest<{
+    result?: { messages?: CloudflarePulledMessage[] };
+  }>(queueId, "pull", {
+    batch_size: options.batchSize ?? 10,
+    visibility_timeout_ms: options.visibilityTimeoutMs ?? 3_600_000,
+  });
+
+  return { messages: payload.result?.messages ?? [] };
+}
+
+export async function ackCloudflareQueueMessages(
+  queueName: string,
+  acks: string[],
+  retries: { lease_id: string; delay_seconds?: number }[] = [],
+): Promise<void> {
+  const queueId = getCloudflareQueueId(queueName);
+  await cloudflareQueueRequest(queueId, "ack", {
+    acks: acks.map((lease_id) => ({ lease_id })),
+    retries,
+  });
+}
+
+export function parseCloudflareQueueBody(message: CloudflarePulledMessage): Record<string, unknown> {
+  if (message.body && typeof message.body === "object" && !Array.isArray(message.body)) {
+    return message.body as Record<string, unknown>;
+  }
+
+  if (typeof message.body !== "string") {
+    throw new Error(`Unsupported Cloudflare queue body type for message ${message.id}`);
+  }
+
+  const contentType = message.metadata?.["CF-Content-Type"] ?? message.metadata?.["content-type"];
+  if (contentType === "json" || contentType === "bytes") {
+    const decoded = Buffer.from(message.body, "base64").toString("utf8");
+    return JSON.parse(decoded);
+  }
+
+  return JSON.parse(message.body);
 }

--- a/src/lib/storage/init.ts
+++ b/src/lib/storage/init.ts
@@ -1,7 +1,7 @@
 // Storage initialization
 // Creates and configures the storage provider instance
 
-import { StoreS3, type S3Config } from './s3';
+import { createS3ConfigFromEnv, StoreS3, type S3Config } from './s3';
 import { createLogger } from './logger';
 
 const logger = createLogger('store.init');
@@ -10,24 +10,7 @@ const logger = createLogger('store.init');
  * Validates that all required S3 configuration is available
  */
 function validateS3Config(): S3Config {
-  const bucket = process.env.STORAGE_BUCKET;
-
-  if (!bucket) {
-    throw new Error(
-      'Missing required environment variable: STORAGE_BUCKET. ' +
-        'Set it to your S3 bucket name.'
-    );
-  }
-
-  return {
-    bucket,
-    accessKey: process.env.STORAGE_ACCESS_KEY,
-    secretKey: process.env.STORAGE_SECRET_KEY,
-    region: process.env.STORAGE_REGION || 'us-east-1',
-    endPoint: process.env.STORAGE_ENDPOINT,
-    pathStyle: process.env.STORAGE_PATH_STYLE === 'true',
-    prefix: process.env.STORAGE_PREFIX || 'oghma',
-  };
+  return createS3ConfigFromEnv();
 }
 
 /**

--- a/src/lib/storage/s3.ts
+++ b/src/lib/storage/s3.ts
@@ -55,6 +55,51 @@ export interface S3Config extends StoreProviderConfig {
 }
 
 /**
+ * Build an AWS SDK v3 config for S3-compatible storage, including R2/RustFS.
+ */
+export function createS3ClientConfig(config: S3Config): S3ClientConfig {
+  const clientConfig: S3ClientConfig = {
+    region: config.region ?? 'us-east-1',
+    ...(config.endPoint && { endpoint: config.endPoint }),
+    ...(config.pathStyle !== undefined && { forcePathStyle: config.pathStyle }),
+  };
+
+  if (config.accessKey && config.secretKey) {
+    clientConfig.credentials = {
+      accessKeyId: config.accessKey,
+      secretAccessKey: config.secretKey,
+    };
+  }
+
+  return clientConfig;
+}
+
+export function createS3ConfigFromEnv(): S3Config {
+  const bucket = process.env.STORAGE_BUCKET;
+
+  if (!bucket) {
+    throw new Error(
+      'Missing required environment variable: STORAGE_BUCKET. ' +
+        'Set it to your S3 bucket name.'
+    );
+  }
+
+  return {
+    bucket,
+    accessKey: process.env.STORAGE_ACCESS_KEY,
+    secretKey: process.env.STORAGE_SECRET_KEY,
+    region: process.env.STORAGE_REGION || 'us-east-1',
+    endPoint: process.env.STORAGE_ENDPOINT,
+    pathStyle: process.env.STORAGE_PATH_STYLE === 'true',
+    prefix: process.env.STORAGE_PREFIX || 'oghma',
+  };
+}
+
+export function createS3ClientFromEnv(): S3Client {
+  return new S3Client(createS3ClientConfig(createS3ConfigFromEnv()));
+}
+
+/**
  * S3-compatible storage provider
  * Supports AWS S3, MinIO, and other S3-compatible endpoints
  */
@@ -81,21 +126,7 @@ export class StoreS3 extends StoreProvider {
    * Create and configure S3Client instance
    */
   private createS3Client(config: S3Config): S3Client {
-    const clientConfig: S3ClientConfig = {
-      region: config.region ?? 'us-east-1',
-      ...(config.endPoint && { endpoint: config.endPoint }),
-      ...(config.pathStyle !== undefined && { forcePathStyle: config.pathStyle }),
-    };
-
-    // Only add credentials if both key and secret are provided
-    if (config.accessKey && config.secretKey) {
-      clientConfig.credentials = {
-        accessKeyId: config.accessKey,
-        secretAccessKey: config.secretKey,
-      };
-    }
-
-    return new S3Client(clientConfig);
+    return new S3Client(createS3ClientConfig(config));
   }
 
   /**

--- a/src/lib/vault/export-worker.js
+++ b/src/lib/vault/export-worker.js
@@ -7,7 +7,6 @@
 import sql from "../../database/pgsql.js";
 import { Zip, ZipDeflate } from "fflate";
 import {
-  S3Client,
   CreateMultipartUploadCommand,
   UploadPartCommand,
   CompleteMultipartUploadCommand,
@@ -16,6 +15,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { getStorageProvider } from "../storage/init.ts";
+import { createS3ClientFromEnv } from "../storage/s3.ts";
 import { buildExportPathMap } from "./tree-builder.js";
 import { sendVaultExportCompleteEmail } from "../email.js";
 
@@ -118,9 +118,7 @@ export async function processVaultExport(msg) {
 
   const bucket = process.env.STORAGE_BUCKET;
   const prefix = process.env.STORAGE_PREFIX || "oghma";
-  const s3 = new S3Client({
-    region: process.env.STORAGE_REGION || "us-east-1",
-  });
+  const s3 = createS3ClientFromEnv();
   const outputKey = `${prefix}/exports/${userId}/${jobId}/vault-export.zip`;
 
   const uploader = new S3MultipartZipUploader(s3, bucket, outputKey);

--- a/src/lib/vault/import-worker.js
+++ b/src/lib/vault/import-worker.js
@@ -14,6 +14,7 @@ import { chunkText } from "../chunking.ts";
 import { replaceNoteEmbeddings } from "../rag/indexing.ts";
 import { stripMarkdown } from "../strip-markdown.ts";
 import { getStorageProvider } from "../storage/init.ts";
+import { createS3ClientFromEnv } from "../storage/s3.ts";
 import { addNoteToTree } from "../notes/storage/pg-tree.js";
 import { extractWithMarker } from "../ocr.ts";
 import { persistMarkerAssetsForNote } from "../marker-output.ts";
@@ -214,15 +215,13 @@ class EntryQueue {
  * Memory stays bounded at ~FILE_CONCURRENCY * largest_file_size.
  */
 async function streamAndProcessZip(s3Key, userId, jobId, processEntry) {
-  const { S3Client, GetObjectCommand } = await import("@aws-sdk/client-s3");
+  const { GetObjectCommand } = await import("@aws-sdk/client-s3");
 
   const bucket = process.env.STORAGE_BUCKET;
   const prefix = process.env.STORAGE_PREFIX || "oghma";
   const fullKey = `${prefix}/${s3Key}`;
 
-  const s3 = new S3Client({
-    region: process.env.STORAGE_REGION || "us-east-1",
-  });
+  const s3 = createS3ClientFromEnv();
   const res = await s3.send(
     new GetObjectCommand({ Bucket: bucket, Key: fullKey }),
   );


### PR DESCRIPTION
## Summary\n- Add R2-compatible shared S3 config and move vault import/export paths onto it\n- Add Cloudflare Queues HTTP publish/pull support while keeping BullMQ fallback\n- Add Cloudflare setup and object-storage migration scripts\n\n## Verification\n- npm run test -- src/__tests__/lib/queue-cloudflare.test.ts\n- full precommit test suite passed on commit 9598cdf\n- dev environment redeployed with R2 + Cloudflare Queues\n- remote R2 object counts match RustFS prefixes and SHA spot checks passed\n\n## Deployment notes\n- R2 bucket: oghma-notes\n- Dev is already running with QUEUE_PROVIDER=cloudflare and R2 storage\n- RustFS remains untouched as fallback\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cloudflare Queues as an alternative to the existing queue backend
  * Added support for Cloudflare R2 as an alternative storage provider
  * Added migration tools and setup scripts for Cloudflare infrastructure

* **Documentation**
  * Expanded deployment guide with Cloudflare configuration options and setup instructions
  * Updated infrastructure guidance with Cloudflare deployment recommendations and migration paths
  * Enhanced environment variable templates with Cloudflare-specific configuration details

* **Chores**
  * Added configuration templates and examples for Cloudflare integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->