### PR TITLE
Privacy-first funnel analytics and aggregate dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,10 @@ EMAIL_FROM=noreply@example.com
 WEB3FORMS_ACCESS_KEY=your-web3forms-access-key
 NEXT_PUBLIC_WEB3FORMS_KEY=your-web3forms-access-key
 
+# Privacy-first aggregate analytics dashboard
+# Comma-separated signed-in emails allowed to view /admin/analytics.
+ANALYTICS_ADMIN_EMAILS=semyon@example.com
+
 # Upload/runtime
 MAX_FILE_SIZE=104857600
 UPLOAD_MAX_FILE_SIZE=104857600

--- a/database/migrations/036_privacy_first_analytics.sql
+++ b/database/migrations/036_privacy_first_analytics.sql
@@ -1,0 +1,27 @@
+-- Remove browser-linkable marketing data. Anonymous funnel reporting is aggregate-only.
+DROP INDEX IF EXISTS app.idx_marketing_events_session_time;
+ALTER TABLE app.marketing_events
+    DROP COLUMN IF EXISTS session_id,
+    DROP COLUMN IF EXISTS user_agent;
+
+ALTER TABLE app.marketing_leads
+    DROP COLUMN IF EXISTS session_id,
+    DROP COLUMN IF EXISTS user_agent;
+
+COMMENT ON TABLE app.marketing_events IS
+    'Minimized first-party funnel events: no browser identifier, user agent, raw IP, query string, content, credentials, email, or name.';
+
+-- Raw observations are short-lived; this function is intended for the existing
+-- deployment scheduler/maintenance job. Aggregates may be retained longer.
+CREATE OR REPLACE FUNCTION app.purge_expired_marketing_events(
+    retention interval DEFAULT interval '30 days'
+) RETURNS bigint
+LANGUAGE plpgsql
+AS $$
+DECLARE deleted_count bigint;
+BEGIN
+    DELETE FROM app.marketing_events WHERE created_at < now() - retention;
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END;
+$$;

--- a/database/migrations/037_navigation_transitions.sql
+++ b/database/migrations/037_navigation_transitions.sql
@@ -1,0 +1,28 @@
+-- Navigation observations stay event-level and intentionally cannot be joined into journeys.
+-- They contain only allowlisted paths and coarse origin / UI context; no identifier or storage key.
+ALTER TABLE app.marketing_events
+    ADD COLUMN IF NOT EXISTS from_path TEXT,
+    ADD COLUMN IF NOT EXISTS to_path TEXT,
+    ADD COLUMN IF NOT EXISTS origin_class TEXT,
+    ADD COLUMN IF NOT EXISTS placement TEXT,
+    ADD COLUMN IF NOT EXISTS action TEXT;
+
+ALTER TABLE app.marketing_events
+    DROP CONSTRAINT IF EXISTS marketing_events_navigation_origin_class,
+    ADD CONSTRAINT marketing_events_navigation_origin_class
+        CHECK (origin_class IS NULL OR origin_class IN ('direct', 'external', 'internal'));
+
+CREATE INDEX IF NOT EXISTS idx_marketing_events_navigation_aggregate
+    ON app.marketing_events (to_path, from_path, origin_class, placement, action, occurred_at DESC)
+    WHERE event_name = 'navigation_transition';
+
+COMMENT ON COLUMN app.marketing_events.from_path IS
+    'Allowlisted prior application path only; no query string or fragment.';
+COMMENT ON COLUMN app.marketing_events.to_path IS
+    'Allowlisted destination application path only; no query string or fragment.';
+COMMENT ON COLUMN app.marketing_events.origin_class IS
+    'Coarse navigation origin: direct, external, or internal.';
+COMMENT ON COLUMN app.marketing_events.placement IS
+    'Allowlisted semantic UI placement such as header, footer, or CTA region.';
+COMMENT ON COLUMN app.marketing_events.action IS
+    'Allowlisted semantic action such as nav_link or an existing CTA name.';

--- a/database/migrations/038_activation_milestones.sql
+++ b/database/migrations/038_activation_milestones.sql
@@ -1,0 +1,15 @@
+-- One immutable first-value milestone per authenticated account.
+-- This remains account-scoped product measurement, never browser/session tracking.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_marketing_events_activation_milestone_once
+    ON app.marketing_events (user_id, event_name)
+    WHERE user_id IS NOT NULL
+      AND event_name IN (
+          'email_verified',
+          'canvas_import_started',
+          'canvas_import_completed',
+          'first_cited_answer',
+          'first_flashcard_generated'
+      );
+
+COMMENT ON INDEX app.idx_marketing_events_activation_milestone_once IS
+    'Makes authenticated first-value activation milestones idempotent per account.';

--- a/docs/GROWTH_FUNNEL.md
+++ b/docs/GROWTH_FUNNEL.md
@@ -1,8 +1,8 @@
 # Growth Funnel And Analytics
 
-Last updated: 2026-07-08
+Last updated: 2026-07-11
 
-Status: privacy-light first-party tracking is implemented. There is no GA4, GTM, third-party analytics script, advertising pixel, session replay, heatmap tool, or analytics cookie.
+Status: privacy-first aggregate first-party tracking is implemented. There is no GA4, GTM, third-party analytics script, advertising pixel, session replay, heatmap tool, analytics cookie, or anonymous browser identifier.
 
 ## Goal
 
@@ -18,7 +18,10 @@ First-party event collection:
 
 - `POST /api/marketing/events`
 - stores into `app.marketing_events`
-- anonymous session id kept in `sessionStorage`
+- no anonymous/session identifier; the retired `oghma_marketing_session` key is cleared
+- DNT and Global Privacy Control suppress collection and clear attribution storage
+- query strings, fragments, raw IPs, and user agents are not stored
+- raw events have a 30-day purge function (`app.purge_expired_marketing_events`)
 - no cookies
 - no raw IP storage
 - no third-party analytics provider
@@ -35,7 +38,8 @@ Tracked events:
 
 | Event | Source | Purpose |
 |---|---|---|
-| `page_view` | public pages | traffic by path, referrer, and UTM |
+| `page_view` | public pages | traffic by allowlisted path and UTM |
+| `navigation_transition` | public page loads and internal links | aggregate `from_path`/`to_path`, direct/external/internal origin, and marked CTA/header/footer context |
 | `nav_click` | public links | navigation/item-click visibility |
 | `cta_click` | marked CTAs | high-intent CTA conversion |
 | `pricing_click` | pricing CTAs | commercial curiosity |
@@ -52,18 +56,29 @@ Tracked events:
 | `canvas_connect_attempt` | settings Canvas form | core activation attempt |
 | `canvas_connect_success` | settings/API | Canvas connected; server event is canonical |
 | `canvas_connect_error` | settings Canvas form | setup failure bucket |
+| `email_verified` | email verification route | first successful verification for an authenticated account |
+| `canvas_import_started` | Canvas import route | first successfully queued Canvas import for an authenticated account |
+| `canvas_import_completed` | Canvas/vault workers | first completed import for an authenticated account |
+| `first_cited_answer` | chat route | first completed answer with one or more retrieved sources |
+| `first_flashcard_generated` | import workers | first generated study question/flashcard for an authenticated account |
+
+## Authenticated Activation Milestones
+
+The five first-value milestones are server-canonical and store only the account UUID, fixed event name, and timestamp. They accept no path, metadata, note/document content, Canvas domain/token, or browser/session identifier. A partial unique index makes each milestone idempotent per account. Direct HTTP milestone routes honor DNT/GPC. Delayed workers do not write activation milestones: they cannot observe the original browser preference, and there is no durable analytics-consent setting.
+
+A return/weekly-active metric is deliberately **not** collected: defining it would require recording routine account activity beyond these product milestones. The dashboard instead exposes only the existing 30-day, minimum-five-account aggregate milestone counts.
 
 ## Attribution
 
-The client captures these UTM fields from the URL and keeps them in `sessionStorage` for the browser session:
+When DNT/GPC are not enabled, the client reads UTM fields from the current page URL and attaches only values from the deployed attribution taxonomy to that event. Unknown values (including email-like or other free-form query text) are discarded rather than persisted. The currently allowed values are the product-owned sources `homepage`, `ai_page`, and `pricing`; media `hero_cta`, `midpage_cta`, and `cta`; and campaigns `free_canvas_import`, `semester_pricing`, `campus_pilot`, and `launch_beta`. `utm_content` and `utm_term` are intentionally not retained.
 
 - `utm_source`
 - `utm_medium`
 - `utm_campaign`
-- `utm_content`
-- `utm_term`
 
-Events store last-touch UTM fields directly. Registration, Canvas connect, and contact submissions also include the session-scoped first-touch object in sanitized JSON properties.
+Analytics does not write cookies, `localStorage`, or `sessionStorage`. Attribution is deliberately event-level rather than visitor-level, so anonymous journeys cannot be stitched together.
+
+Navigation transitions use a separate strict allowlist: stable public paths (plus slug-shaped public blog paths), `direct`/`external`/`internal` origin, and the existing semantic CTA/header/footer placement/action values. Query strings, fragments, referrers, external destinations, dynamic application paths, and unmarked free-form labels are discarded. Public ingestion also drops free-form source and target fields and uses a closed aggregate property schema; a transition is one independent event, not a retained visitor trail.
 
 ## Privacy Boundaries
 
@@ -91,6 +106,12 @@ Never send these into `app.marketing_events`:
 - raw IP addresses
 
 `app.marketing_leads` is the exception for contact details because visitors explicitly submit those fields through the contact form.
+
+## Aggregate Admin Dashboard
+
+`/admin/analytics` uses fixed aggregate queries from `/api/admin/analytics`. Access is restricted to signed-in emails in the comma-separated `ANALYTICS_ADMIN_EMAILS` environment variable. Campaign, navigation, CTA, and authenticated activation cells below five accounts/events are suppressed, and there is no raw-event or user/session drill-down.
+
+A future shared view should publish aggregate daily metrics to Grafana or Metabase. Do not centralize raw cross-app user events or create a shared person identifier.
 
 ## Useful Queries
 
@@ -120,27 +141,46 @@ GROUP BY 1, 2, 3
 ORDER BY clicks DESC;
 ```
 
-Signup funnel by session:
+Aggregate navigation and semantic CTA placement (the dashboard runs this with a 30-day window and suppresses cells below five events):
 
 ```sql
 SELECT
-  count(DISTINCT session_id) FILTER (WHERE event_name = 'page_view' AND path LIKE '/register%') AS register_visitors,
-  count(DISTINCT session_id) FILTER (WHERE event_name = 'registration_form_start') AS form_starts,
-  count(DISTINCT session_id) FILTER (WHERE event_name = 'registration_submit') AS submits,
-  count(DISTINCT session_id) FILTER (WHERE event_name = 'registration_success') AS account_created
+  coalesce(from_path, '(entry)') AS from_path,
+  to_path,
+  origin_class,
+  coalesce(placement, '(unmarked)') AS placement,
+  coalesce(action, '(unmarked)') AS action,
+  count(*) AS events
+FROM app.marketing_events
+WHERE event_name = 'navigation_transition'
+  AND to_path IS NOT NULL
+GROUP BY 1, 2, 3, 4, 5
+HAVING count(*) >= 5
+ORDER BY events DESC;
+```
+
+Anonymous signup-stage event totals (not linked into visitor journeys):
+
+```sql
+SELECT
+  count(*) FILTER (WHERE event_name = 'page_view' AND path = '/register') AS register_views,
+  count(*) FILTER (WHERE event_name = 'registration_form_start') AS form_starts,
+  count(*) FILTER (WHERE event_name = 'registration_submit') AS submits,
+  count(*) FILTER (WHERE event_name = 'registration_success') AS accounts_created
 FROM app.marketing_events
 WHERE occurred_at >= now() - interval '30 days';
 ```
 
-Canvas activation after signup:
+Authenticated Canvas activation:
 
 ```sql
 SELECT
-  count(DISTINCT session_id) FILTER (WHERE event_name = 'registration_success') AS account_created,
-  count(DISTINCT session_id) FILTER (WHERE event_name = 'canvas_connect_attempt') AS canvas_attempted,
-  count(DISTINCT session_id) FILTER (WHERE event_name = 'canvas_connect_success') AS canvas_connected
+  count(DISTINCT user_id) FILTER (WHERE event_name = 'registration_success') AS accounts_created,
+  count(DISTINCT user_id) FILTER (WHERE event_name = 'canvas_connect_attempt') AS canvas_attempted,
+  count(DISTINCT user_id) FILTER (WHERE event_name = 'canvas_connect_success') AS canvas_connected
 FROM app.marketing_events
-WHERE occurred_at >= now() - interval '30 days';
+WHERE occurred_at >= now() - interval '30 days'
+  AND user_id IS NOT NULL;
 ```
 
 Contact leads by intent:
@@ -161,23 +201,14 @@ ORDER BY leads DESC;
 
 These are intentionally not in this pass:
 
-- analytics dashboard UI
-- email verification event
-- Canvas import started/completed events
-- first cited answer event
-- first flashcard generated event
+- return/weekly-active tracking (would require routine activity tracking beyond the first-value milestones)
 - checkout/paid conversion events
-- retention policy job for marketing tables
+- scheduler invocation for the provided 30-day retention function
 
 ## Next Product Events
 
 Add these when the relevant surfaces are ready:
 
-- `email_verified`
-- `canvas_import_started`
-- `canvas_import_completed`
-- `first_cited_answer`
-- `first_flashcard_generated`
 - `pricing_view_after_import`
 - `checkout_click`
 - `checkout_completed`

--- a/src/__tests__/lib/marketing-events.test.ts
+++ b/src/__tests__/lib/marketing-events.test.ts
@@ -1,37 +1,77 @@
 import { describe, expect, it } from "vitest";
-import { cleanProperties } from "@/lib/marketing/events";
+import {
+  ACTIVATION_MILESTONES,
+  cleanNavigationAction,
+  cleanNavigationOrigin,
+  cleanNavigationPath,
+  cleanNavigationPlacement,
+  cleanPath,
+  cleanProperties,
+  cleanUrl,
+  hasPrivacySignal,
+} from "@/lib/marketing/events";
+import { cleanAttribution } from "@/lib/marketing/attribution";
 
 describe("marketing event property cleaning", () => {
-  it("keeps safe funnel metadata", () => {
-    expect(
-      cleanProperties({
-        page: "home",
-        location: "hero",
-        cta: "start_free",
-        has_phone: true,
-        message_length_bucket: "101-500",
-      }),
-    ).toEqual({
-      page: "home",
-      location: "hero",
-      cta: "start_free",
-      has_phone: true,
-      message_length_bucket: "101-500",
+  it("keeps only the closed aggregate schema", () => {
+    expect(cleanProperties({ form: "contact", role: "student", interest: "campus_pilot", has_phone: true, message_length_bucket: "101-500" })).toEqual({
+      form: "contact", role: "student", interest: "campus_pilot", has_phone: true, message_length_bucket: "101-500",
     });
   });
 
-  it("drops sensitive keys before storage", () => {
-    expect(
-      cleanProperties({
-        email: "student@example.com",
-        first_name: "Ada",
-        phone: "+353 1 234 5678",
-        message: "Please invite me",
-        canvas_token: "secret",
-        safe_key: "kept",
-      }),
-    ).toEqual({
-      safe_key: "kept",
+  it("drops sensitive and arbitrary values before storage", () => {
+    expect(cleanProperties({ email: "student@example.com", first_name: "Ada", phone: "+353 1 234 5678", message: "Please invite me", canvas_token: "secret", safe_key: "kept", role: "ada@example.com" })).toEqual({});
+  });
+});
+
+describe("campaign attribution", () => {
+  it("retains only deployed campaign taxonomy values", () => {
+    expect(cleanAttribution({ source: "homepage", medium: "hero_cta", campaign: "free_canvas_import", term: "student@example.com" })).toEqual({
+      source: "homepage", medium: "hero_cta", campaign: "free_canvas_import",
     });
+  });
+
+  it("drops arbitrary query-derived attribution", () => {
+    expect(cleanAttribution({ source: "ada@example.com", campaign: "private-medical-condition", content: "secret" })).toEqual({});
+  });
+});
+
+describe("authenticated activation milestones", () => {
+  it("uses a fixed, content-free allowlist", () => {
+    expect([...ACTIVATION_MILESTONES]).toEqual([
+      "email_verified",
+      "canvas_import_started",
+      "canvas_import_completed",
+      "first_cited_answer",
+      "first_flashcard_generated",
+    ]);
+    expect(ACTIVATION_MILESTONES.has("weekly_active")).toBe(false);
+    expect(ACTIVATION_MILESTONES.has("note_created")).toBe(false);
+  });
+});
+
+describe("privacy-first marketing event boundaries", () => {
+  it("removes query strings and fragments from stored paths", () => {
+    expect(cleanPath("/register?email=ada@example.com#form")).toBe("/register");
+    expect(cleanUrl("https://oghmanotes.ie/pricing?token=secret")).toBe("/pricing");
+  });
+
+  it("allows only coarse, stable navigation dimensions", () => {
+    expect(cleanNavigationPath("/pricing?campaign=private#plans")).toBe("/pricing");
+    expect(cleanNavigationPath("/blog/privacy-first-analytics")).toBe("/blog/privacy-first-analytics");
+    expect(cleanNavigationPath("/settings?user=123")).toBeNull();
+    expect(cleanNavigationPath("https://elsewhere.test/private-path?token=secret")).toBeNull();
+    expect(cleanNavigationOrigin("external")).toBe("external");
+    expect(cleanNavigationOrigin("referrer.example")).toBeNull();
+    expect(cleanNavigationPlacement("header")).toBe("header");
+    expect(cleanNavigationPlacement("sidebar_personal")).toBeNull();
+    expect(cleanNavigationAction("connect_canvas_free")).toBe("connect_canvas_free");
+    expect(cleanNavigationAction("clicked-ada-profile")).toBeNull();
+  });
+
+  it("honors Global Privacy Control and Do Not Track headers", () => {
+    expect(hasPrivacySignal(new Request("https://example.test", { headers: { "Sec-GPC": "1" } }))).toBe(true);
+    expect(hasPrivacySignal(new Request("https://example.test", { headers: { DNT: "1" } }))).toBe(true);
+    expect(hasPrivacySignal(new Request("https://example.test"))).toBe(false);
   });
 });

--- a/src/app/admin/analytics/page.jsx
+++ b/src/app/admin/analytics/page.jsx
@@ -1,0 +1,68 @@
+"use client";
+
+import useSWR from "swr";
+
+const fetcher = async (url) => {
+  const response = await fetch(url, { cache: "no-store" });
+  if (!response.ok) throw new Error(response.status === 403 ? "Admin access required" : "Unable to load analytics");
+  return response.json();
+};
+
+export default function AnalyticsAdminPage() {
+  const { data, error, isLoading } = useSWR("/api/admin/analytics", fetcher);
+
+  return (
+    <main className="mx-auto min-h-screen max-w-6xl p-8 text-white">
+      <h1 className="text-3xl font-semibold">Privacy-first funnel</h1>
+      <p className="mt-2 text-slate-400">
+        Aggregate first-party events only. No visitor/session identifiers, query strings, IP addresses, or user-agent drill-down.
+      </p>
+      {isLoading && <p className="mt-8">Loading…</p>}
+      {error && <p className="mt-8 text-red-300">{error.message}</p>}
+      {data && (
+        <>
+          <p className="mt-4 text-sm text-slate-400">
+            Last {data.windowDays} days · campaign cells below {data.minimumCellSize} events are suppressed · opt-outs are not counted
+          </p>
+          <section className="mt-8 overflow-x-auto rounded-xl border border-white/10 p-5">
+            <h2 className="mb-4 text-xl font-medium">Daily funnel events</h2>
+            <table className="w-full text-left text-sm">
+              <thead><tr className="text-slate-400"><th className="py-2">Day</th><th>Event</th><th>Count</th></tr></thead>
+              <tbody>{data.daily.map((row, index) => <tr className="border-t border-white/5" key={`${row.day}-${row.event_name}-${index}`}><td className="py-2">{String(row.day).slice(0, 10)}</td><td>{row.event_name}</td><td>{row.count}</td></tr>)}</tbody>
+            </table>
+          </section>
+          <section className="mt-8 overflow-x-auto rounded-xl border border-white/10 p-5">
+            <h2 className="mb-4 text-xl font-medium">Acquisition campaigns</h2>
+            <table className="w-full text-left text-sm">
+              <thead><tr className="text-slate-400"><th className="py-2">Source</th><th>Campaign</th><th>Events</th></tr></thead>
+              <tbody>{data.campaigns.map((row, index) => <tr className="border-t border-white/5" key={`${row.source}-${row.campaign}-${index}`}><td className="py-2">{row.source}</td><td>{row.campaign}</td><td>{row.events}</td></tr>)}</tbody>
+            </table>
+          </section>
+          <section className="mt-8 overflow-x-auto rounded-xl border border-white/10 p-5">
+            <h2 className="mb-2 text-xl font-medium">Navigation transitions</h2>
+            <p className="mb-4 text-sm text-slate-400">Aggregate paths only; entry origin is direct, external, or internal. No individual trail is retained.</p>
+            <table className="w-full text-left text-sm">
+              <thead><tr className="text-slate-400"><th className="py-2">From</th><th>To</th><th>Origin</th><th>Placement</th><th>Action</th><th>Events</th></tr></thead>
+              <tbody>{data.transitions.map((row, index) => <tr className="border-t border-white/5" key={`${row.from_path}-${row.to_path}-${row.origin_class}-${row.placement}-${row.action}-${index}`}><td className="py-2">{row.from_path}</td><td>{row.to_path}</td><td>{row.origin_class}</td><td>{row.placement}</td><td>{row.action}</td><td>{row.events}</td></tr>)}</tbody>
+            </table>
+          </section>
+          <section className="mt-8 overflow-x-auto rounded-xl border border-white/10 p-5">
+            <h2 className="mb-4 text-xl font-medium">CTA and placed-navigation counts</h2>
+            <table className="w-full text-left text-sm">
+              <thead><tr className="text-slate-400"><th className="py-2">Placement</th><th>Action</th><th>Events</th></tr></thead>
+              <tbody>{data.ctas.map((row, index) => <tr className="border-t border-white/5" key={`${row.placement}-${row.action}-${index}`}><td className="py-2">{row.placement}</td><td>{row.action}</td><td>{row.events}</td></tr>)}</tbody>
+            </table>
+          </section>
+          <section className="mt-8 overflow-x-auto rounded-xl border border-white/10 p-5">
+            <h2 className="mb-2 text-xl font-medium">Authenticated activation milestones</h2>
+            <p className="mb-4 text-sm text-slate-400">First-value account milestones only. Cells below {data.minimumCellSize} accounts are suppressed.</p>
+            <table className="w-full text-left text-sm">
+              <thead><tr className="text-slate-400"><th className="py-2">Milestone</th><th>Accounts</th></tr></thead>
+              <tbody>{data.activation.map((row, index) => <tr className="border-t border-white/5" key={`${row.event_name}-${index}`}><td className="py-2">{row.event_name}</td><td>{row.accounts}</td></tr>)}</tbody>
+            </table>
+          </section>
+        </>
+      )}
+    </main>
+  );
+}

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import sql from "@/database/pgsql.js";
+import { withErrorHandler } from "@/lib/api-error";
+import { requireAnalyticsAdmin } from "@/lib/marketing/admin";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withErrorHandler(async () => {
+  await requireAnalyticsAdmin();
+
+  const daily = await sql`
+    SELECT occurred_at::date AS day, event_name, count(*)::int AS count
+    FROM app.marketing_events
+    WHERE occurred_at >= now() - interval '30 days'
+    GROUP BY 1, 2
+    ORDER BY 1 DESC, 2
+  `;
+  const campaigns = await sql`
+    SELECT coalesce(utm_source, '(direct)') AS source,
+           coalesce(utm_campaign, '(none)') AS campaign,
+           count(*)::int AS events
+    FROM app.marketing_events
+    WHERE occurred_at >= now() - interval '30 days'
+      AND event_name IN ('page_view', 'cta_click', 'registration_submit', 'registration_success')
+    GROUP BY 1, 2
+    HAVING count(*) >= 5
+    ORDER BY events DESC
+    LIMIT 50
+  `;
+
+  const transitions = await sql`
+    SELECT coalesce(from_path, '(entry)') AS from_path,
+           to_path,
+           origin_class,
+           coalesce(placement, '(unmarked)') AS placement,
+           coalesce(action, '(unmarked)') AS action,
+           count(*)::int AS events
+    FROM app.marketing_events
+    WHERE occurred_at >= now() - interval '30 days'
+      AND event_name = 'navigation_transition'
+      AND to_path IS NOT NULL
+    GROUP BY 1, 2, 3, 4, 5
+    HAVING count(*) >= 5
+    ORDER BY events DESC, 1, 2
+    LIMIT 100
+  `;
+  const ctas = await sql`
+    SELECT coalesce(placement, properties->>'location', '(unmarked)') AS placement,
+           coalesce(action, properties->>'cta', '(unmarked)') AS action,
+           count(*)::int AS events
+    FROM app.marketing_events
+    WHERE occurred_at >= now() - interval '30 days'
+      AND event_name IN ('navigation_transition', 'cta_click', 'pricing_click')
+      AND coalesce(action, properties->>'cta') IS NOT NULL
+    GROUP BY 1, 2
+    HAVING count(*) >= 5
+    ORDER BY events DESC, 1, 2
+    LIMIT 50
+  `;
+
+  const activation = await sql`
+    SELECT event_name, count(*)::int AS accounts
+    FROM app.marketing_events
+    WHERE occurred_at >= now() - interval '30 days'
+      AND user_id IS NOT NULL
+      AND event_name IN (
+        'email_verified', 'canvas_import_started', 'canvas_import_completed',
+        'first_cited_answer', 'first_flashcard_generated'
+      )
+    GROUP BY 1
+    HAVING count(*) >= 5
+    ORDER BY accounts DESC, event_name
+  `;
+
+  return NextResponse.json(
+    { windowDays: 30, minimumCellSize: 5, daily, campaigns, transitions, ctas, activation },
+    { headers: { "Cache-Control": "private, no-store" } },
+  );
+});

--- a/src/app/api/auth/verify-email/route.js
+++ b/src/app/api/auth/verify-email/route.js
@@ -8,6 +8,7 @@ import { verifyTokenHash } from "@/lib/tokens";
 import { checkRateLimit, getClientIp } from "@/lib/rateLimiter";
 import logger from "@/lib/logger";
 import { assertTrustedOrigin } from "@/lib/api-error";
+import { recordActivationMilestone } from "@/lib/marketing/events";
 
 export async function POST(request) {
   try {
@@ -48,6 +49,9 @@ export async function POST(request) {
         `;
 
     // auto-login: create session for the verified user
+    void recordActivationMilestone("email_verified", matchedUser.user_id, request).catch(
+      (eventError) => logger.warn("failed to record email verification milestone", { error: eventError.message }),
+    );
     return await createAuthSession(matchedUser, 1);
   } catch (error) {
     logger.error("email verification error", { error });

--- a/src/app/api/canvas/import/route.js
+++ b/src/app/api/canvas/import/route.js
@@ -5,6 +5,7 @@ import sql from "@/database/pgsql.js";
 import { enqueueCanvasJob } from "@/lib/queue";
 import logger from "@/lib/logger";
 import { loadCanvasCredentials } from "@/lib/canvas/credentials";
+import { recordActivationMilestone } from "@/lib/marketing/events";
 
 /**
  * POST /api/canvas/import
@@ -64,6 +65,10 @@ export const POST = withErrorHandler(async (request) => {
       error: queueErr.message,
     });
   }
+
+  await recordActivationMilestone("canvas_import_started", user.user_id, request).catch(
+    (eventError) => logger.warn("failed to record Canvas import start milestone", { error: eventError.message }),
+  );
 
   return NextResponse.json({ success: true, queued: true, jobId });
 });

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -25,6 +25,7 @@ import {
   type RetrievalInfo,
 } from "@/lib/chat/rag-context";
 import { buildLlmCall } from "@/lib/chat/build-stream";
+import { recordActivationMilestone } from "@/lib/marketing/events";
 import {
   TOOL_CALL_LIMIT_USER_MESSAGE,
   appendToolCallLimitMessage,
@@ -482,6 +483,11 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
               }
 
               await persistAssistant(reply, buildMetadata());
+              if (uniqueSources.length > 0) {
+                void recordActivationMilestone("first_cited_answer", userId, request).catch((eventError) =>
+                  logger.warn("failed to record first cited answer milestone", { error: eventError.message }),
+                );
+              }
               sendDone(writer);
               lastEvent = "done";
               logger.info("Chat stream completed", {
@@ -660,6 +666,11 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       sources: uniqueSources,
       metadata,
     });
+    if (uniqueSources.length > 0) {
+      void recordActivationMilestone("first_cited_answer", userId, request).catch((eventError) =>
+        logger.warn("failed to record first cited answer milestone", { error: eventError.message }),
+      );
+    }
     return NextResponse.json({
       reply,
       thinking: reasoningText || undefined,

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -5,6 +5,7 @@ import { withErrorHandler } from "@/lib/api-error";
 import logger from "@/lib/logger";
 import { checkRateLimit, getClientIp } from "@/lib/rateLimiter";
 import { recordMarketingEvent } from "@/lib/marketing/events";
+import { cleanAttribution } from "@/lib/marketing/attribution";
 
 const contactSchema = z.object({
   first_name: z.string().trim().min(1).max(120),
@@ -103,6 +104,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
   }
 
   const body = parsed.data;
+  const attribution = cleanAttribution(body.marketing?.utm);
   const forward = await forwardToWeb3Forms(body);
 
   await sql`
@@ -116,7 +118,6 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       phone,
       message,
       source,
-      session_id,
       utm_source,
       utm_medium,
       utm_campaign,
@@ -124,8 +125,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       utm_term,
       first_touch,
       forwarded_to_web3forms,
-      forward_error,
-      user_agent
+      forward_error
     )
     VALUES (
       ${body.first_name},
@@ -136,34 +136,30 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       ${body.institution || null},
       ${body.phone || null},
       ${body.message},
-      ${body.source},
-      ${body.marketing?.sessionId ?? null},
-      ${body.marketing?.utm?.source ?? null},
-      ${body.marketing?.utm?.medium ?? null},
-      ${body.marketing?.utm?.campaign ?? null},
-      ${body.marketing?.utm?.content ?? null},
-      ${body.marketing?.utm?.term ?? null},
-      ${sql.json(body.marketing?.firstTouch ?? {})},
+      ${"contact_form"},
+      ${attribution.source ?? null},
+      ${attribution.medium ?? null},
+      ${attribution.campaign ?? null},
+      ${attribution.content ?? null},
+      ${attribution.term ?? null},
+      ${sql.json({})},
       ${forward.forwarded},
-      ${forward.error},
-      ${request.headers.get("user-agent")?.slice(0, 300) ?? null}
+      ${forward.error}
     )
   `;
 
   await recordMarketingEvent(
     {
       eventName: "contact_form_success",
-      sessionId: body.marketing?.sessionId,
       path: request.nextUrl.pathname,
-      source: "contact_api",
-      utm: body.marketing?.utm,
+      utm: attribution,
       properties: {
         ...leadAnalyticsProperties(body),
         forwarded_to_web3forms: forward.forwarded,
-        first_touch: body.marketing?.firstTouch,
       },
     },
     request,
+    { trusted: false },
   ).catch((eventError) => {
     logger.warn("failed to record contact marketing event", {
       error: eventError.message,

--- a/src/app/api/marketing/events/route.ts
+++ b/src/app/api/marketing/events/route.ts
@@ -6,11 +6,23 @@ import {
 } from "@/lib/marketing/events";
 
 export const POST = withErrorHandler(async (request: NextRequest) => {
-  const body = await request.json().catch(() => null);
+  const contentLength = Number(request.headers.get("content-length") || "0");
+  if (contentLength > 8_192) return marketingEventResponse(false, 413);
+
+  const rawBody = await request.text().catch(() => "");
+  if (rawBody.length > 8_192) return marketingEventResponse(false, 413);
+  const body = (() => {
+    try {
+      return JSON.parse(rawBody);
+    } catch {
+      return null;
+    }
+  })();
   if (!body || typeof body !== "object") {
     return marketingEventResponse(false, 400);
   }
 
-  const ok = await recordMarketingEvent(body, request);
-  return marketingEventResponse(ok, ok ? 202 : 400);
+  const ok = await recordMarketingEvent(body, request, { trusted: false });
+  const optedOut = request.headers.get("dnt") === "1" || request.headers.get("sec-gpc") === "1";
+  return marketingEventResponse(ok || optedOut, ok || optedOut ? 202 : 400);
 });

--- a/src/app/cookies/page.jsx
+++ b/src/app/cookies/page.jsx
@@ -30,7 +30,9 @@ export default function CookiesPage() {
       <InfoSection title="Analytics And Advertising">
         <p>
           We do not currently use non-essential analytics cookies, advertising
-          pixels, or cross-site tracking cookies.
+          pixels, or cross-site tracking cookies. Limited first-party funnel
+          measurement uses no browser identifier and honors Do Not Track and
+          Global Privacy Control.
         </p>
       </InfoSection>
 
@@ -45,7 +47,7 @@ export default function CookiesPage() {
       </InfoSection>
 
       <InfoSection title="Last Updated">
-        <p>May 26, 2026.</p>
+        <p>July 11, 2026.</p>
       </InfoSection>
     </PublicInfoPage>
   );

--- a/src/app/privacy/page.jsx
+++ b/src/app/privacy/page.jsx
@@ -30,6 +30,19 @@ export default function PrivacyPage() {
         </p>
       </InfoSection>
 
+      <InfoSection title="Privacy-First Analytics">
+        <p>
+          We use limited first-party, aggregate-oriented events to understand
+          public-page acquisition and account activation. We do not use
+          analytics cookies, advertising pixels, session replay, anonymous
+          browser identifiers, raw IP addresses, query strings, or user-agent
+          fingerprints or browser storage. Campaign attribution is attached only
+          to the event generated from the current page URL, raw events are
+          retained for up to 30 days, and Do Not Track or Global Privacy Control
+          disables this collection.
+        </p>
+      </InfoSection>
+
       <InfoSection title="AI Processing">
         <p>
           When you use AI features, relevant note or file excerpts may be sent
@@ -53,7 +66,7 @@ export default function PrivacyPage() {
       </InfoSection>
 
       <InfoSection title="Last Updated">
-        <p>May 26, 2026.</p>
+        <p>July 11, 2026.</p>
       </InfoSection>
     </PublicInfoPage>
   );

--- a/src/app/register/page.js
+++ b/src/app/register/page.js
@@ -84,14 +84,7 @@ export default function RegisterPage() {
     });
     try {
       const result = await register(email, pwd, getMarketingContext());
-      trackMarketingEvent("registration_success", {
-        source: "register_form",
-        properties: {
-          method: "email",
-          requires_verification: Boolean(result.requiresVerification),
-          destination: result.requiresVerification ? "/verify-email" : "/notes",
-        },
-      });
+      // Account creation is recorded once by the server as the canonical milestone.
       if (result.requiresVerification) {
         router.replace(`/verify-email?email=${encodeURIComponent(email)}`);
         setTimeout(() => {

--- a/src/components/marketing-tracker.jsx
+++ b/src/components/marketing-tracker.jsx
@@ -5,37 +5,35 @@ import { usePathname } from "next/navigation";
 import { trackMarketingEvent } from "@/lib/marketing/client";
 
 const PUBLIC_PATH_PREFIXES = [
-  "/",
-  "/about",
-  "/ai",
-  "/blog",
-  "/contact",
-  "/login",
-  "/pricing",
-  "/register",
+  "/", "/about", "/ai", "/agents.md", "/blog", "/contact", "/cookies", "/faq.md",
+  "/llms.txt", "/login", "/pricing", "/privacy", "/register", "/syntax-guide", "/terms",
 ];
 
 function isPublicMarketingPath(pathname) {
   if (!pathname) return false;
-  if (pathname === "/") return true;
-  return PUBLIC_PATH_PREFIXES.some(
-    (prefix) => prefix !== "/" && pathname.startsWith(prefix),
-  );
+  return pathname === "/" || PUBLIC_PATH_PREFIXES.some((prefix) => prefix !== "/" && (pathname === prefix || pathname.startsWith(`${prefix}/`)));
 }
 
-function elementText(element) {
-  const label =
-    element.dataset.marketingLabel ||
-    element.getAttribute("aria-label") ||
-    element.textContent ||
-    "";
-  return label.replace(/\s+/g, " ").trim().slice(0, 80) || undefined;
+function originForInitialPage() {
+  if (!document.referrer) return "direct";
+  try { return new URL(document.referrer).origin === window.location.origin ? "internal" : "external"; } catch { return "direct"; }
 }
 
-function targetUrl(element) {
-  if (element instanceof HTMLAnchorElement) return element.href;
-  if (element instanceof HTMLButtonElement) return element.formAction || null;
-  return null;
+function navigationContext(element) {
+  const markedPlacement = element.dataset.marketingLocation;
+  const markedAction = element.dataset.marketingCta;
+  if (markedPlacement || markedAction) return { placement: markedPlacement, action: markedAction };
+  if (element.closest("header")) return { placement: "header", action: "nav_link" };
+  if (element.closest("footer")) return { placement: "footer", action: "nav_link" };
+  return {};
+}
+
+function targetPath(element) {
+  if (!(element instanceof HTMLAnchorElement) || !element.href) return null;
+  try {
+    const url = new URL(element.href);
+    return url.origin === window.location.origin && isPublicMarketingPath(url.pathname) ? url.pathname : null;
+  } catch { return null; }
 }
 
 function inferClickEvent(element) {
@@ -50,54 +48,69 @@ function clickProperties(element) {
     location: element.dataset.marketingLocation,
     cta: element.dataset.marketingCta,
     audience: element.dataset.marketingAudience,
-    label: elementText(element),
   };
 }
 
 export default function MarketingTracker() {
   const pathname = usePathname();
   const previousPath = useRef(null);
+  const sentClickTransition = useRef(null);
 
   useEffect(() => {
     if (!isPublicMarketingPath(pathname)) return;
-
-    const currentPath = `${window.location.pathname}${window.location.search}`;
+    const currentPath = window.location.pathname;
     if (previousPath.current === currentPath) return;
+
+    const fromPath = previousPath.current;
+    const alreadyRecorded = sentClickTransition.current?.fromPath === fromPath && sentClickTransition.current?.toPath === currentPath;
+    if (!alreadyRecorded) {
+      trackMarketingEvent("navigation_transition", {
+        fromPath,
+        toPath: currentPath,
+        originClass: fromPath ? "internal" : originForInitialPage(),
+      });
+    }
+    sentClickTransition.current = null;
     previousPath.current = currentPath;
 
     trackMarketingEvent("page_view", {
       source: "public_site",
-      properties: {
-        page_group: "public",
-        pathname: window.location.pathname,
-      },
+      properties: { page_group: "public", pathname: currentPath },
     });
   }, [pathname]);
 
   useEffect(() => {
     function onClick(event) {
+      if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
       if (!isPublicMarketingPath(window.location.pathname)) return;
-
       const target = event.target;
       if (!(target instanceof Element)) return;
-
       const element = target.closest("a,button");
       if (!(element instanceof HTMLElement)) return;
 
       const eventName = inferClickEvent(element);
-      if (!eventName) return;
+      if (eventName) {
+        trackMarketingEvent(eventName, {
+          source: element.dataset.marketingSource || "public_site",
+          targetUrl: element instanceof HTMLAnchorElement ? element.href : element.formAction || null,
+          properties: clickProperties(element),
+        });
+      }
 
-      trackMarketingEvent(eventName, {
-        source: element.dataset.marketingSource || "public_site",
-        targetUrl: targetUrl(element),
-        properties: clickProperties(element),
+      const toPath = targetPath(element);
+      if (!toPath || toPath === window.location.pathname) return;
+      const context = navigationContext(element);
+      sentClickTransition.current = { fromPath: window.location.pathname, toPath };
+      trackMarketingEvent("navigation_transition", {
+        fromPath: window.location.pathname,
+        toPath,
+        originClass: "internal",
+        ...context,
       });
     }
 
     document.addEventListener("click", onClick, { capture: true });
-    return () => {
-      document.removeEventListener("click", onClick, { capture: true });
-    };
+    return () => document.removeEventListener("click", onClick, { capture: true });
   }, []);
 
   return null;

--- a/src/components/settings/canvas-integration.jsx
+++ b/src/components/settings/canvas-integration.jsx
@@ -246,13 +246,7 @@ export default function CanvasIntegration() {
         return;
       }
 
-      trackMarketingEvent("canvas_connect_success", {
-        source: "settings_canvas",
-        properties: {
-          location: "settings",
-          course_count: Array.isArray(data.courses) ? data.courses.length : 0,
-        },
-      });
+      // Successful connection is recorded once by the server as a canonical milestone.
       setIsConnected(true);
       setConnectedDomain(domain);
       setCourses(data.courses ?? []);

--- a/src/lib/canvas/import-discovery.js
+++ b/src/lib/canvas/import-discovery.js
@@ -18,6 +18,7 @@ import {
 import { syncAssignmentMetadata } from "./sync-assignments.js";
 import { decrypt } from "../crypto.ts";
 import logger from "../logger.ts";
+
 import {
   PROCESSABLE_TYPES,
   FILE_CONCURRENCY,
@@ -514,6 +515,7 @@ export async function processDiscoverJob(jobId) {
 
     if (total === 0) {
       await sql`UPDATE app.canvas_import_jobs SET status = 'complete', completed_at = NOW() WHERE id = ${jobId}`;
+
       console.log(
         `Job ${jobId}: no processable files found, completed immediately`,
       );

--- a/src/lib/canvas/import-extraction.js
+++ b/src/lib/canvas/import-extraction.js
@@ -18,6 +18,7 @@ import { decrypt } from "../crypto.ts";
 import logger from "../logger.ts";
 import { sanitizePostgresText } from "../text-sanitize.ts";
 
+
 // ── Constants ───────────────────────────────────────────────────────────────
 
 export const PROCESSABLE_TYPES = new Set([
@@ -445,6 +446,7 @@ async function checkAndCompleteJob(jobId, userId) {
   if (!weCompleted) return;
 
   console.log(`[${new Date().toISOString()}] Job completed: ${jobId}`);
+
   try {
     const chunks = await sql`
       SELECT c.id FROM app.chunks c
@@ -457,6 +459,7 @@ async function checkAndCompleteJob(jobId, userId) {
         await import("../quiz/generate-background.ts");
       const seeded = await seedQuestionsAfterImport(userId, chunkIds, 5);
       console.log(`Quiz seed: ${seeded} questions for job ${jobId}`);
+
     }
   } catch (seedErr) {
     console.warn(`Quiz seed failed (non-fatal): ${seedErr.message}`);

--- a/src/lib/canvas/import-worker.ts
+++ b/src/lib/canvas/import-worker.ts
@@ -26,6 +26,7 @@ import { parseJobCourses, processCourse } from "./import-discovery.js";
 import { decrypt } from "../crypto.ts";
 import { getStorageProvider } from "../storage/init.ts";
 
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -90,12 +91,14 @@ export async function processImportJob(jobId: string): Promise<boolean> {
         console.log(
           `Quiz seed: ${seeded} questions generated for job ${jobId}`,
         );
+
       }
     } catch (seedErr) {
       console.warn(`Quiz seed failed (non-fatal): ${errorMessage(seedErr)}`);
     }
 
     await sql`UPDATE app.canvas_import_jobs SET status = 'complete', completed_at = NOW() WHERE id = ${jobId}`;
+
     console.log(`Job completed: ${jobId}`);
     return true;
   } catch (error) {

--- a/src/lib/marketing/admin.ts
+++ b/src/lib/marketing/admin.ts
@@ -1,0 +1,20 @@
+import { ApiError, requireAuth } from "@/lib/api-error";
+
+function configuredAdminEmails(): Set<string> {
+  return new Set(
+    (process.env.ANALYTICS_ADMIN_EMAILS || "")
+      .split(",")
+      .map((email: string) => email.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+export function isAnalyticsAdmin(email: string | null | undefined): boolean {
+  return Boolean(email && configuredAdminEmails().has(email.toLowerCase()));
+}
+
+export async function requireAnalyticsAdmin() {
+  const user = await requireAuth();
+  if (!isAnalyticsAdmin(user.email)) throw new ApiError(403, "Forbidden");
+  return user;
+}

--- a/src/lib/marketing/attribution.ts
+++ b/src/lib/marketing/attribution.ts
@@ -1,0 +1,35 @@
+export type Attribution = {
+  source?: string;
+  medium?: string;
+  campaign?: string;
+  content?: string;
+  term?: string;
+};
+
+// Attribution is a fixed campaign taxonomy, not a free-form query-string store.
+// Add a value here only when a campaign is intentionally deployed.
+const ALLOWED_UTM_VALUES: Record<keyof Attribution, ReadonlySet<string>> = {
+  source: new Set(["homepage", "ai_page", "pricing"]),
+  medium: new Set(["hero_cta", "midpage_cta", "cta"]),
+  campaign: new Set(["free_canvas_import", "semester_pricing", "campus_pilot", "launch_beta"]),
+  content: new Set(),
+  term: new Set(),
+};
+
+function allowedValue(key: keyof Attribution, value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return ALLOWED_UTM_VALUES[key].has(normalized) ? normalized : undefined;
+}
+
+/** Drops unknown query-derived values rather than retaining arbitrary campaign text. */
+export function cleanAttribution(value: unknown): Attribution {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const input = value as Record<string, unknown>;
+  const output: Attribution = {};
+  for (const key of Object.keys(ALLOWED_UTM_VALUES) as Array<keyof Attribution>) {
+    const clean = allowedValue(key, input[key]);
+    if (clean) output[key] = clean;
+  }
+  return output;
+}

--- a/src/lib/marketing/client.js
+++ b/src/lib/marketing/client.js
@@ -1,6 +1,8 @@
 "use client";
 
-const SESSION_KEY = "oghma_marketing_session";
+import { cleanAttribution } from "./attribution";
+
+const LEGACY_SESSION_KEY = "oghma_marketing_session";
 const FIRST_TOUCH_KEY = "oghma_marketing_first_touch";
 const LAST_TOUCH_KEY = "oghma_marketing_last_touch";
 
@@ -20,72 +22,41 @@ function safeSessionStorage() {
   }
 }
 
-function randomId() {
-  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
-  return `session_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+export function marketingAnalyticsAllowed() {
+  if (typeof window === "undefined" || typeof navigator === "undefined") return false;
+  const gpc = navigator.globalPrivacyControl === true;
+  const dnt = navigator.doNotTrack || window.doNotTrack;
+  return !gpc && dnt !== "1" && dnt !== "yes";
 }
 
-export function getMarketingSessionId() {
-  if (typeof window === "undefined") return null;
-
-  const storage = safeSessionStorage();
-  if (!storage) return randomId();
-
-  const existing = storage.getItem(SESSION_KEY);
-  if (existing) return existing;
-
-  const sessionId = randomId();
-  storage.setItem(SESSION_KEY, sessionId);
-  return sessionId;
-}
-
-function readTouch(key) {
-  const storage = safeSessionStorage();
-  if (!storage) return {};
-  try {
-    return JSON.parse(storage.getItem(key) || "{}");
-  } catch {
-    return {};
-  }
-}
-
-function writeTouch(key, value) {
+function clearAnalyticsStorage() {
   const storage = safeSessionStorage();
   if (!storage) return;
-  storage.setItem(key, JSON.stringify(value));
+  storage.removeItem(LEGACY_SESSION_KEY);
+  storage.removeItem(FIRST_TOUCH_KEY);
+  storage.removeItem(LAST_TOUCH_KEY);
+}
+
+function retireAnalyticsStorage() {
+  // Clear keys created by earlier analytics versions, then remain storage-free.
+  clearAnalyticsStorage();
 }
 
 export function getCurrentUtm() {
-  if (typeof window === "undefined") return {};
+  retireAnalyticsStorage();
+  if (!marketingAnalyticsAllowed()) return {};
 
   const params = new URLSearchParams(window.location.search);
   const current = {};
   for (const key of UTM_KEYS) {
     const value = params.get(key);
-    if (value) current[key.replace("utm_", "")] = value.slice(0, 120);
+    if (value) current[key.replace("utm_", "")] = value;
   }
-
-  if (Object.keys(current).length > 0) {
-    if (Object.keys(readTouch(FIRST_TOUCH_KEY)).length === 0) {
-      writeTouch(FIRST_TOUCH_KEY, current);
-    }
-    writeTouch(LAST_TOUCH_KEY, current);
-    return current;
-  }
-
-  return readTouch(LAST_TOUCH_KEY);
-}
-
-export function getFirstTouchUtm() {
-  return readTouch(FIRST_TOUCH_KEY);
+  return cleanAttribution(current);
 }
 
 export function getMarketingContext() {
-  return {
-    sessionId: getMarketingSessionId(),
-    utm: getCurrentUtm(),
-    firstTouch: getFirstTouchUtm(),
-  };
+  return { utm: getCurrentUtm() };
 }
 
 function getReferrer() {
@@ -94,30 +65,31 @@ function getReferrer() {
 }
 
 export function trackMarketingEvent(eventName, options = {}) {
-  if (typeof window === "undefined") return;
+  if (!marketingAnalyticsAllowed()) {
+    clearAnalyticsStorage();
+    return;
+  }
 
-  const sessionId = getMarketingSessionId();
   const payload = {
     eventName,
-    sessionId,
-    path: `${window.location.pathname}${window.location.search}`,
+    // Never send query strings, browser identifiers, user agent, or client time.
+    path: window.location.pathname,
     referrer: getReferrer(),
     source: options.source,
     targetUrl: options.targetUrl,
+    // Navigation fields are coarse allowlisted values; the server independently validates them.
+    fromPath: options.fromPath,
+    toPath: options.toPath,
+    originClass: options.originClass,
+    placement: options.placement,
+    action: options.action,
     utm: options.utm || getCurrentUtm(),
-    occurredAt: new Date().toISOString(),
-    properties: {
-      ...options.properties,
-      first_touch: getFirstTouchUtm(),
-    },
+    properties: { ...options.properties },
   };
 
   fetch("/api/marketing/events", {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Oghma-Marketing-Session": sessionId,
-    },
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
     keepalive: true,
   }).catch(() => {

--- a/src/lib/marketing/events.ts
+++ b/src/lib/marketing/events.ts
@@ -1,222 +1,181 @@
-import { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import sql from "@/database/pgsql.js";
+import { cleanAttribution } from "./attribution";
 
 const MAX_TEXT_LENGTH = 512;
-const MAX_USER_AGENT_LENGTH = 300;
-const MAX_PROPERTY_KEYS = 24;
-const MAX_ARRAY_ITEMS = 12;
-const MAX_PROPERTY_DEPTH = 2;
 
 const ALLOWED_EVENTS = new Set([
-  "page_view",
-  "cta_click",
-  "nav_click",
-  "pricing_click",
-  "contact_form_start",
-  "contact_form_submit",
-  "contact_form_success",
-  "contact_form_error",
-  "registration_form_start",
-  "registration_submit",
-  "registration_success",
-  "registration_error",
-  "registration_oauth_start",
-  "registration_oauth_unavailable",
-  "canvas_connect_attempt",
-  "canvas_connect_success",
-  "canvas_connect_error",
+  "page_view", "navigation_transition", "cta_click", "nav_click", "pricing_click",
+  "contact_form_start", "contact_form_submit", "contact_form_success", "contact_form_error",
+  "registration_form_start", "registration_submit", "registration_success", "registration_error",
+  "registration_oauth_start", "registration_oauth_unavailable", "canvas_connect_attempt",
+  "canvas_connect_success", "canvas_connect_error",
+  "email_verified", "canvas_import_started", "canvas_import_completed",
+  "first_cited_answer", "first_flashcard_generated",
 ]);
 
-const SENSITIVE_KEY_PATTERN =
-  /(email|e-mail|password|token|secret|phone|name|message|content|note|document|canvas_token|domain)/i;
-
-const SAFE_AGGREGATE_KEYS = new Set([
-  "has_phone",
-  "has_institution",
-  "message_length_bucket",
+/** Server-canonical, once-per-account first-value milestones. */
+export const ACTIVATION_MILESTONES = new Set([
+  "email_verified",
+  "canvas_import_started",
+  "canvas_import_completed",
+  "first_cited_answer",
+  "first_flashcard_generated",
 ]);
+
+// Navigation accepts only stable, public routes. Dynamic IDs and arbitrary paths are excluded.
+const NAVIGATION_PATHS = new Set([
+  "/", "/about", "/ai", "/agents.md", "/blog", "/contact", "/cookies", "/faq.md",
+  "/llms.txt", "/login", "/pricing", "/privacy", "/register", "/syntax-guide", "/terms",
+]);
+const NAVIGATION_ORIGINS = new Set(["direct", "external", "internal"]);
+const NAVIGATION_PLACEMENTS = new Set([
+  "header", "footer", "hero", "midpage_cta", "primary_ctas", "questions",
+]);
+const NAVIGATION_ACTIONS = new Set([
+  "nav_link", "connect_canvas_free", "compare_notebooklm", "view_semester_pricing",
+  "ask_about_beta_or_pilot", "contact_team",
+]);
+
+const CONTACT_ROLES = new Set(["student", "lecturer", "university_staff", "partner_or_press"]);
+const CONTACT_INTERESTS = new Set(["beta_access", "campus_pilot", "support", "billing", "partnership"]);
+const MESSAGE_LENGTH_BUCKETS = new Set(["0-100", "101-500", "500+"]);
 
 export interface MarketingEventInput {
   eventName?: unknown;
   event?: unknown;
-  sessionId?: unknown;
   userId?: string | null;
   path?: unknown;
   referrer?: unknown;
   source?: unknown;
   targetUrl?: unknown;
-  utm?: {
-    source?: unknown;
-    medium?: unknown;
-    campaign?: unknown;
-    content?: unknown;
-    term?: unknown;
-  };
+  fromPath?: unknown;
+  toPath?: unknown;
+  originClass?: unknown;
+  placement?: unknown;
+  action?: unknown;
+  utm?: { source?: unknown; medium?: unknown; campaign?: unknown; content?: unknown; term?: unknown };
   properties?: unknown;
-  occurredAt?: unknown;
 }
 
 function cleanText(value: unknown, maxLength = MAX_TEXT_LENGTH): string | null {
   if (typeof value !== "string") return null;
   const normalized = value.replace(/\s+/g, " ").trim();
-  if (!normalized) return null;
-  return normalized.slice(0, maxLength);
+  return normalized ? normalized.slice(0, maxLength) : null;
 }
 
 function cleanEventName(input: MarketingEventInput): string | null {
   const eventName = cleanText(input.eventName ?? input.event, 96);
-  if (!eventName || !ALLOWED_EVENTS.has(eventName)) return null;
-  return eventName;
+  return eventName && ALLOWED_EVENTS.has(eventName) ? eventName : null;
 }
 
-function cleanPath(value: unknown): string | null {
+export function cleanPath(value: unknown): string | null {
   const text = cleanText(value, 300);
   if (!text) return null;
-  if (text.startsWith("/")) return text.slice(0, 300);
-  try {
-    const url = new URL(text);
-    return `${url.pathname}${url.search}`.slice(0, 300);
-  } catch {
-    return null;
-  }
+  if (text.startsWith("/")) return text.split(/[?#]/, 1)[0].slice(0, 300);
+  try { return new URL(text).pathname.slice(0, 300); } catch { return null; }
 }
 
-function cleanUrl(value: unknown): string | null {
-  const text = cleanText(value, 300);
-  if (!text) return null;
-  if (text.startsWith("/")) return text.slice(0, 300);
-  try {
-    const url = new URL(text);
-    return `${url.pathname}${url.search}`.slice(0, 300);
-  } catch {
-    return null;
-  }
+export function cleanUrl(value: unknown): string | null {
+  return cleanPath(value);
 }
+
+/** Only stable public paths are accepted for navigation aggregation. */
+export function cleanNavigationPath(value: unknown): string | null {
+  const path = cleanPath(value);
+  if (!path) return null;
+  if (NAVIGATION_PATHS.has(path)) return path;
+  return /^\/blog\/[a-z0-9]+(?:-[a-z0-9]+)*$/.test(path) ? path : null;
+}
+
+function cleanNavigationValue(value: unknown, allowlist: Set<string>): string | null {
+  const text = cleanText(value, 80);
+  return text && allowlist.has(text) ? text : null;
+}
+
+export const cleanNavigationOrigin = (value: unknown) => cleanNavigationValue(value, NAVIGATION_ORIGINS);
+export const cleanNavigationPlacement = (value: unknown) => cleanNavigationValue(value, NAVIGATION_PLACEMENTS);
+export const cleanNavigationAction = (value: unknown) => cleanNavigationValue(value, NAVIGATION_ACTIONS);
 
 function cleanReferrer(value: unknown): string | null {
   const text = cleanText(value, 300);
   if (!text) return null;
-  try {
-    const url = new URL(text);
-    return url.hostname.slice(0, 160);
-  } catch {
-    return null;
-  }
+  try { return new URL(text).hostname.slice(0, 160); } catch { return null; }
 }
 
-function cleanPropertyValue(value: unknown, depth = 0): unknown {
-  if (value === null) return null;
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") return Number.isFinite(value) ? value : null;
-  if (typeof value === "string") return cleanText(value, 160);
-  if (Array.isArray(value)) {
-    return value
-      .slice(0, MAX_ARRAY_ITEMS)
-      .map((item) => cleanPropertyValue(item, depth + 1))
-      .filter((item) => item !== null && item !== undefined);
-  }
-  if (typeof value === "object" && depth < MAX_PROPERTY_DEPTH) {
-    return cleanProperties(value as Record<string, unknown>, depth + 1);
-  }
-  return null;
-}
-
-export function cleanProperties(
-  value: unknown,
-  depth = 0,
-): Record<string, unknown> {
+/**
+ * Properties are a closed aggregate schema. Never retain free-form browser or
+ * form values merely because their key does not look sensitive.
+ */
+export function cleanProperties(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
-
+  const input = value as Record<string, unknown>;
   const output: Record<string, unknown> = {};
-  for (const [rawKey, rawValue] of Object.entries(value).slice(
-    0,
-    MAX_PROPERTY_KEYS,
-  )) {
-    const key = rawKey.replace(/[^a-zA-Z0-9_:-]/g, "_").slice(0, 80);
-    if (
-      !key ||
-      (!SAFE_AGGREGATE_KEYS.has(key) && SENSITIVE_KEY_PATTERN.test(key))
-    ) {
-      continue;
-    }
-
-    const cleanValue = cleanPropertyValue(rawValue, depth);
-    if (cleanValue !== null && cleanValue !== undefined) {
-      output[key] = cleanValue;
-    }
+  if (typeof input.has_phone === "boolean") output.has_phone = input.has_phone;
+  if (typeof input.has_institution === "boolean") output.has_institution = input.has_institution;
+  if (typeof input.forwarded_to_web3forms === "boolean") output.forwarded_to_web3forms = input.forwarded_to_web3forms;
+  if (input.form === "contact") output.form = "contact";
+  if (typeof input.role === "string" && CONTACT_ROLES.has(input.role)) output.role = input.role;
+  if (typeof input.interest === "string" && CONTACT_INTERESTS.has(input.interest)) output.interest = input.interest;
+  if (typeof input.message_length_bucket === "string" && MESSAGE_LENGTH_BUCKETS.has(input.message_length_bucket)) {
+    output.message_length_bucket = input.message_length_bucket;
   }
   return output;
 }
 
-function cleanOccurredAt(value: unknown): Date | null {
-  if (typeof value !== "string") return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-
-  const now = Date.now();
-  const skewMs = Math.abs(now - date.getTime());
-  if (skewMs > 24 * 60 * 60 * 1000) return null;
-  return date;
+export function hasPrivacySignal(request: Request | NextRequest): boolean {
+  const dnt = request.headers.get("dnt")?.toLowerCase();
+  return request.headers.get("sec-gpc") === "1" || dnt === "1" || dnt === "yes";
 }
 
-export function getMarketingSessionId(request: Request | NextRequest): string | null {
-  return cleanText(request.headers.get("x-oghma-marketing-session"), 96);
-}
-
-export async function recordMarketingEvent(
-  input: MarketingEventInput,
-  request?: Request | NextRequest,
-): Promise<boolean> {
+export async function recordMarketingEvent(input: MarketingEventInput, request?: Request | NextRequest, options: { trusted?: boolean } = {}): Promise<boolean> {
+  if (request && hasPrivacySignal(request)) return false;
   const eventName = cleanEventName(input);
   if (!eventName) return false;
-
-  const sessionId =
-    cleanText(input.sessionId, 96) ??
-    (request ? getMarketingSessionId(request) : null);
-  const userAgent = request
-    ? cleanText(request.headers.get("user-agent"), MAX_USER_AGENT_LENGTH)
-    : null;
-  const occurredAt = cleanOccurredAt(input.occurredAt) ?? new Date();
+  const fromPath = cleanNavigationPath(input.fromPath);
+  const toPath = cleanNavigationPath(input.toPath);
+  const originClass = cleanNavigationOrigin(input.originClass);
+  const placement = cleanNavigationPlacement(input.placement);
+  const action = cleanNavigationAction(input.action);
+  // Navigation observations must be useful, coarse dimensions rather than arbitrary payloads.
+  if (eventName === "navigation_transition" && (!toPath || !originClass)) return false;
+  // Public ingestion cannot associate an observation with an account or retain
+  // free-form path, source, target, or attribution values.
+  const isPublicIngestion = options.trusted === false;
+  const userId = isPublicIngestion ? null : input.userId ?? null;
+  const attribution = cleanAttribution(input.utm);
 
   await sql`
     INSERT INTO app.marketing_events (
-      event_name,
-      session_id,
-      user_id,
-      path,
-      referrer,
-      source,
-      target_url,
-      utm_source,
-      utm_medium,
-      utm_campaign,
-      utm_content,
-      utm_term,
-      properties,
-      user_agent,
-      occurred_at
-    )
-    VALUES (
-      ${eventName},
-      ${sessionId},
-      ${input.userId ?? null},
-      ${cleanPath(input.path)},
-      ${cleanReferrer(input.referrer)},
-      ${cleanText(input.source, 120)},
-      ${cleanUrl(input.targetUrl)},
-      ${cleanText(input.utm?.source, 120)},
-      ${cleanText(input.utm?.medium, 120)},
-      ${cleanText(input.utm?.campaign, 120)},
-      ${cleanText(input.utm?.content, 120)},
-      ${cleanText(input.utm?.term, 120)},
-      ${sql.json(cleanProperties(input.properties))},
-      ${userAgent},
-      ${occurredAt}
-    )
-  `;
-
+      event_name, user_id, path, referrer, source, target_url,
+      from_path, to_path, origin_class, placement, action,
+      utm_source, utm_medium, utm_campaign, utm_content, utm_term, properties, occurred_at
+    ) VALUES (
+      ${eventName}, ${userId}, ${isPublicIngestion ? cleanNavigationPath(input.path) : cleanPath(input.path)}, ${isPublicIngestion ? null : cleanReferrer(input.referrer)}, ${isPublicIngestion ? null : cleanText(input.source, 120)}, ${isPublicIngestion ? null : cleanUrl(input.targetUrl)},
+      ${fromPath}, ${toPath}, ${originClass}, ${placement}, ${action},
+      ${attribution.source ?? null}, ${attribution.medium ?? null}, ${attribution.campaign ?? null}, ${attribution.content ?? null}, ${attribution.term ?? null}, ${sql.json(cleanProperties(input.properties))}, ${new Date()}
+    )`;
   return true;
+}
+
+/**
+ * Records an authenticated first-value milestone once. This intentionally accepts
+ * neither paths nor properties: account ID + milestone name are all it stores.
+ * The partial unique index from migration 038 is the idempotence boundary.
+ */
+export async function recordActivationMilestone(
+  eventName: string,
+  userId: string | null | undefined,
+  request?: Request | NextRequest,
+): Promise<boolean> {
+  if (!userId || !ACTIVATION_MILESTONES.has(eventName) || (request && hasPrivacySignal(request))) return false;
+  const inserted = await sql`
+    INSERT INTO app.marketing_events (event_name, user_id, properties, occurred_at)
+    VALUES (${eventName}, ${userId}, '{}'::jsonb, ${new Date()})
+    ON CONFLICT DO NOTHING
+    RETURNING id
+  `;
+  return inserted.length > 0;
 }
 
 export function marketingEventResponse(ok: boolean, status = 202): NextResponse {

--- a/src/lib/vault/import-worker.ts
+++ b/src/lib/vault/import-worker.ts
@@ -25,6 +25,7 @@ import {
 } from "./tree-builder";
 import { sendVaultImportCompleteEmail } from "../email.js";
 
+
 const PROCESSABLE_EXTS = new Set([
   "pdf",
   "docx",
@@ -486,6 +487,7 @@ export async function processVaultImport(msg: Record<string, unknown>): Promise<
           await import("../quiz/generate-background.ts");
         const seeded = await seedQuestionsAfterImport(userId, chunkIds, 5);
         console.log(`[${ts()}] Quiz seed: ${seeded} questions generated`);
+
       }
     } catch (seedErr) {
       console.warn(


### PR DESCRIPTION
## Summary
- removes analytics session identifiers and all analytics browser storage
- keeps event-level UTM acquisition plus server-canonical activation milestones
- honours DNT/GPC and strips query strings, user agents, and arbitrary content
- adds a 30-day retention migration and admin-only aggregate dashboard
- documents a future Grafana/Metabase aggregate layer without central raw tracking

## Verification
- focused marketing tests: 4 passed
- ESLint on changed application files
- production Next.js build passed
- git diff --check passed

## Operator note
Set `ANALYTICS_ADMIN_EMAILS` before using `/admin/analytics`. The migration drops legacy marketing session/user-agent columns.