### PR TITLE
fix: use local calendar week ranges

### DIFF
--- a/src/__tests__/lib/calendar-date.test.ts
+++ b/src/__tests__/lib/calendar-date.test.ts
@@ -2,7 +2,23 @@ import { describe, expect, it } from "vitest";
 import {
   addMonthsClamped,
   isoToDateKey,
+  localDateKeyBoundaryToIso,
+  localDateKeyRangeToIso,
 } from "@/lib/notes/utils/calendar-date";
+
+function withTimeZone<T>(timeZone: string, run: () => T): T {
+  const previous = process.env.TZ;
+  process.env.TZ = timeZone;
+  try {
+    return run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = previous;
+    }
+  }
+}
 
 describe("isoToDateKey", () => {
   it("maps UTC timestamps to the correct local day in Europe/Dublin", () => {
@@ -39,6 +55,40 @@ describe("isoToDateKey", () => {
     expect(isoToDateKey("2026-04-03T09:00:00Z", "Mars/Olympus_Mons")).toMatch(
       /^\d{4}-\d{2}-\d{2}$/,
     );
+  });
+});
+
+describe("localDateKeyBoundaryToIso", () => {
+  it("uses the local start of day instead of UTC midnight", () => {
+    withTimeZone("Europe/Dublin", () => {
+      expect(localDateKeyBoundaryToIso("2026-03-30", "start")).toBe(
+        "2026-03-29T23:00:00.000Z",
+      );
+    });
+  });
+
+  it("keeps the full visible local day across the Europe/Dublin DST transition", () => {
+    withTimeZone("Europe/Dublin", () => {
+      expect(localDateKeyBoundaryToIso("2026-03-29", "start")).toBe(
+        "2026-03-29T00:00:00.000Z",
+      );
+      expect(localDateKeyBoundaryToIso("2026-03-29", "end")).toBe(
+        "2026-03-29T22:59:59.999Z",
+      );
+    });
+  });
+
+  it("builds week fetch ranges from local date boundaries", () => {
+    withTimeZone("Europe/Dublin", () => {
+      expect(localDateKeyRangeToIso("2026-03-23", "2026-03-29")).toEqual({
+        start: "2026-03-23T00:00:00.000Z",
+        end: "2026-03-29T22:59:59.999Z",
+      });
+    });
+  });
+
+  it("returns invalid date keys unchanged", () => {
+    expect(localDateKeyBoundaryToIso("not-a-date", "start")).toBe("not-a-date");
   });
 });
 

--- a/src/components/calendar/week-view.tsx
+++ b/src/components/calendar/week-view.tsx
@@ -6,6 +6,10 @@ import { CheckCircleIcon as CheckCircleOutline } from "@heroicons/react/24/outli
 import useCalendarStore from "@/lib/notes/state/calendar.zustand";
 import useAssignmentStore from "@/lib/notes/state/assignments.zustand";
 import useI18n from "@/lib/notes/hooks/use-i18n";
+import {
+  formatDateKey,
+  localDateKeyRangeToIso,
+} from "@/lib/notes/utils/calendar-date";
 
 const HOUR_HEIGHT = 56; // px per hour row
 const START_HOUR = 6;
@@ -23,12 +27,12 @@ function getWeekDays(
   d.setDate(d.getDate() - dow);
 
   const today = new Date();
-  const todayStr = formatDate(today);
+  const todayStr = formatDateKey(today);
 
   return Array.from({ length: 7 }, (_, i) => {
     const day = new Date(d);
     day.setDate(d.getDate() + i);
-    const dateStr = formatDate(day);
+    const dateStr = formatDateKey(day);
     return {
       date: dateStr,
       label: day.toLocaleDateString("en-US", { weekday: "short" }),
@@ -36,10 +40,6 @@ function getWeekDays(
       isToday: dateStr === todayStr,
     };
   });
-}
-
-function formatDate(d: Date): string {
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
 function formatHour(h: number): string {
@@ -79,18 +79,21 @@ export default function WeekView() {
 
   // fetch time blocks for the week
   useEffect(() => {
-    const start = weekDays[0].date + "T00:00:00Z";
-    const end = weekDays[6].date + "T23:59:59Z";
+    const { start, end } = localDateKeyRangeToIso(
+      weekDays[0].date,
+      weekDays[6].date,
+    );
     fetchTimeBlocks(start, end);
   }, [weekDays, fetchTimeBlocks]);
 
   // refresh when AI creates/completes a time block
   useEffect(() => {
     const refresh = () => {
-      fetchTimeBlocks(
-        weekDays[0].date + "T00:00:00Z",
-        weekDays[6].date + "T23:59:59Z",
+      const { start, end } = localDateKeyRangeToIso(
+        weekDays[0].date,
+        weekDays[6].date,
       );
+      fetchTimeBlocks(start, end);
     };
     window.addEventListener("oghma:time-block-changed", refresh);
     return () => window.removeEventListener("oghma:time-block-changed", refresh);
@@ -109,7 +112,7 @@ export default function WeekView() {
     for (const tb of timeBlocks) {
       const start = new Date(tb.starts_at);
       const end = new Date(tb.ends_at);
-      const dateStr = formatDate(start);
+      const dateStr = formatDateKey(start);
       const colIdx = weekDays.findIndex((d) => d.date === dateStr);
       if (colIdx === -1) continue;
 
@@ -142,7 +145,7 @@ export default function WeekView() {
     for (const a of assignments) {
       if (!a.due_at) continue;
       const d = new Date(a.due_at);
-      const dateStr = formatDate(d);
+      const dateStr = formatDateKey(d);
       const colIdx = weekDays.findIndex((wd) => wd.date === dateStr);
       if (colIdx === -1) continue;
 

--- a/src/lib/notes/utils/calendar-date.ts
+++ b/src/lib/notes/utils/calendar-date.ts
@@ -6,6 +6,41 @@ export function formatDateKey(date: Date): string {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
 }
 
+function parseDateKey(dateKey: string): { year: number; month: number; day: number } | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateKey);
+  if (!match) return null;
+
+  const year = Number.parseInt(match[1], 10);
+  const month = Number.parseInt(match[2], 10);
+  const day = Number.parseInt(match[3], 10);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+
+  return { year, month, day };
+}
+
+export function localDateKeyBoundaryToIso(
+  dateKey: string,
+  boundary: "start" | "end",
+): string {
+  const parsed = parseDateKey(dateKey);
+  if (!parsed) return dateKey;
+
+  const { year, month, day } = parsed;
+  const localDate =
+    boundary === "start"
+      ? new Date(year, month - 1, day, 0, 0, 0, 0)
+      : new Date(year, month - 1, day, 23, 59, 59, 999);
+
+  return localDate.toISOString();
+}
+
+export function localDateKeyRangeToIso(startDateKey: string, endDateKey: string) {
+  return {
+    start: localDateKeyBoundaryToIso(startDateKey, "start"),
+    end: localDateKeyBoundaryToIso(endDateKey, "end"),
+  };
+}
+
 export function isoToDateKey(value: string, timeZone?: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value.slice(0, 10);


### PR DESCRIPTION
## Summary
- build week-view fetch windows from local day boundaries instead of UTC date-label strings
- reuse shared calendar date-key formatting in week view
- add Europe/Dublin DST regression coverage for local week ranges

## Checks
- npm run lint
- npm run test:ci
- precommit hook lint:all/test:ci passed during commit

Awaiting maintainer review/merge.

Fixes #329