### PR TITLE
draft: bugfix — compute pinned favorites tree

### DIFF
--- a/src/__tests__/lib/notes/tree-utils.test.ts
+++ b/src/__tests__/lib/notes/tree-utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { NOTE_PINNED } from "@/lib/notes/types/meta";
+import { ROOT_ID, TreeModel } from "@/lib/notes/types/tree";
+import { buildPinnedTree } from "@/lib/notes/state/tree-utils";
+
+function note(id: string, pinned = NOTE_PINNED.UNPINNED, pid?: string) {
+  return {
+    id,
+    title: id,
+    deleted: 0,
+    shared: 0,
+    pinned,
+    pid,
+  };
+}
+
+describe("buildPinnedTree", () => {
+  it("keeps pinned notes and their ancestor path only", () => {
+    const tree: TreeModel = {
+      rootId: ROOT_ID,
+      items: {
+        [ROOT_ID]: { id: ROOT_ID, children: ["folder", "loose"] },
+        folder: {
+          id: "folder",
+          children: ["pinned", "unpinned"],
+          data: note("folder"),
+        },
+        pinned: {
+          id: "pinned",
+          children: [],
+          data: note("pinned", NOTE_PINNED.PINNED, "folder"),
+        },
+        unpinned: {
+          id: "unpinned",
+          children: [],
+          data: note("unpinned", NOTE_PINNED.UNPINNED, "folder"),
+        },
+        loose: {
+          id: "loose",
+          children: [],
+          data: note("loose"),
+        },
+      },
+    };
+
+    const pinnedTree = buildPinnedTree(tree);
+
+    expect(new Set(Object.keys(pinnedTree.items))).toEqual(
+      new Set([ROOT_ID, "folder", "pinned"]),
+    );
+    expect(pinnedTree.items[ROOT_ID].children).toEqual(["folder"]);
+    expect(pinnedTree.items.folder.children).toEqual(["pinned"]);
+  });
+
+  it("returns an empty root when no loaded notes are pinned", () => {
+    const tree: TreeModel = {
+      rootId: ROOT_ID,
+      items: {
+        [ROOT_ID]: { id: ROOT_ID, children: ["note"] },
+        note: { id: "note", children: [], data: note("note") },
+      },
+    };
+
+    expect(buildPinnedTree(tree).items[ROOT_ID].children).toEqual([]);
+  });
+});

--- a/src/lib/notes/state/tree-utils.ts
+++ b/src/lib/notes/state/tree-utils.ts
@@ -5,6 +5,68 @@ import { ROOT_ID, TreeItemModel, TreeModel } from "@/lib/notes/types/tree";
 import { NoteModel } from "@/lib/notes/types/note";
 import { NOTE_DELETED, NOTE_SHARED, NOTE_PINNED } from "@/lib/notes/types/meta";
 
+function hasPinnedDescendant(
+  tree: TreeModel,
+  id: string,
+  visited = new Set<string>(),
+): boolean {
+  if (visited.has(id)) return false;
+  visited.add(id);
+
+  const item = tree.items[id];
+  if (!item) return false;
+  if (item.data?.pinned === NOTE_PINNED.PINNED) return true;
+
+  return item.children.some((childId) =>
+    hasPinnedDescendant(tree, childId, visited),
+  );
+}
+
+/**
+ * Build the Favorites tree from the currently loaded note tree.
+ *
+ * The normal tree is loaded lazily, so this function only includes loaded
+ * pinned notes plus the ancestor chain needed to render them in context.
+ * Children are filtered to included ids to avoid dangling react-complex-tree
+ * references when a folder contains unpinned notes.
+ */
+export function buildPinnedTree(tree: TreeModel): TreeModel {
+  const includedIds = new Set<string>([ROOT_ID]);
+
+  for (const id of Object.keys(tree.items)) {
+    if (id === ROOT_ID || hasPinnedDescendant(tree, id)) {
+      includedIds.add(id);
+    }
+  }
+
+  const items: TreeModel["items"] = {};
+  for (const id of includedIds) {
+    if (id === ROOT_ID) continue;
+
+    const item = tree.items[id];
+    if (!item) continue;
+
+    items[id] = {
+      ...item,
+      children: item.children.filter((childId) => includedIds.has(childId)),
+    };
+  }
+
+  return {
+    rootId: ROOT_ID,
+    items: {
+      [ROOT_ID]: {
+        ...tree.items[ROOT_ID],
+        id: ROOT_ID,
+        children: tree.items[ROOT_ID]?.children.filter((childId) =>
+          includedIds.has(childId),
+        ) ?? [],
+      },
+      ...items,
+    },
+  };
+}
+
 /**
  * walk up the tree from a note to root, collecting each parent TreeItemModel
  */

--- a/src/lib/notes/state/tree.ts
+++ b/src/lib/notes/state/tree.ts
@@ -16,6 +16,7 @@ import {
   findParentTreeItems,
   checkAncestorsExpanded,
   buildTreeItemFromApi,
+  buildPinnedTree,
 } from "./tree-utils";
 
 const TREE_CACHE_KEY = "tree";
@@ -151,7 +152,7 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
 
       newTree.items[ROOT_ID].children = rootChildren;
 
-      set({ tree: newTree, initLoaded: true });
+      set({ tree: newTree, pinnedTree: buildPinnedTree(newTree), initLoaded: true });
 
       // persist tree structure to IndexedDB for instant load on next visit
       await uiCache.setItem(TREE_CACHE_KEY, newTree);
@@ -213,7 +214,7 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
           };
         }
 
-        set({ tree: newTree });
+        set({ tree: newTree, pinnedTree: buildPinnedTree(newTree) });
         await uiCache.setItem(TREE_CACHE_KEY, newTree);
       }
 
@@ -239,7 +240,7 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
 
     newTree.items[item.id].data = item;
     newTree.items[item.id].isFolder = item.isFolder ?? false;
-    set({ tree: newTree });
+    set({ tree: newTree, pinnedTree: buildPinnedTree(newTree) });
 
     // persist tree to IndexedDB cache
     uiCache
@@ -251,7 +252,7 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
     const currentTree = get().tree;
     const newTree = TreeActions.removeItem(currentTree, id);
 
-    set({ tree: newTree });
+    set({ tree: newTree, pinnedTree: buildPinnedTree(newTree) });
 
     // persist tree to IndexedDB cache
     await uiCache.setItem(TREE_CACHE_KEY, newTree);
@@ -302,7 +303,7 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
       };
     }
 
-    set({ tree: newTree });
+    set({ tree: newTree, pinnedTree: buildPinnedTree(newTree) });
 
     // update cache with new tree state
     await uiCache.setItem(TREE_CACHE_KEY, newTree);
@@ -314,7 +315,7 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
       });
     } catch {
       // revert on failure
-      set({ tree: currentTree });
+      set({ tree: currentTree, pinnedTree: buildPinnedTree(currentTree) });
       await uiCache.setItem(TREE_CACHE_KEY, currentTree);
       const { toast: toastFn } = get();
       toastFn?.("Failed to move item", "error");
@@ -326,7 +327,7 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
     const { treeAPI } = state;
     const currentTree = get().tree;
     const newTree = TreeActions.mutateItem(currentTree, id, data);
-    set({ tree: newTree });
+    set({ tree: newTree, pinnedTree: buildPinnedTree(newTree) });
 
     // sync expanded state with react-complex-tree
     if (data.isExpanded !== undefined) {
@@ -359,7 +360,7 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
     const currentTree = get().tree;
     const newTree = TreeActions.restoreItem(currentTree, id, pid);
 
-    set({ tree: newTree });
+    set({ tree: newTree, pinnedTree: buildPinnedTree(newTree) });
     await Promise.all(
       TreeActions.flattenTree(newTree, id).map(
         async (item) =>
@@ -373,7 +374,7 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
   deleteItem: async (id: string) => {
     const currentTree = get().tree;
     const newTree = TreeActions.deleteItem(currentTree, id);
-    set({ tree: newTree });
+    set({ tree: newTree, pinnedTree: buildPinnedTree(newTree) });
 
     // persist tree to IndexedDB cache
     await uiCache.setItem(TREE_CACHE_KEY, newTree);
@@ -397,7 +398,7 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
         }),
       currentTree,
     );
-    set({ tree: newTree });
+    set({ tree: newTree, pinnedTree: buildPinnedTree(newTree) });
 
     for (const item of items) {
       await treeAPI.mutate({
@@ -437,8 +438,5 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
     await get().initTree();
   },
 }));
-
-// TODO: Implement pinnedTree computation with proper Zustand v5 API
-// Currently disabled to allow build to succeed
 
 export default useNoteTreeStore;


### PR DESCRIPTION
repo-agent validation

Lane: bugfix
Goal: Compute the note sidebar Favorites tree from pinned notes instead of leaving `pinnedTree` permanently empty.
Base branch: dev
Source: scan (`src/lib/notes/state/tree.ts` TODO and Favorites component consuming `pinnedTree`)
Risk: low

Changed files:
- `src/lib/notes/state/tree-utils.ts`
- `src/lib/notes/state/tree.ts`
- `src/__tests__/lib/notes/tree-utils.test.ts`

Checks run:
- `npm run test:ci -- src/__tests__/lib/notes/tree-utils.test.ts` — pass (2 tests)
- `npm run lint -- src/lib/notes/state/tree-utils.ts src/lib/notes/state/tree.ts src/__tests__/lib/notes/tree-utils.test.ts` — pass
- pre-commit `npm run lint:all` / full `npm run test:ci` — pass (83 files, 645 tests); non-blocking existing warnings: one eslint warning in `scripts/i18n-audit.mjs`, Docker `--dry-run` unsupported and shellcheck missing are reported as skipped by the hook

Test result: passed
Opus verdict: PASS_OPEN_PR
Known limitations: Favorites are derived from the currently loaded lazy tree; unloaded descendants will appear after their containing folder/children are loaded.
Status: awaiting maintainer review/merge
