### PR TITLE
fix: fail closed for sensitive rate limits

### DIFF
--- a/src/__tests__/lib/rate-limiter-fail-closed.test.ts
+++ b/src/__tests__/lib/rate-limiter-fail-closed.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+const rateLimitViolation = vi.fn();
+
+vi.mock("@/lib/logger", () => ({ default: logger }));
+vi.mock("@/lib/metrics", () => ({
+  Metrics: { rateLimitViolation },
+}));
+vi.mock("@/database/pgsql.js", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/lib/redis", () => ({
+  redisReady: true,
+  redis: {
+    pipeline: () => {
+      throw new Error("redis unavailable");
+    },
+  },
+}));
+
+describe("checkRateLimit fail-closed categories", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 503 instead of in-memory fallback for auth-sensitive categories", async () => {
+    const { checkRateLimit } = await import("@/lib/rateLimiter");
+
+    const response = await checkRateLimit("password-reset", "user@example.com");
+
+    expect(response).not.toBeNull();
+    expect(response?.status).toBe(503);
+    expect(response?.headers.get("Retry-After")).toBe("30");
+    await expect(response?.json()).resolves.toEqual({
+      error: "Service temporarily unavailable. Please try again shortly.",
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      "redis rate limit failed for fail-closed category",
+      expect.objectContaining({
+        category: "password-reset",
+        error: "redis unavailable",
+        publicStatus: 503,
+        retryAfterSeconds: 30,
+      }),
+    );
+    expect(rateLimitViolation).toHaveBeenCalledWith(
+      "password-reset:store-unavailable",
+    );
+  });
+});

--- a/src/lib/rateLimitConfig.ts
+++ b/src/lib/rateLimitConfig.ts
@@ -5,6 +5,12 @@ export interface RateLimitRule {
   limit: number;
   windowSeconds: number;
   keyType: 'userId' | 'ip' | 'email';
+  /**
+   * When true, Redis/store errors block the protected action instead of using
+   * the per-process in-memory fallback. Use this for security-sensitive flows
+   * where fail-open behavior can weaken abuse protection across app instances.
+   */
+  failClosedOnStoreError?: boolean;
 }
 
 export const RATE_LIMITS: Record<string, RateLimitRule> = {
@@ -14,13 +20,13 @@ export const RATE_LIMITS: Record<string, RateLimitRule> = {
   'canvas-connect': { limit: 10,  windowSeconds: 3600,  keyType: 'userId' },
 
   // tier 2 — auth security (public endpoints)
-  'register':       { limit: 5,   windowSeconds: 3600,  keyType: 'ip' },
-  'password-reset': { limit: 3,   windowSeconds: 3600,  keyType: 'email' },
-  'password-verify':{ limit: 10,  windowSeconds: 3600,  keyType: 'ip' },
+  'register':       { limit: 5,   windowSeconds: 3600,  keyType: 'ip',    failClosedOnStoreError: true },
+  'password-reset': { limit: 3,   windowSeconds: 3600,  keyType: 'email', failClosedOnStoreError: true },
+  'password-verify':{ limit: 10,  windowSeconds: 3600,  keyType: 'ip',    failClosedOnStoreError: true },
 
   // tier 3 — resource protection
   'upload':         { limit: 30,  windowSeconds: 3600,  keyType: 'userId' },
-  'vault-delete':   { limit: 1,   windowSeconds: 86400, keyType: 'userId' },
+  'vault-delete':   { limit: 1,   windowSeconds: 86400, keyType: 'userId', failClosedOnStoreError: true },
   'contact':        { limit: 5,   windowSeconds: 3600,  keyType: 'ip' },
   'share':          { limit: 10,  windowSeconds: 3600,  keyType: 'userId' },
 };

--- a/src/lib/rateLimiter.ts
+++ b/src/lib/rateLimiter.ts
@@ -96,6 +96,18 @@ function logViolation(category: string, identifier: string, count: number, limit
   });
 }
 
+function rateLimitStoreUnavailableResponse(): NextResponse {
+  return NextResponse.json(
+    { error: 'Service temporarily unavailable. Please try again shortly.' },
+    {
+      status: 503,
+      headers: {
+        'Retry-After': '30',
+      },
+    },
+  );
+}
+
 export async function checkRateLimit(
   category: string,
   identifier: string,
@@ -116,9 +128,18 @@ export async function checkRateLimit(
     try {
       result = await redisCheck(key, rule, now);
     } catch (err) {
-      logger.warn('redis rate limit failed, falling back to memory', {
-        category, error: (err as Error).message,
-      });
+      const error = (err as Error).message;
+      if (rule.failClosedOnStoreError) {
+        logger.error('redis rate limit failed for fail-closed category', {
+          category, error,
+          publicStatus: 503,
+          retryAfterSeconds: 30,
+        });
+        void Metrics.rateLimitViolation(`${category}:store-unavailable`);
+        return rateLimitStoreUnavailableResponse();
+      }
+
+      logger.warn('redis rate limit failed, falling back to memory', { category, error });
       result = memCheck(key, rule, now);
     }
   } else {


### PR DESCRIPTION
## Summary
- add fail-closed rate-limit behavior for auth-sensitive and vault-delete categories when Redis checks error
- return a 503 with Retry-After instead of per-process memory fallback for those categories
- cover the behavior with a focused Vitest case

## Checks
- npm run lint -- src/lib/rateLimitConfig.ts src/lib/rateLimiter.ts src/__tests__/lib/rate-limiter-fail-closed.test.ts
- npm run test:ci -- src/__tests__/lib/rate-limiter-fail-closed.test.ts src/__tests__/lib/client-ip.test.ts
- precommit via git commit: eslint . && npm run test:ci (81 files / 627 tests passed; Docker dry-run validation skipped by existing hook after unsupported flag; shellcheck unavailable warnings, hook still passed)

Refs #331

Awaiting maintainer review/merge.