### PR TITLE
fix: guard malformed search SSE counts

### DIFF
--- a/src/__tests__/lib/chat/parse-sse-frame.test.ts
+++ b/src/__tests__/lib/chat/parse-sse-frame.test.ts
@@ -70,3 +70,45 @@ describe("parseSseFrame — tool-call events", () => {
     });
   });
 });
+
+describe("parseSseFrame — search events", () => {
+  it("uses safe defaults for malformed numeric payload fields", () => {
+    const update = parseSseFrame({
+      event: "search",
+      data: JSON.stringify({
+        scopeSize: "all",
+        resultsFound: "many",
+        results: "not-an-array",
+      }),
+    });
+
+    expect(update).toEqual({
+      type: "search",
+      searchContext: {
+        scopeSize: null,
+        resultsFound: 0,
+        results: [],
+      },
+    });
+  });
+
+  it("preserves valid search summary counts", () => {
+    const update = parseSseFrame({
+      event: "search",
+      data: JSON.stringify({
+        scopeSize: 3,
+        resultsFound: 2,
+        results: [{ noteId: "note-1", title: "Intro", distance: 0.12 }],
+      }),
+    });
+
+    expect(update).toEqual({
+      type: "search",
+      searchContext: {
+        scopeSize: 3,
+        resultsFound: 2,
+        results: [{ noteId: "note-1", title: "Intro", distance: 0.12 }],
+      },
+    });
+  });
+});

--- a/src/lib/chat/parse-sse-frame.ts
+++ b/src/lib/chat/parse-sse-frame.ts
@@ -36,11 +36,16 @@ export function parseSseFrame(frame: SseFrame): MessageUpdate | null {
     }
 
     case "search": {
+      const scopeSize =
+        typeof payload.scopeSize === "number" ? payload.scopeSize : null;
+      const resultsFound =
+        typeof payload.resultsFound === "number" ? payload.resultsFound : 0;
+
       return {
         type: "search",
         searchContext: {
-          scopeSize: (payload.scopeSize as number) ?? null,
-          resultsFound: (payload.resultsFound as number) ?? 0,
+          scopeSize,
+          resultsFound,
           results: Array.isArray(payload.results)
             ? (payload.results as SearchContextData["results"])
             : [],


### PR DESCRIPTION
## Summary
- Validate search SSE numeric summary fields before passing them to chat UI state
- Add parser coverage for malformed and valid search event payloads

## Checks
- npm run test:ci -- src/__tests__/lib/chat/parse-sse-frame.test.ts
- npm run lint -- src/lib/chat/parse-sse-frame.ts src/__tests__/lib/chat/parse-sse-frame.test.ts
- precommit: npm run lint:all and npm run test:ci passed; Docker dry-run validation reported unsupported --dry-run and was skipped by the hook

Awaiting maintainer review/merge.