### PR TITLE
fix: normalize fill-in quiz answer grading

### DIFF
--- a/src/__tests__/lib/quiz/fill-answer.test.ts
+++ b/src/__tests__/lib/quiz/fill-answer.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { isFillAnswerCorrect, normalizeFillAnswer } from "@/lib/quiz/fill-answer";
+
+describe("normalizeFillAnswer", () => {
+  it("ignores case and surrounding whitespace", () => {
+    expect(normalizeFillAnswer("  Photosynthesis  ")).toBe("photosynthesis");
+  });
+
+  it("collapses internal whitespace", () => {
+    expect(normalizeFillAnswer("cell\n  membrane\ttransport")).toBe(
+      "cell membrane transport",
+    );
+  });
+
+  it("normalizes accents and punctuation", () => {
+    expect(normalizeFillAnswer("Café-au-lait!")).toBe("cafe au lait");
+  });
+});
+
+describe("isFillAnswerCorrect", () => {
+  it("accepts punctuation-insensitive matches", () => {
+    expect(isFillAnswerCorrect("binary search tree", "Binary-search tree")).toBe(
+      true,
+    );
+  });
+
+  it("accepts accent-insensitive matches", () => {
+    expect(isFillAnswerCorrect("cafe au lait", "Café au lait")).toBe(true);
+  });
+
+  it("rejects blank answers", () => {
+    expect(isFillAnswerCorrect(" --- ", "---")).toBe(false);
+  });
+
+  it("rejects different answers after normalization", () => {
+    expect(isFillAnswerCorrect("mitosis", "meiosis")).toBe(false);
+  });
+});

--- a/src/app/api/quiz/sessions/[id]/answer/route.ts
+++ b/src/app/api/quiz/sessions/[id]/answer/route.ts
@@ -10,17 +10,16 @@ import {
 import { normalizeQuizQuestion } from "@/lib/quiz/normalize-question";
 import { generateUUID } from "@/lib/utils/uuid";
 import { SESSION_DEFAULTS } from "@/lib/quiz/types";
+import { isFillAnswerCorrect } from "@/lib/quiz/fill-answer";
 import sql from "@/database/pgsql.js";
 
-// compute correctness server-side — mirrors client logic in question-card.tsx
+// Compute correctness server-side using the same fill-in normalization as the client.
 function checkAnswerCorrect(
-  questionType: string,
+  _questionType: string,
   userAnswer: string,
   correctAnswer: string,
 ): boolean {
-  const ua = userAnswer.trim().toLowerCase();
-  const ca = correctAnswer.trim().toLowerCase();
-  return ua === ca;
+  return isFillAnswerCorrect(userAnswer, correctAnswer);
 }
 
 export const POST = withErrorHandler(

--- a/src/components/quiz/question-card.tsx
+++ b/src/components/quiz/question-card.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useMemo } from "react";
 import useI18n from "@/lib/notes/hooks/use-i18n";
 import { BLOOM_NAMES } from "@/lib/quiz/types";
 import type { BloomLevel } from "@/lib/quiz/types";
+import { isFillAnswerCorrect } from "@/lib/quiz/fill-answer";
 import QuizMarkdown from "./quiz-markdown";
 
 interface QuestionCardProps {
@@ -43,10 +44,10 @@ export default function QuestionCard({
     setSubmitted(true);
 
     if (question.question_type === "fill_in") {
-      const correct =
-        fillInAnswer.trim().toLowerCase() ===
-        question.correct_answer.trim().toLowerCase();
-      onAnswer(fillInAnswer, correct);
+      onAnswer(
+        fillInAnswer,
+        isFillAnswerCorrect(fillInAnswer, question.correct_answer),
+      );
     } else if (selected !== null && hasOptions) {
       const isCorrect = options[selected].is_correct;
       onAnswer(options[selected].text, isCorrect);

--- a/src/lib/quiz/fill-answer.ts
+++ b/src/lib/quiz/fill-answer.ts
@@ -1,0 +1,27 @@
+const COMBINING_MARKS_REGEX = /\p{M}/gu;
+const PUNCTUATION_OR_SYMBOL_REGEX = /[\p{P}\p{S}]/gu;
+const WHITESPACE_REGEX = /\s+/g;
+
+/**
+ * Normalize free-text quiz answers before comparing them.
+ *
+ * Fill-in answers are short recall prompts, so grading should not depend on
+ * casing, accent marks, punctuation, or incidental whitespace.
+ */
+export function normalizeFillAnswer(answer: string): string {
+  return answer
+    .normalize("NFKD")
+    .replace(COMBINING_MARKS_REGEX, "")
+    .toLocaleLowerCase("en")
+    .replace(PUNCTUATION_OR_SYMBOL_REGEX, " ")
+    .replace(WHITESPACE_REGEX, " ")
+    .trim();
+}
+
+export function isFillAnswerCorrect(userAnswer: string, correctAnswer: string): boolean {
+  const normalizedUserAnswer = normalizeFillAnswer(userAnswer);
+  return (
+    normalizedUserAnswer.length > 0 &&
+    normalizedUserAnswer === normalizeFillAnswer(correctAnswer)
+  );
+}


### PR DESCRIPTION
## Summary
- normalize fill-in quiz answers before grading so case, accents, punctuation, and incidental whitespace do not cause false negatives
- share the same helper between the quiz UI and server-side answer route
- add focused tests for fill-in normalization

## Checks
- npm run test:ci -- src/__tests__/lib/quiz/fill-answer.test.ts src/__tests__/api/quiz-answer.test.ts
- npm run test:ci
- npm run lint (passes with existing warning in scripts/i18n-audit.mjs)
- precommit hook lint:all + tests passed; Docker dry-run validation skipped due unsupported local Docker flag, per hook output

Awaits maintainer review/merge.

Fixes #330