### PR TITLE
bugfix — accept fill-answer alternatives

### DIFF
--- a/src/__tests__/lib/quiz/fill-answer.test.ts
+++ b/src/__tests__/lib/quiz/fill-answer.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isFillAnswerCorrect, normalizeFillAnswer } from "@/lib/quiz/fill-answer";
+import {
+  acceptedFillAnswers,
+  isFillAnswerCorrect,
+  normalizeFillAnswer,
+} from "@/lib/quiz/fill-answer";
 
 describe("normalizeFillAnswer", () => {
   it("ignores case and surrounding whitespace", () => {
@@ -17,6 +21,23 @@ describe("normalizeFillAnswer", () => {
   });
 });
 
+describe("acceptedFillAnswers", () => {
+  it("normalizes and deduplicates stored alternatives", () => {
+    expect(acceptedFillAnswers(["Café", "cafe", "Coffee"])).toEqual([
+      "cafe",
+      "coffee",
+    ]);
+  });
+
+  it("splits compact alternatives stored in the answer string", () => {
+    expect(acceptedFillAnswers("mitochondria | mitochondrion; power house")).toEqual([
+      "mitochondria",
+      "mitochondrion",
+      "power house",
+    ]);
+  });
+});
+
 describe("isFillAnswerCorrect", () => {
   it("accepts punctuation-insensitive matches", () => {
     expect(isFillAnswerCorrect("binary search tree", "Binary-search tree")).toBe(
@@ -26,6 +47,27 @@ describe("isFillAnswerCorrect", () => {
 
   it("accepts accent-insensitive matches", () => {
     expect(isFillAnswerCorrect("cafe au lait", "Café au lait")).toBe(true);
+  });
+
+  it("accepts synonym alternatives from the stored answer", () => {
+    expect(isFillAnswerCorrect("mitochondrion", "mitochondria | mitochondrion")).toBe(
+      true,
+    );
+  });
+
+  it("accepts synonym alternatives from generated answer arrays", () => {
+    expect(
+      isFillAnswerCorrect("power house", [
+        "mitochondria",
+        "powerhouse",
+        "power house",
+      ]),
+    ).toBe(true);
+  });
+
+  it("preserves slash-containing answers as one answer", () => {
+    expect(isFillAnswerCorrect("TCP/IP", "TCP/IP")).toBe(true);
+    expect(isFillAnswerCorrect("TCP", "TCP/IP")).toBe(false);
   });
 
   it("rejects blank answers", () => {

--- a/src/lib/quiz/fill-answer.ts
+++ b/src/lib/quiz/fill-answer.ts
@@ -1,6 +1,7 @@
 const COMBINING_MARKS_REGEX = /\p{M}/gu;
 const PUNCTUATION_OR_SYMBOL_REGEX = /[\p{P}\p{S}]/gu;
 const WHITESPACE_REGEX = /\s+/g;
+const ALTERNATIVE_DELIMITER_REGEX = /\s*(?:\||;)\s*/u;
 
 /**
  * Normalize free-text quiz answers before comparing them.
@@ -18,10 +19,25 @@ export function normalizeFillAnswer(answer: string): string {
     .trim();
 }
 
-export function isFillAnswerCorrect(userAnswer: string, correctAnswer: string): boolean {
+export function acceptedFillAnswers(correctAnswer: string | string[]): string[] {
+  const candidates = Array.isArray(correctAnswer)
+    ? correctAnswer
+    : correctAnswer.split(ALTERNATIVE_DELIMITER_REGEX);
+
+  const normalized = candidates
+    .map((candidate) => normalizeFillAnswer(candidate))
+    .filter((candidate) => candidate.length > 0);
+
+  return Array.from(new Set(normalized));
+}
+
+export function isFillAnswerCorrect(
+  userAnswer: string,
+  correctAnswer: string | string[],
+): boolean {
   const normalizedUserAnswer = normalizeFillAnswer(userAnswer);
   return (
     normalizedUserAnswer.length > 0 &&
-    normalizedUserAnswer === normalizeFillAnswer(correctAnswer)
+    acceptedFillAnswers(correctAnswer).includes(normalizedUserAnswer)
   );
 }


### PR DESCRIPTION
## repo-agent validation

Lane: bugfix
Goal: Fix #330 by allowing fill-in quiz grading to accept normalized alternatives/synonyms while keeping server-side grading authoritative.
Base branch: dev
Source: GitHub issue #330
Risk: low/medium — scoped to fill-in answer normalization and tests.

## Changed files
- `src/lib/quiz/fill-answer.ts`
- `src/__tests__/lib/quiz/fill-answer.test.ts`

## Checks run
- `npm test -- src/__tests__/api/quiz-answer.test.ts src/__tests__/lib/quiz/fill-answer.test.ts` — pass, 30 tests
- `npm run lint -- src/lib/quiz/fill-answer.ts src/__tests__/lib/quiz/fill-answer.test.ts` — pass
- pre-commit `npm run lint:all` / `vitest run` — pass, 85 files / 656 tests
- pre-commit Docker marker validation attempted but skipped by existing local Docker/buildx limitation (`permission denied` buildx plugin / legacy builder lacks `--dry-run`); hook still reported precommit checks passed.

## Opus verdict
PASS_OPEN_PR — focused change; alternatives added and exact-match fallback preserved; callers unaffected.

## Known limitations
- Alternative delimiters are deliberately limited to `|` and `;` so slash-containing answers such as `TCP/IP` remain single answers.
- Existing stored answers that use `|` or `;` as literal content may now be treated as alternatives; this is the intended delimiter convention for fill-in synonyms.

Status: awaiting maintainer review/merge.

Closes #330
