### PR TITLE
deadcode — remove stale share router TODO

### DIFF
--- a/src/components/notes/sharing/share-modal.tsx
+++ b/src/components/notes/sharing/share-modal.tsx
@@ -6,8 +6,6 @@ import usePortalStore from "@/lib/notes/state/portal";
 import IconButton from "@/components/icon-button";
 import useNoteStore from "@/lib/notes/state/note";
 import { NOTE_SHARED } from "@/lib/notes/types/meta";
-// TODO: Convert to App Router (next/navigation) when sharing is active
-// import { useRouter } from 'next/router';
 import {
   useRouter as useNextRouter,
   usePathname,


### PR DESCRIPTION
repo-agent validation

Lane: docs/deadcode
Goal: remove stale share-modal router TODO now that the archived component already uses next/navigation.
Base branch: dev
Source: scout found stale TODO in source
Risk: low — comment-only cleanup
Changed files:
- src/components/notes/sharing/share-modal.tsx

Checks run:
- npm ci — pass
- npm run lint — pass

Test result: pass
Opus verdict: PASS_OPEN_PR
Known limitations: no runtime behavior changed; this only removes obsolete comments from an archived component.
Status: awaiting maintainer review/merge.
