### PR TITLE
draft: ci — remove unused i18n audit variable

### DIFF
--- a/scripts/i18n-audit.mjs
+++ b/scripts/i18n-audit.mjs
@@ -132,7 +132,6 @@ function main() {
 
   const baseLocale = readLocale(BASE_LOCALE);
   const baseKeys = Object.keys(baseLocale).sort();
-  const baseSet = new Set(baseKeys);
 
   let hasError = false;
   let hasWarning = false;


### PR DESCRIPTION
## repo-agent validation

Lane: ci / bugfix
Goal: remove the unused `baseSet` local from `scripts/i18n-audit.mjs` so ESLint is green again.
Base branch: dev
Source: scout found `npm run lint` failing on `scripts/i18n-audit.mjs:135 no-unused-vars`.
Risk: low

Changed files:
- `scripts/i18n-audit.mjs`

Checks run:
- `npm run lint` ✅
- `npm run test:ci` ✅ — 82 files / 643 tests
- commit hook `npm run lint:all` ✅ — reran ESLint and Vitest; Docker dry-run/shellcheck portions were skipped by existing hook logic because this runner lacks compatible Docker dry-run/shellcheck support.

Test result: passed
Opus verdict: PASS_OPEN_PR

Known limitations:
- This PR only removes the dead variable; it does not change i18n audit behavior.

Status: awaiting maintainer review/merge.
