### PR TITLE
tests: fix TypeScript no-emit test errors

### DIFF
--- a/src/__tests__/api/quiz-answer.test.ts
+++ b/src/__tests__/api/quiz-answer.test.ts
@@ -10,7 +10,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ── mocks (hoisted) ──────────────────────────────────────────────────────────
 
 vi.mock("@/database/pgsql.js", () => {
-  const sqlMock = vi.fn();
+  const sqlMock = vi.fn() as ReturnType<typeof vi.fn> & {
+    begin: ReturnType<typeof vi.fn>;
+    __txMock: ReturnType<typeof vi.fn>;
+  };
   sqlMock.mockResolvedValue([]);
   // tx mock used inside sql.begin() transactions
   const txMock = vi.fn();

--- a/src/__tests__/api/quiz-dashboard.test.ts
+++ b/src/__tests__/api/quiz-dashboard.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/lib/auth", () => ({
 import sql from "@/database/pgsql.js";
 import { validateSession } from "@/lib/auth";
 import { GET as getDashboard } from "@/app/api/quiz/dashboard/route";
+import { NextRequest } from "next/server";
 
 describe("GET /api/quiz/dashboard", () => {
   beforeEach(() => {
@@ -30,7 +31,9 @@ describe("GET /api/quiz/dashboard", () => {
   });
 
   it("filters archived courses in aggregate card and review queries", async () => {
-    const response = await getDashboard();
+    const response = await getDashboard(
+      new NextRequest("http://localhost/api/quiz/dashboard"),
+    );
 
     expect(response.status).toBe(200);
 

--- a/src/__tests__/lib/canvas-import-extraction.test.ts
+++ b/src/__tests__/lib/canvas-import-extraction.test.ts
@@ -157,7 +157,7 @@ describe("processExtractionRetry", () => {
       attempt: 1,
     });
 
-    const updateQueries = vi
+    const updateQueries: string[] = vi
       .mocked(sql)
       .mock.calls.map((call: any[]) => call[0]?.join(""))
       .filter((query: string | undefined) =>


### PR DESCRIPTION
## repo-agent validation

Lane: tests / ci

Goal: make TypeScript no-emit pass for test files while addressing issue #312.

Base branch: dev

Source: GitHub issue #312 / repo-agent scan

Risk: low — test-only type fixes, no runtime source changes.

Changed files:
- `src/__tests__/api/quiz-answer.test.ts`
- `src/__tests__/api/quiz-dashboard.test.ts`
- `src/__tests__/lib/canvas-import-extraction.test.ts`

Checks run:
- `npm exec -- tsc --noEmit --pretty false` — pass
- `npm run lint` — pass
- `npm run test:ci` — pass, 84 files / 646 tests
- commit hook `npm run lint:all` — pass

Opus verdict: PASS_OPEN_PR

Known limitations:
- Docker marker dry-run validation in the commit hook reported `unknown flag: --dry-run` and was skipped by the repo hook; this is pre-existing tool compatibility, not part of this test-only change.

Status: awaiting maintainer review/merge.

Closes #312 when merged.
