### PR TITLE
fix: import React on settings page

### DIFF
--- a/src/app/settings/page.jsx
+++ b/src/app/settings/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import {


### PR DESCRIPTION
## Summary\n- Import the React namespace in the settings page so JSX rendering works in the Vitest settings page test environment.\n\n## Verification\n- npm run lint (passes with existing warning in scripts/i18n-audit.mjs)\n- npm run test:ci -- src/__tests__/app/settings-page.test.ts (passes)\n- npm run test:ci (80 files / 626 tests passed)\n\nDraft PR awaiting maintainer review/merge.