### PR TITLE
bugfix — route authenticated 404 users to notes

### DIFF
--- a/src/app/not-found-content.tsx
+++ b/src/app/not-found-content.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Button } from "@/components/catalyst/button";
+import { Heading } from "@/components/catalyst/heading";
+import { Text } from "@/components/catalyst/text";
+import useI18n from "@/lib/notes/hooks/use-i18n";
+import { useRouter } from "next/navigation";
+
+export default function NotFoundContent({ homeUrl }: { homeUrl: string }) {
+  const router = useRouter();
+  const { t } = useI18n();
+
+  return (
+    <main className="grid min-h-dvh place-items-center bg-white px-6 py-24 dark:bg-zinc-900 sm:py-32 lg:px-8">
+      <div className="text-center">
+        <p className="text-base font-semibold text-blue-600 dark:text-blue-400">
+          {t("error.404")}
+        </p>
+        <Heading className="mt-4 text-5xl sm:text-7xl">
+          {t("error.page_not_found")}
+        </Heading>
+        <Text className="mt-6 text-lg text-zinc-600 dark:text-zinc-400 sm:text-xl/8">
+          {t("error.page_not_found_description")}
+        </Text>
+        <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-6">
+          <Button href={homeUrl}>{t("error.go_home")}</Button>
+          <Button plain onClick={() => router.back()}>
+            {t("error.go_back")} <span aria-hidden="true">&rarr;</span>
+          </Button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,40 +1,9 @@
-"use client";
+import { auth } from "@/auth";
+import NotFoundContent from "./not-found-content";
 
-import { Button } from "@/components/catalyst/button";
-import { Heading } from "@/components/catalyst/heading";
-import { Text } from "@/components/catalyst/text";
-import { useRouter } from "next/navigation";
-import useI18n from "@/lib/notes/hooks/use-i18n";
+export default async function NotFound() {
+  const session = await auth();
+  const homeUrl = session?.user?.id ? "/notes" : "/";
 
-export default function NotFound() {
-  const router = useRouter();
-  const { t } = useI18n();
-
-  // TODO: Check if user is authenticated
-  // const { auth } = useContext(AuthContext) or similar
-  // const isAuthenticated = !!auth?.accessToken
-  // const homeUrl = isAuthenticated ? '/notes' : '/'
-  const homeUrl = "/";
-
-  return (
-    <main className="grid min-h-dvh place-items-center bg-white px-6 py-24 dark:bg-zinc-900 sm:py-32 lg:px-8">
-      <div className="text-center">
-        <p className="text-base font-semibold text-blue-600 dark:text-blue-400">
-          {t("error.404")}
-        </p>
-        <Heading className="mt-4 text-5xl sm:text-7xl">
-          {t("error.page_not_found")}
-        </Heading>
-        <Text className="mt-6 text-lg text-zinc-600 dark:text-zinc-400 sm:text-xl/8">
-          {t("error.page_not_found_description")}
-        </Text>
-        <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-6">
-          <Button href={homeUrl}>{t("error.go_home")}</Button>
-          <Button plain onClick={() => router.back()}>
-            {t("error.go_back")} <span aria-hidden="true">&rarr;</span>
-          </Button>
-        </div>
-      </div>
-    </main>
-  );
+  return <NotFoundContent homeUrl={homeUrl} />;
 }


### PR DESCRIPTION
## repo-agent validation

- Kanban task: not available in this run (kanban CLI/tool unavailable in this environment)
- Issue: none; source was repo-agent scan of a stale TODO in `src/app/not-found.tsx`
- Lane: bugfix
- Goal: make the 404 page's **Go home** action send authenticated users to `/notes` while keeping unauthenticated users on `/`
- Base branch: `dev`
- Source: targeted scan; `not-found.tsx` had a TODO and always used `/`
- Risk: low

## Changed files

- `src/app/not-found.tsx`
- `src/app/not-found-content.tsx`

## Checks run

- `npm ci --ignore-scripts` — pass
- `npm run lint -- src/app/not-found.tsx src/app/not-found-content.tsx` — pass
- `npm run test:ci -- --run src/__tests__/auth.config.test.ts` — pass

## Opus verdict

`PASS_OPEN_PR`

> Logic correct: `session?.user?.id` matches the session shape set in `src/auth.config.ts`; authenticated → `/notes`, else `/`. Server/client split keeps async auth server-side and router/i18n client-side.

## Known limitations

- No full app build was run; validation was limited to targeted lint plus an auth config unit test.
- Draft PR only; awaiting maintainer review/merge.

Status: awaiting maintainer review/merge.
