### PR TITLE
feat: add auth.md new-user registration claims

### DIFF
--- a/database/migrations/039_agent_registration_claims.sql
+++ b/database/migrations/039_agent_registration_claims.sql
@@ -1,0 +1,26 @@
+-- auth.md v1: agent-initiated registration claims for previously unknown users.
+-- This table deliberately does not issue API credentials. A claim only proves that
+-- the email owner completed the normal OghmaNotes registration and verification flow.
+CREATE TABLE IF NOT EXISTS app.agent_registration_claims (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email TEXT NOT NULL,
+    claim_token_hash TEXT NOT NULL UNIQUE,
+    user_code_hash TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'registered', 'verified')),
+    created_user_id UUID REFERENCES app.login(user_id) ON DELETE SET NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    registered_at TIMESTAMPTZ,
+    verified_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_registration_claims_open_email
+    ON app.agent_registration_claims (LOWER(email))
+    WHERE status IN ('pending', 'registered');
+
+CREATE INDEX IF NOT EXISTS idx_agent_registration_claims_token_expiry
+    ON app.agent_registration_claims (claim_token_hash, expires_at);
+
+COMMENT ON TABLE app.agent_registration_claims IS
+    'Short-lived auth.md claims that let an agent begin registration for a new user; no API credentials are issued.';

--- a/docs/engineering/agent-compatibility.md
+++ b/docs/engineering/agent-compatibility.md
@@ -39,6 +39,7 @@ All rows below describe current code, not desired future behavior.
 | `/ai.md`, `/agents.md` | Full public `text/markdown` agent profile and action guide. | Discovery/read-only |
 | `/info.md`, `/faq.md`, `/pricing.md` | Purpose-specific compact facts, FAQ, and pricing documents using `text/markdown`. | Discovery/read-only |
 | `/llms.txt`, `/llms-full.txt` | Compact index and full profile using `text/plain`. | Discovery/read-only |
+| `/auth.md` | Agent-initiated registration instructions for previously unknown users. The person still chooses a password and verifies their email in the browser. | Discovery/low-risk intent capture |
 | `/agent-api.json`, `/openapi.json` | Public OpenAPI 3.1 JSON aliases for the documented agent surface. Operations include IDs, tags, security hints, and agent-safety metadata. This is not a promise that every app API is autonomous-agent safe. | Discovery |
 | `/agent-sitemap.xml` | Lists the agent-resource paths from `AGENT_RESOURCE_PATHS`. | Discovery |
 | `/sitemap.xml` | Includes public product pages, agent resources, blog posts, and the syntax guide. | Discovery |
@@ -58,6 +59,7 @@ highest-risk boundaries:
 |---|---|---|
 | `POST /api/auth/register` | Creates an account and starts verification. | Prefer the visible registration flow; never ask for or retain a password. Confirm before submission. |
 | `POST /api/auth/login` | Creates an authenticated browser session. | Keep credential entry under user control. Do not request cookies or credentials in chat. |
+| `POST /agent/identity` | Starts a short-lived registration claim for a new email address. | Give the person the returned URI and six-digit code; never request a password, cookie, or email-verification token. This does not issue an API credential. |
 | `POST /api/chat` | Uses a signed-in user's private study context and may persist chat state. | Require an explicit user request and the normal session/ownership checks. |
 | `GET /contact` | Opens the human-readable contact page. No first-party public contact POST API is documented. | Draft or navigate only; confirm before submitting the visible form. |
 

--- a/docs/engineering/agent-compatibility.md
+++ b/docs/engineering/agent-compatibility.md
@@ -39,7 +39,7 @@ All rows below describe current code, not desired future behavior.
 | `/ai.md`, `/agents.md` | Full public `text/markdown` agent profile and action guide. | Discovery/read-only |
 | `/info.md`, `/faq.md`, `/pricing.md` | Purpose-specific compact facts, FAQ, and pricing documents using `text/markdown`. | Discovery/read-only |
 | `/llms.txt`, `/llms-full.txt` | Compact index and full profile using `text/plain`. | Discovery/read-only |
-| `/auth.md` | Agent-initiated registration instructions for previously unknown users. The person still chooses a password and verifies their email in the browser. | Discovery/low-risk intent capture |
+| `/auth.md` | Agent-initiated registration instructions for previously unknown users. The person completes a matching verified Google/GitHub OAuth flow or chooses a password and verifies their email in the browser. | Discovery/low-risk intent capture |
 | `/agent-api.json`, `/openapi.json` | Public OpenAPI 3.1 JSON aliases for the documented agent surface. Operations include IDs, tags, security hints, and agent-safety metadata. This is not a promise that every app API is autonomous-agent safe. | Discovery |
 | `/agent-sitemap.xml` | Lists the agent-resource paths from `AGENT_RESOURCE_PATHS`. | Discovery |
 | `/sitemap.xml` | Includes public product pages, agent resources, blog posts, and the syntax guide. | Discovery |
@@ -59,7 +59,7 @@ highest-risk boundaries:
 |---|---|---|
 | `POST /api/auth/register` | Creates an account and starts verification. | Prefer the visible registration flow; never ask for or retain a password. Confirm before submission. |
 | `POST /api/auth/login` | Creates an authenticated browser session. | Keep credential entry under user control. Do not request cookies or credentials in chat. |
-| `POST /agent/identity` | Starts a short-lived registration claim for a new email address. | Give the person the returned URI and six-digit code; never request a password, cookie, or email-verification token. This does not issue an API credential. |
+| `POST /agent/identity` | Starts a short-lived registration claim for a new email address. | Give the person the returned URI and six-digit code; OAuth and email proof remain in the user's browser. Never request a password, provider token, cookie, or email-verification token. This does not issue an API credential. |
 | `POST /api/chat` | Uses a signed-in user's private study context and may persist chat state. | Require an explicit user request and the normal session/ownership checks. |
 | `GET /contact` | Opens the human-readable contact page. No first-party public contact POST API is documented. | Draft or navigate only; confirm before submitting the visible form. |
 

--- a/src/__tests__/api/agent-registration.test.ts
+++ b/src/__tests__/api/agent-registration.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/database/pgsql.js", () => ({ default: vi.fn() }));
+vi.mock("@/lib/rateLimiter", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+  getClientIp: vi.fn().mockReturnValue("127.0.0.1"),
+}));
+vi.mock("@/lib/auth", () => ({
+  createErrorResponse: (error: string, status = 400) =>
+    Response.json({ success: false, error }, { status }),
+  parseJsonBody: async (request: Request) => ({
+    data: await request.json(),
+    error: null,
+  }),
+}));
+vi.mock("@/lib/agent-registration", () => ({
+  createAgentRegistrationClaim: vi.fn(),
+  findAgentRegistrationClaim: vi.fn(),
+  findOpenAgentRegistrationByEmail: vi.fn(),
+}));
+
+import sql from "@/database/pgsql.js";
+import {
+  createAgentRegistrationClaim,
+  findAgentRegistrationClaim,
+  findOpenAgentRegistrationByEmail,
+} from "@/lib/agent-registration";
+import { POST as startRegistration } from "@/app/agent/identity/route";
+import { POST as readClaim } from "@/app/agent/identity/claim/route";
+
+const CLAIM_TOKEN = "a".repeat(64);
+
+function request(url: string, body: unknown) {
+  return new NextRequest(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(sql).mockResolvedValue([]);
+  vi.mocked(findOpenAgentRegistrationByEmail).mockResolvedValue(null);
+});
+
+describe("auth.md new-user registration", () => {
+  it("starts a short-lived service_auth claim for a previously unknown email", async () => {
+    const expiresAt = new Date("2026-07-14T12:15:00.000Z");
+    vi.mocked(createAgentRegistrationClaim).mockResolvedValue({
+      claim: {
+        id: "claim-1",
+        email: "student@example.com",
+        status: "pending",
+        expires_at: expiresAt,
+        created_user_id: null,
+      },
+      claimToken: CLAIM_TOKEN,
+      userCode: "123456",
+    });
+
+    const response = await startRegistration(
+      request("https://oghmanotes.ie/agent/identity", {
+        type: "service_auth",
+        login_hint: "Student@example.com",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      registration_id: "claim-1",
+      registration_type: "service_auth",
+      claim_token: CLAIM_TOKEN,
+      claim: {
+        user_code: "123456",
+        verification_uri: expect.stringContaining("/register?agent_claim_token="),
+      },
+    });
+    expect(createAgentRegistrationClaim).toHaveBeenCalledWith(
+      "student@example.com",
+    );
+  });
+
+  it("refuses an existing account instead of creating a claim", async () => {
+    vi.mocked(sql).mockResolvedValue([{ user_id: "user-1" }]);
+
+    const response = await startRegistration(
+      request("https://oghmanotes.ie/agent/identity", {
+        type: "service_auth",
+        login_hint: "student@example.com",
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(createAgentRegistrationClaim).not.toHaveBeenCalled();
+  });
+
+  it("reports verified completion but never issues an API credential", async () => {
+    vi.mocked(findAgentRegistrationClaim).mockResolvedValue({
+      id: "claim-1",
+      email: "student@example.com",
+      status: "verified",
+      expires_at: new Date("2099-07-14T12:15:00.000Z"),
+      created_user_id: "user-1",
+    });
+
+    const response = await readClaim(
+      request("https://oghmanotes.ie/agent/identity/claim", {
+        claim_token: CLAIM_TOKEN,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("verified");
+    expect(body).not.toHaveProperty("access_token");
+  });
+});

--- a/src/__tests__/api/agent-registration.test.ts
+++ b/src/__tests__/api/agent-registration.test.ts
@@ -15,19 +15,29 @@ vi.mock("@/lib/auth", () => ({
   }),
 }));
 vi.mock("@/lib/agent-registration", () => ({
+  completeOAuthAgentRegistration: vi.fn(),
   createAgentRegistrationClaim: vi.fn(),
   findAgentRegistrationClaim: vi.fn(),
   findOpenAgentRegistrationByEmail: vi.fn(),
 }));
+vi.mock("@/auth", () => ({
+  auth: vi.fn(),
+}));
+vi.mock("@/lib/api-error", () => ({
+  assertTrustedOrigin: vi.fn(),
+}));
 
 import sql from "@/database/pgsql.js";
 import {
+  completeOAuthAgentRegistration,
   createAgentRegistrationClaim,
   findAgentRegistrationClaim,
   findOpenAgentRegistrationByEmail,
 } from "@/lib/agent-registration";
+import { auth } from "@/auth";
 import { POST as startRegistration } from "@/app/agent/identity/route";
 import { POST as readClaim } from "@/app/agent/identity/claim/route";
+import { POST as completeClaim } from "@/app/agent/identity/claim/complete/route";
 
 const CLAIM_TOKEN = "a".repeat(64);
 
@@ -43,6 +53,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(sql).mockResolvedValue([]);
   vi.mocked(findOpenAgentRegistrationByEmail).mockResolvedValue(null);
+  vi.mocked(auth).mockResolvedValue(null as any);
 });
 
 describe("auth.md new-user registration", () => {
@@ -55,6 +66,7 @@ describe("auth.md new-user registration", () => {
         status: "pending",
         expires_at: expiresAt,
         created_user_id: null,
+        created_at: new Date("2026-07-14T12:00:00.000Z"),
       },
       claimToken: CLAIM_TOKEN,
       userCode: "123456",
@@ -103,6 +115,7 @@ describe("auth.md new-user registration", () => {
       status: "verified",
       expires_at: new Date("2099-07-14T12:15:00.000Z"),
       created_user_id: "user-1",
+      created_at: new Date("2026-07-14T12:00:00.000Z"),
     });
 
     const response = await readClaim(
@@ -115,5 +128,35 @@ describe("auth.md new-user registration", () => {
     const body = await response.json();
     expect(body.status).toBe("verified");
     expect(body).not.toHaveProperty("access_token");
+  });
+
+  it("completes a claim only from an authenticated matching OAuth account", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1", email: "student@example.com" },
+      expires: "2099-07-14T12:15:00.000Z",
+    } as any);
+    vi.mocked(completeOAuthAgentRegistration).mockResolvedValue({
+      id: "claim-1",
+      email: "student@example.com",
+      status: "verified",
+      expires_at: new Date("2099-07-14T12:15:00.000Z"),
+      created_user_id: "user-1",
+      created_at: new Date("2026-07-14T12:00:00.000Z"),
+    });
+
+    const response = await completeClaim(
+      request("https://oghmanotes.ie/agent/identity/claim/complete", {
+        claim_token: CLAIM_TOKEN,
+        user_code: "123456",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(completeOAuthAgentRegistration).toHaveBeenCalledWith(
+      CLAIM_TOKEN,
+      "123456",
+      "user-1",
+      "student@example.com",
+    );
   });
 });

--- a/src/__tests__/api/auth-verify-email-agent.test.ts
+++ b/src/__tests__/api/auth-verify-email-agent.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { tx, sql } = vi.hoisted(() => {
+  const transaction = vi.fn();
+  return {
+    tx: transaction,
+    sql: Object.assign(vi.fn(), { begin: vi.fn() }),
+  };
+});
+
+vi.mock("@/database/pgsql.js", () => ({ default: sql }));
+vi.mock("@/lib/auth", () => ({
+  createAuthSession: vi.fn().mockResolvedValue(Response.json({ success: true })),
+  createErrorResponse: (error: string, status = 400) =>
+    Response.json({ success: false, error }, { status }),
+  parseJsonBody: async (request: Request) => ({
+    data: await request.json(),
+    error: null,
+  }),
+}));
+vi.mock("@/lib/tokens", () => ({ verifyTokenHash: vi.fn(() => true) }));
+vi.mock("@/lib/rateLimiter", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+  getClientIp: vi.fn(() => "127.0.0.1"),
+}));
+vi.mock("@/lib/logger", () => ({
+  default: { error: vi.fn(), warn: vi.fn() },
+}));
+vi.mock("@/lib/api-error", () => ({ assertTrustedOrigin: vi.fn() }));
+vi.mock("@/lib/marketing/events", () => ({
+  recordActivationMilestone: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { createAuthSession } from "@/lib/auth";
+import { POST } from "@/app/api/auth/verify-email/route.js";
+
+function request() {
+  return new Request("https://oghmanotes.ie/api/auth/verify-email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token: "verification-token" }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sql.mockResolvedValue([
+    {
+      user_id: "00000000-0000-4000-8000-000000000001",
+      email: "student@example.com",
+      verification_token: "stored-hash",
+    },
+  ]);
+  tx.mockResolvedValue([]);
+  sql.begin.mockImplementation(async (callback) => callback(tx));
+});
+
+describe("email verification with an agent registration claim", () => {
+  it("commits account verification and claim completion in one transaction", async () => {
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(sql.begin).toHaveBeenCalledOnce();
+    expect(tx).toHaveBeenCalledTimes(2);
+    expect(createAuthSession).toHaveBeenCalledOnce();
+  });
+
+  it("does not create a session when the atomic verification transaction fails", async () => {
+    tx.mockResolvedValueOnce([]).mockRejectedValueOnce(new Error("db failed"));
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(500);
+    expect(createAuthSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/app/agent-content-routes.test.ts
+++ b/src/__tests__/app/agent-content-routes.test.ts
@@ -172,6 +172,9 @@ describe("agent-readable content routes", () => {
     expect(body.paths["/agent/identity/claim"].post.summary).toBe(
       "Poll an agent registration claim",
     );
+    expect(body.paths["/agent/identity/claim/complete"].post.summary).toBe(
+      "Complete an agent registration claim with OAuth",
+    );
     expect(
       body.paths["/api/auth/register"].post[
         "x-human-confirmation-required"

--- a/src/__tests__/app/agent-content-routes.test.ts
+++ b/src/__tests__/app/agent-content-routes.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vitest";
 import { GET as agentSitemap } from "@/app/agent-sitemap.xml/route";
 import { GET as agentApi } from "@/app/agent-api.json/route";
 import { GET as aiMarkdown } from "@/app/ai.md/route";
+import { GET as authMarkdown } from "@/app/auth.md/route";
+import { GET as authorizationServerMetadata } from "@/app/.well-known/oauth-authorization-server/route";
+import { GET as protectedResourceMetadata } from "@/app/.well-known/oauth-protected-resource/route";
 import { GET as agentsMarkdown } from "@/app/agents.md/route";
 import { GET as faqMarkdown } from "@/app/faq.md/route";
 import { GET as infoMarkdown } from "@/app/info.md/route";
@@ -26,6 +29,23 @@ describe("agent-readable content routes", () => {
     expect(body).toContain("POST https://oghmanotes.ie/api/auth/register");
     expect(body).toContain("GET https://oghmanotes.ie/ai?format=md");
     expect(body).toContain("GET https://oghmanotes.ie/info?format=md");
+  });
+
+  it("publishes auth.md discovery without advertising private API access", async () => {
+    const response = authMarkdown();
+    const body = await response.text();
+    const protectedResource = await protectedResourceMetadata().json();
+    const authorizationServer = await authorizationServerMetadata().json();
+
+    expect(response.headers.get("content-type")).toContain("text/markdown");
+    expect(body).toContain("agent-initiated registration for new users only");
+    expect(body).toContain("does not issue agent access tokens");
+    expect(protectedResource.scopes_supported).toEqual([]);
+    expect(authorizationServer.agent_auth).toMatchObject({
+      skill: "https://oghmanotes.ie/auth.md",
+      identity_types_supported: ["service_auth"],
+      credentials_issued: false,
+    });
   });
 
   it("serves compact and full LLM text resources separately", async () => {
@@ -89,6 +109,7 @@ describe("agent-readable content routes", () => {
     expect(body).toContain("<loc>https://oghmanotes.ie/openapi.json</loc>");
     expect(body).toContain("<loc>https://oghmanotes.ie/llms.txt</loc>");
     expect(body).toContain("<loc>https://oghmanotes.ie/llms-full.txt</loc>");
+    expect(body).toContain("<loc>https://oghmanotes.ie/auth.md</loc>");
   });
 
   it("serves a structured agent API document", async () => {
@@ -139,6 +160,17 @@ describe("agent-readable content routes", () => {
     );
     expect(body.paths["/api/auth/register"].post.summary).toBe(
       "Create a user account",
+    );
+    expect(body.paths["/agent/identity"].post.summary).toBe(
+      "Start an agent-initiated new-user registration",
+    );
+    expect(
+      body.paths["/agent/identity"].post[
+        "x-human-confirmation-required"
+      ],
+    ).toBe(true);
+    expect(body.paths["/agent/identity/claim"].post.summary).toBe(
+      "Poll an agent registration claim",
     );
     expect(
       body.paths["/api/auth/register"].post[

--- a/src/__tests__/app/proxy-markdown.test.ts
+++ b/src/__tests__/app/proxy-markdown.test.ts
@@ -32,4 +32,16 @@ describe("markdown content negotiation proxy", () => {
       "https://oghmanotes.ie/pricing.md",
     );
   });
+
+  it("allows an authenticated OAuth callback to finish an agent registration", async () => {
+    const response = await proxy(
+      new NextRequest(
+        "https://oghmanotes.ie/register?agent_claim_token=claim&agent_oauth=complete",
+        { headers: { cookie: "authjs.session-token=session" } },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
 });

--- a/src/__tests__/auth.config.test.ts
+++ b/src/__tests__/auth.config.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/lib/logger", () => ({
 
 vi.mock("@/lib/auth-oauth", () => ({
   findOrCreateOAuthUser: vi.fn(),
+  resolveVerifiedOAuthEmail: vi.fn(),
 }));
 
 const originalEnv = { ...process.env };

--- a/src/__tests__/lib/auth-oauth.test.ts
+++ b/src/__tests__/lib/auth-oauth.test.ts
@@ -27,6 +27,7 @@ import {
   syncProfileToLogin,
   getLinkedProviders,
   findOrCreateOAuthUser,
+  resolveVerifiedOAuthEmail,
 } from "@/lib/auth-oauth";
 import sql from "@/database/pgsql.js";
 
@@ -34,11 +35,15 @@ const mockSql = sql as unknown as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("isEmailVerifiedByProvider", () => {
-  it("returns true for google (always verified)", () => {
-    expect(isEmailVerifiedByProvider("google", {})).toBe(true);
+  it("requires google to explicitly assert email verification", () => {
+    expect(isEmailVerifiedByProvider("google", {})).toBe(false);
+    expect(
+      isEmailVerifiedByProvider("google", { email_verified: true }),
+    ).toBe(true);
   });
 
   it("returns true for github when email_verified is true", () => {
@@ -53,6 +58,36 @@ describe("isEmailVerifiedByProvider", () => {
 
   it("returns false for unknown provider", () => {
     expect(isEmailVerifiedByProvider("unknown", {})).toBe(false);
+  });
+});
+
+describe("resolveVerifiedOAuthEmail", () => {
+  it("accepts a Google email only when the profile marks it verified", async () => {
+    await expect(
+      resolveVerifiedOAuthEmail("google", {
+        email: "Student@Example.com",
+        email_verified: true,
+      }),
+    ).resolves.toBe("student@example.com");
+    await expect(
+      resolveVerifiedOAuthEmail("google", { email: "student@example.com" }),
+    ).resolves.toBeNull();
+  });
+
+  it("uses GitHub's authenticated primary verified email", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        Response.json([
+          { email: "other@example.com", primary: false, verified: true },
+          { email: "Primary@Example.com", primary: true, verified: true },
+        ]),
+      ),
+    );
+
+    await expect(
+      resolveVerifiedOAuthEmail("github", {}, "github-token"),
+    ).resolves.toBe("primary@example.com");
   });
 });
 
@@ -143,7 +178,11 @@ describe("findOrCreateOAuthUser", () => {
     mockSql.mockResolvedValueOnce([]);
     // syncProfileToLogin
     mockSql.mockResolvedValueOnce([]);
-    const result = await findOrCreateOAuthUser(googleProfile, {});
+    // mark the login email verified
+    mockSql.mockResolvedValueOnce([]);
+    const result = await findOrCreateOAuthUser(googleProfile, {
+      email_verified: true,
+    });
     expect(result).toBe("u-1");
   });
 
@@ -156,7 +195,11 @@ describe("findOrCreateOAuthUser", () => {
     mockSql.mockResolvedValueOnce([]);
     // syncProfileToLogin
     mockSql.mockResolvedValueOnce([]);
-    const result = await findOrCreateOAuthUser(googleProfile, {});
+    // mark the login email verified
+    mockSql.mockResolvedValueOnce([]);
+    const result = await findOrCreateOAuthUser(googleProfile, {
+      email_verified: true,
+    });
     expect(result).toBe("u-existing");
   });
 
@@ -169,26 +212,21 @@ describe("findOrCreateOAuthUser", () => {
     mockSql.mockResolvedValueOnce([{ user_id: "u-new" }]);
     // linkOAuthAccount
     mockSql.mockResolvedValueOnce([]);
-    const result = await findOrCreateOAuthUser(googleProfile, {});
+    const result = await findOrCreateOAuthUser(googleProfile, {
+      email_verified: true,
+    });
     expect(result).toBe("u-new");
   });
 
-  it("does not auto-link when email is unverified (github)", async () => {
+  it("rejects an unverified provider email", async () => {
     const ghProfile = {
       ...googleProfile,
       provider: "github",
       providerAccountId: "gh-1",
     };
-    // findOAuthAccount: not found
-    mockSql.mockResolvedValueOnce([]);
-    // no login lookup (email not verified) — goes straight to INSERT
-    // INSERT login: returns new user_id
-    mockSql.mockResolvedValueOnce([{ user_id: "u-new-gh" }]);
-    // linkOAuthAccount
-    mockSql.mockResolvedValueOnce([]);
-    const result = await findOrCreateOAuthUser(ghProfile, {
-      email_verified: false,
-    });
-    expect(result).toBe("u-new-gh");
+    await expect(
+      findOrCreateOAuthUser(ghProfile, { email_verified: false }),
+    ).rejects.toThrow("verified email");
+    expect(mockSql).not.toHaveBeenCalled();
   });
 });

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,22 @@
+import { getBaseUrl } from "@/lib/public/agent-content";
+
+export function GET() {
+  const baseUrl = getBaseUrl();
+  return Response.json(
+    {
+      issuer: baseUrl,
+      resource: baseUrl,
+      authorization_servers: [baseUrl],
+      grant_types_supported: [],
+      agent_auth: {
+        skill: `${baseUrl}/auth.md`,
+        identity_endpoint: `${baseUrl}/agent/identity`,
+        claim_endpoint: `${baseUrl}/agent/identity/claim`,
+        identity_types_supported: ["service_auth"],
+        registration_scope: "new_user_only",
+        credentials_issued: false,
+      },
+    },
+    { headers: { "Cache-Control": "public, max-age=300, s-maxage=3600" } },
+  );
+}

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,15 @@
+import { getBaseUrl } from "@/lib/public/agent-content";
+
+export function GET() {
+  const baseUrl = getBaseUrl();
+  return Response.json(
+    {
+      resource: baseUrl,
+      resource_name: "OghmaNotes",
+      authorization_servers: [baseUrl],
+      scopes_supported: [],
+      bearer_methods_supported: [],
+    },
+    { headers: { "Cache-Control": "public, max-age=300, s-maxage=3600" } },
+  );
+}

--- a/src/app/agent/identity/claim/complete/route.ts
+++ b/src/app/agent/identity/claim/complete/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from "next/server";
+import { auth } from "@/auth";
+import { createErrorResponse, parseJsonBody } from "@/lib/auth";
+import { completeOAuthAgentRegistration } from "@/lib/agent-registration";
+import { assertTrustedOrigin } from "@/lib/api-error";
+import { checkRateLimit, getClientIp } from "@/lib/rateLimiter";
+import {
+  agentRegistrationCompleteSchema,
+  validateBody,
+} from "@/lib/validations/schemas";
+
+export async function POST(request: NextRequest) {
+  assertTrustedOrigin(request);
+  const limited = await checkRateLimit(
+    "agent-registration-claim",
+    getClientIp(request),
+  );
+  if (limited) return limited;
+
+  const session = await auth();
+  if (!session?.user?.id || !session.user.email) {
+    return createErrorResponse("OAuth authentication is required", 401);
+  }
+
+  const { data, error } = await parseJsonBody(request);
+  if (error) return error;
+  const result = validateBody(agentRegistrationCompleteSchema, data);
+  if (!result.success) return result.response;
+
+  const claim = await completeOAuthAgentRegistration(
+    result.data.claim_token,
+    result.data.user_code,
+    session.user.id,
+    session.user.email,
+  );
+  if (!claim) {
+    return createErrorResponse(
+      "The OAuth email does not match this new-user claim, or the claim expired",
+      400,
+    );
+  }
+
+  return Response.json({
+    registration_id: claim.id,
+    registration_type: "service_auth",
+    status: "verified",
+  });
+}

--- a/src/app/agent/identity/claim/route.ts
+++ b/src/app/agent/identity/claim/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { createErrorResponse, parseJsonBody } from "@/lib/auth";
+import { findAgentRegistrationClaim } from "@/lib/agent-registration";
+import { checkRateLimit, getClientIp } from "@/lib/rateLimiter";
+import { agentRegistrationClaimSchema, validateBody } from "@/lib/validations/schemas";
+
+export async function POST(request: NextRequest) {
+  const limited = await checkRateLimit("agent-registration-claim", getClientIp(request));
+  if (limited) return limited;
+
+  const { data, error } = await parseJsonBody(request);
+  if (error) return error;
+  const result = validateBody(agentRegistrationClaimSchema, data);
+  if (!result.success) return result.response;
+
+  const claim = await findAgentRegistrationClaim(result.data.claim_token);
+  if (!claim || claim.expires_at <= new Date()) {
+    return createErrorResponse("Invalid or expired registration claim", 400);
+  }
+
+  return Response.json({
+    registration_id: claim.id,
+    registration_type: "service_auth",
+    status: claim.status,
+    expires_at: claim.expires_at.toISOString(),
+  });
+}

--- a/src/app/agent/identity/route.ts
+++ b/src/app/agent/identity/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest } from "next/server";
+import sql from "@/database/pgsql.js";
+import { createErrorResponse, parseJsonBody } from "@/lib/auth";
+import { createAgentRegistrationClaim, findOpenAgentRegistrationByEmail } from "@/lib/agent-registration";
+import { checkRateLimit, getClientIp } from "@/lib/rateLimiter";
+import { agentRegistrationSchema, validateBody } from "@/lib/validations/schemas";
+import { getBaseUrl } from "@/lib/public/agent-content";
+
+export async function POST(request: NextRequest) {
+  const limited = await checkRateLimit("agent-registration", getClientIp(request));
+  if (limited) return limited;
+
+  const { data, error } = await parseJsonBody(request);
+  if (error) return error;
+  const result = validateBody(agentRegistrationSchema, data);
+  if (!result.success) return result.response;
+
+  const email = result.data.login_hint.toLowerCase();
+  const [existingUser] = await sql`SELECT user_id FROM app.login WHERE LOWER(email) = ${email} LIMIT 1`;
+  if (existingUser) {
+    return createErrorResponse("This email already has an OghmaNotes account", 409);
+  }
+
+  const existingClaim = await findOpenAgentRegistrationByEmail(email);
+  if (existingClaim) {
+    return createErrorResponse("A registration claim is already pending for this email", 409);
+  }
+
+  const { claim, claimToken, userCode } = await createAgentRegistrationClaim(email);
+  const baseUrl = getBaseUrl();
+  return Response.json(
+    {
+      registration_id: claim.id,
+      registration_type: "service_auth",
+      claim_token: claimToken,
+      claim_token_expires: claim.expires_at.toISOString(),
+      claim: {
+        user_code: userCode,
+        expires_in: 900,
+        verification_uri: `${baseUrl}/register?agent_claim_token=${encodeURIComponent(claimToken)}`,
+      },
+    },
+    { status: 201 },
+  );
+}

--- a/src/app/api/auth/register/route.js
+++ b/src/app/api/auth/register/route.js
@@ -25,6 +25,7 @@ import logger from "@/lib/logger";
 import { withErrorHandler } from "@/lib/api-error";
 import { recordMarketingEvent } from "@/lib/marketing/events";
 import { registerSchema, validateBody } from "@/lib/validations/schemas";
+import { validateAgentRegistrationForSignup } from "@/lib/agent-registration";
 
 const GETTING_STARTED_TITLE = "Getting Started";
 const GETTING_STARTED_CONTENT = `# Welcome to OghmaNotes
@@ -73,7 +74,7 @@ export const POST = withErrorHandler(async (request) => {
     const zodResult = validateBody(registerSchema, body);
     if (!zodResult.success) return zodResult.response;
 
-    const { email, password } = body;
+    const { email, password, agentClaimToken, agentUserCode } = zodResult.data;
 
     // 2. Validate credentials format and password strength
     const validation = validateAuthCredentials(email, password, true);
@@ -90,6 +91,20 @@ export const POST = withErrorHandler(async (request) => {
 
     if (existingUser.length > 0) {
       return createErrorResponse("User already exists", 409);
+    }
+
+    const agentClaim = agentClaimToken
+      ? await validateAgentRegistrationForSignup(
+          agentClaimToken,
+          agentUserCode || "",
+          email,
+        )
+      : null;
+    if (agentClaimToken && !agentClaim) {
+      return createErrorResponse(
+        "Invalid, expired, or incomplete agent registration claim",
+        400,
+      );
     }
 
     // 4. Hash password
@@ -122,6 +137,14 @@ export const POST = withErrorHandler(async (request) => {
         INSERT INTO app.tree_items (user_id, note_id, parent_id)
         VALUES (${userId}::uuid, ${gettingStartedNoteId}::uuid, NULL)
       `;
+
+      if (agentClaim) {
+        await tx`
+          UPDATE app.agent_registration_claims
+          SET status = 'registered', created_user_id = ${userId}::uuid, registered_at = NOW()
+          WHERE id = ${agentClaim.id}::uuid AND status = 'pending'
+        `;
+      }
 
       return createdUser;
     });

--- a/src/app/api/auth/verify-email/route.js
+++ b/src/app/api/auth/verify-email/route.js
@@ -9,6 +9,7 @@ import { checkRateLimit, getClientIp } from "@/lib/rateLimiter";
 import logger from "@/lib/logger";
 import { assertTrustedOrigin } from "@/lib/api-error";
 import { recordActivationMilestone } from "@/lib/marketing/events";
+import { markAgentRegistrationVerified } from "@/lib/agent-registration";
 
 export async function POST(request) {
   try {
@@ -47,6 +48,8 @@ export async function POST(request) {
             SET email_verified = true, verification_token = NULL, verification_token_expires = NULL
             WHERE user_id = ${matchedUser.user_id}
         `;
+
+    await markAgentRegistrationVerified(matchedUser.user_id);
 
     // auto-login: create session for the verified user
     void recordActivationMilestone("email_verified", matchedUser.user_id, request).catch(

--- a/src/app/api/auth/verify-email/route.js
+++ b/src/app/api/auth/verify-email/route.js
@@ -9,7 +9,6 @@ import { checkRateLimit, getClientIp } from "@/lib/rateLimiter";
 import logger from "@/lib/logger";
 import { assertTrustedOrigin } from "@/lib/api-error";
 import { recordActivationMilestone } from "@/lib/marketing/events";
-import { markAgentRegistrationVerified } from "@/lib/agent-registration";
 
 export async function POST(request) {
   try {
@@ -42,14 +41,22 @@ export async function POST(request) {
       return createErrorResponse("Invalid or expired verification token", 400);
     }
 
-    // mark email as verified, clear token
-    await sql`
+    // Mark the account and any agent registration claim atomically. If either
+    // write fails, the verification token remains usable for a safe retry.
+    await sql.begin(async (tx) => {
+      await tx`
             UPDATE app.login
             SET email_verified = true, verification_token = NULL, verification_token_expires = NULL
             WHERE user_id = ${matchedUser.user_id}
-        `;
-
-    await markAgentRegistrationVerified(matchedUser.user_id);
+      `;
+      await tx`
+        UPDATE app.agent_registration_claims
+        SET status = 'verified', verified_at = NOW()
+        WHERE created_user_id = ${matchedUser.user_id}::uuid
+          AND status = 'registered'
+          AND expires_at > NOW()
+      `;
+    });
 
     // auto-login: create session for the verified user
     void recordActivationMilestone("email_verified", matchedUser.user_id, request).catch(

--- a/src/app/auth.md/route.ts
+++ b/src/app/auth.md/route.ts
@@ -1,0 +1,38 @@
+import { getBaseUrl } from "@/lib/public/agent-content";
+
+export function GET() {
+  const baseUrl = getBaseUrl();
+  const body = `# OghmaNotes auth.md
+
+OghmaNotes supports **agent-initiated registration for new users only**. An agent may start a registration claim, but the person must choose their own password and verify their email in the OghmaNotes browser flow. This release does not issue agent access tokens or grant access to notes, Canvas, chat, or any private API.
+
+## Start registration
+
+POST \`${baseUrl}/agent/identity\` with JSON:
+
+\`\`\`json
+{ "type": "service_auth", "login_hint": "student@example.com" }
+\`\`\`
+
+The email must not already belong to an OghmaNotes account. The response contains a short-lived \`claim_token\`, a six-digit \`user_code\`, and a \`verification_uri\`. Give the person the URI and code. Never ask them for a password, session cookie, email verification link, or verification token.
+
+## Claim and completion
+
+The person opens \`verification_uri\`, enters the code, chooses a password, and verifies their email. Poll \`POST ${baseUrl}/agent/identity/claim\` with \`{ "claim_token": "..." }\` to learn whether the claim is pending, registered, or verified. Poll no more than once every five seconds.
+
+## Limits
+
+- Claims expire after 15 minutes.
+- Claims are for previously unknown email addresses only.
+- Completion creates a normal OghmaNotes account and follows the normal email-verification requirement.
+- A verified claim is proof of completed registration only; it is not an API credential.
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+      "Content-Location": `${baseUrl}/auth.md`,
+    },
+  });
+}

--- a/src/app/auth.md/route.ts
+++ b/src/app/auth.md/route.ts
@@ -18,13 +18,18 @@ The email must not already belong to an OghmaNotes account. The response contain
 
 ## Claim and completion
 
-The person opens \`verification_uri\`, enters the code, chooses a password, and verifies their email. Poll \`POST ${baseUrl}/agent/identity/claim\` with \`{ "claim_token": "..." }\` to learn whether the claim is pending, registered, or verified. Poll no more than once every five seconds.
+The person opens \`verification_uri\`, enters the code, and proves ownership using one of the options shown by OghmaNotes:
+
+- Google or GitHub OAuth with a provider-verified email matching the claim; or
+- a password followed by OghmaNotes email-link verification.
+
+The agent never receives the OAuth token, password, session cookie, or email verification link. Poll \`POST ${baseUrl}/agent/identity/claim\` with \`{ "claim_token": "..." }\` to learn whether the claim is pending, registered, or verified. Poll no more than once every five seconds.
 
 ## Limits
 
 - Claims expire after 15 minutes.
 - Claims are for previously unknown email addresses only.
-- Completion creates a normal OghmaNotes account and follows the normal email-verification requirement.
+- Completion creates a normal OghmaNotes account. OAuth email ownership is accepted only from a verified provider response; password registrations require the normal email link.
 - A verified claim is proof of completed registration only; it is not an API credential.
 `;
 

--- a/src/app/register/page.js
+++ b/src/app/register/page.js
@@ -48,10 +48,37 @@ export default function RegisterPage() {
   }, []);
 
   useEffect(() => {
-    setAgentClaimToken(
-      new URLSearchParams(window.location.search).get("agent_claim_token") || "",
-    );
-  }, []);
+    const params = new URLSearchParams(window.location.search);
+    const claimToken = params.get("agent_claim_token") || "";
+    setAgentClaimToken(claimToken);
+
+    if (claimToken && params.get("agent_oauth") === "complete") {
+      const storageKey = `agent-registration-code:${claimToken}`;
+      const userCode = window.sessionStorage.getItem(storageKey) || "";
+      if (!/^\d{6}$/.test(userCode)) {
+        setErrMsg(t("Enter the six-digit agent registration code and try OAuth again."));
+        return;
+      }
+
+      setLoading(true);
+      fetch("/agent/identity/claim/complete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          claim_token: claimToken,
+          user_code: userCode,
+        }),
+      })
+        .then(async (response) => {
+          const data = await response.json();
+          if (!response.ok) throw new Error(data.error || "OAuth claim failed");
+          window.sessionStorage.removeItem(storageKey);
+          router.replace("/notes");
+        })
+        .catch((error) => setErrMsg(error.message))
+        .finally(() => setLoading(false));
+    }
+  }, [router, t]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -144,6 +171,12 @@ export default function RegisterPage() {
       return;
     }
 
+    if (agentClaimToken && !/^\d{6}$/.test(agentUserCode)) {
+      setErrMsg(t("Enter the six-digit agent registration code first."));
+      errRef.current?.focus();
+      return;
+    }
+
     trackMarketingEvent("registration_oauth_start", {
       source: "register_form",
       properties: {
@@ -153,7 +186,16 @@ export default function RegisterPage() {
         destination: "/notes",
       },
     });
-    signIn(provider, buildOAuthSignInOptions("/notes"));
+    const callbackUrl = agentClaimToken
+      ? `/register?agent_claim_token=${encodeURIComponent(agentClaimToken)}&agent_oauth=complete`
+      : "/notes";
+    if (agentClaimToken) {
+      window.sessionStorage.setItem(
+        `agent-registration-code:${agentClaimToken}`,
+        agentUserCode,
+      );
+    }
+    signIn(provider, buildOAuthSignInOptions(callbackUrl));
   };
 
   const trackFormStart = () => {
@@ -314,7 +356,7 @@ export default function RegisterPage() {
           </form>
 
           {/* Social signup section */}
-          {!agentClaimToken && <div>
+          <div>
             <div className="mt-10 flex items-center gap-x-6">
               <div className="w-full flex-1 border-t border-border-subtle" />
               <p className="text-sm/6 font-medium text-nowrap text-text-tertiary">
@@ -374,7 +416,7 @@ export default function RegisterPage() {
                 <span className="text-sm/6 font-semibold">GitHub</span>
               </button>
             </div>
-          </div>}
+          </div>
         </div>
 
         <p className="mt-8 text-center text-sm/6 text-text-tertiary">

--- a/src/app/register/page.js
+++ b/src/app/register/page.js
@@ -25,6 +25,8 @@ export default function RegisterPage() {
   const [errMsg, setErrMsg] = useState("");
   const [loading, setLoading] = useState(false);
   const [oauthProviders, setOauthProviders] = useState(null);
+  const [agentClaimToken, setAgentClaimToken] = useState("");
+  const [agentUserCode, setAgentUserCode] = useState("");
   const errRef = useRef();
   const startedRef = useRef(false);
   const router = useRouter();
@@ -43,6 +45,12 @@ export default function RegisterPage() {
     return () => {
       mounted = false;
     };
+  }, []);
+
+  useEffect(() => {
+    setAgentClaimToken(
+      new URLSearchParams(window.location.search).get("agent_claim_token") || "",
+    );
   }, []);
 
   const handleSubmit = async (e) => {
@@ -83,7 +91,14 @@ export default function RegisterPage() {
       },
     });
     try {
-      const result = await register(email, pwd, getMarketingContext());
+      const result = await register(
+        email,
+        pwd,
+        getMarketingContext(),
+        agentClaimToken
+          ? { agentClaimToken, agentUserCode }
+          : undefined,
+      );
       // Account creation is recorded once by the server as the canonical milestone.
       if (result.requiresVerification) {
         router.replace(`/verify-email?email=${encodeURIComponent(email)}`);
@@ -214,6 +229,34 @@ export default function RegisterPage() {
               </div>
             </div>
 
+            {agentClaimToken && (
+              <div>
+                <label
+                  htmlFor="agent-user-code"
+                  className="block text-sm/6 font-medium text-text"
+                >
+                  {t("Agent registration code")}
+                </label>
+                <div className="mt-2">
+                  <input
+                    id="agent-user-code"
+                    name="agent-user-code"
+                    inputMode="numeric"
+                    pattern="[0-9]{6}"
+                    required
+                    value={agentUserCode}
+                    onChange={(e) =>
+                      setAgentUserCode(e.target.value.replace(/\D/g, "").slice(0, 6))
+                    }
+                    className="block w-full rounded-radius-md bg-input border border-border-subtle px-3 py-2 text-sm text-text placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary-500/40 focus:border-primary-500/60"
+                  />
+                </div>
+                <p className="mt-1 text-xs text-text-tertiary">
+                  {t("Enter the six-digit code shown by the agent that started this registration.")}
+                </p>
+              </div>
+            )}
+
             <div>
               <label
                 htmlFor="password"
@@ -271,7 +314,7 @@ export default function RegisterPage() {
           </form>
 
           {/* Social signup section */}
-          <div>
+          {!agentClaimToken && <div>
             <div className="mt-10 flex items-center gap-x-6">
               <div className="w-full flex-1 border-t border-border-subtle" />
               <p className="text-sm/6 font-medium text-nowrap text-text-tertiary">
@@ -331,7 +374,7 @@ export default function RegisterPage() {
                 <span className="text-sm/6 font-semibold">GitHub</span>
               </button>
             </div>
-          </div>
+          </div>}
         </div>
 
         <p className="mt-8 text-center text-sm/6 text-text-tertiary">

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -6,7 +6,10 @@ import type { Session, User, NextAuthConfig } from "next-auth";
 import type { JWT } from "next-auth/jwt";
 import sql from "@/database/pgsql";
 import logger from "@/lib/logger";
-import { findOrCreateOAuthUser } from "@/lib/auth-oauth";
+import {
+  findOrCreateOAuthUser,
+  resolveVerifiedOAuthEmail,
+} from "@/lib/auth-oauth";
 import type { OAuthProfile } from "@/lib/auth-oauth";
 
 const providers: NextAuthConfig["providers"] = [];
@@ -56,6 +59,7 @@ if (process.env.GITHUB_ID && process.env.GITHUB_SECRET) {
     GitHub({
       clientId: process.env.GITHUB_ID,
       clientSecret: process.env.GITHUB_SECRET,
+      authorization: { params: { scope: "read:user user:email" } },
     }),
   );
 }
@@ -136,23 +140,38 @@ export const authConfig: NextAuthConfig = {
       if (!account || account.provider === "credentials") return true;
 
       try {
+        const rawProfile = profile ? { ...profile } : {};
+        const verifiedEmail = await resolveVerifiedOAuthEmail(
+          account.provider,
+          rawProfile,
+          account.access_token,
+        );
+        if (!verifiedEmail) {
+          logger.warn("oauth provider did not return a verified email", {
+            provider: account.provider,
+          });
+          return false;
+        }
+        rawProfile.email_verified = true;
+
         const oauthProfile: OAuthProfile = {
           provider: account.provider,
           providerAccountId: account.providerAccountId,
-          email: user.email ?? profile?.email,
+          email: verifiedEmail,
           name: user.name ?? profile?.name,
           image: user.image ?? profile?.picture ?? profile?.avatar_url,
           locale:
             (profile as { locale?: string | null } | undefined)?.locale ?? null,
-          rawProfile: profile ? { ...profile } : {},
+          rawProfile,
         };
 
         const userId = await findOrCreateOAuthUser(
           oauthProfile,
-          profile ? { ...profile } : {},
+          rawProfile,
         );
         // attach user_id so jwt callback can pick it up
         (user as User & { id: string }).id = userId;
+        user.email = verifiedEmail;
         return true;
       } catch (error) {
         logger.error("oauth sign-in failed", {

--- a/src/lib/agent-registration.ts
+++ b/src/lib/agent-registration.ts
@@ -10,6 +10,7 @@ export type AgentRegistrationClaim = {
   status: "pending" | "registered" | "verified";
   expires_at: Date;
   created_user_id: string | null;
+  created_at: Date;
 };
 
 export function generateUserCode(): string {
@@ -18,7 +19,7 @@ export function generateUserCode(): string {
 
 export async function findOpenAgentRegistrationByEmail(email: string) {
   const [claim] = await sql<AgentRegistrationClaim[]>`
-    SELECT id, email, status, expires_at, created_user_id
+    SELECT id, email, status, expires_at, created_user_id, created_at
     FROM app.agent_registration_claims
     WHERE LOWER(email) = LOWER(${email})
       AND status IN ('pending', 'registered')
@@ -38,14 +39,14 @@ export async function createAgentRegistrationClaim(email: string) {
     ) VALUES (
       ${email}, ${hashToken(claimToken)}, ${hashToken(userCode)}, ${expiresAt}
     )
-    RETURNING id, email, status, expires_at, created_user_id
+    RETURNING id, email, status, expires_at, created_user_id, created_at
   `;
   return { claim, claimToken, userCode };
 }
 
 export async function findAgentRegistrationClaim(claimToken: string) {
   const [claim] = await sql<AgentRegistrationClaim[]>`
-    SELECT id, email, status, expires_at, created_user_id
+    SELECT id, email, status, expires_at, created_user_id, created_at
     FROM app.agent_registration_claims
     WHERE claim_token_hash = ${hashToken(claimToken)}
     LIMIT 1
@@ -59,7 +60,7 @@ export async function validateAgentRegistrationForSignup(
   email: string,
 ) {
   const [claim] = await sql<AgentRegistrationClaim[]>`
-    SELECT id, email, status, expires_at, created_user_id
+    SELECT id, email, status, expires_at, created_user_id, created_at
     FROM app.agent_registration_claims
     WHERE claim_token_hash = ${hashToken(claimToken)}
       AND user_code_hash = ${hashToken(userCode)}
@@ -71,23 +72,35 @@ export async function validateAgentRegistrationForSignup(
   return claim ?? null;
 }
 
-export async function markAgentRegistrationRegistered(
-  claimId: string,
+export async function completeOAuthAgentRegistration(
+  claimToken: string,
+  userCode: string,
   userId: string,
+  email: string,
 ) {
-  await sql`
-    UPDATE app.agent_registration_claims
-    SET status = 'registered', created_user_id = ${userId}::uuid, registered_at = NOW()
-    WHERE id = ${claimId}::uuid AND status = 'pending'
+  const [claim] = await sql<AgentRegistrationClaim[]>`
+    UPDATE app.agent_registration_claims AS claim
+    SET status = 'verified',
+        created_user_id = ${userId}::uuid,
+        registered_at = NOW(),
+        verified_at = NOW()
+    WHERE claim.claim_token_hash = ${hashToken(claimToken)}
+      AND claim.user_code_hash = ${hashToken(userCode)}
+      AND claim.status = 'pending'
+      AND claim.expires_at > NOW()
+      AND LOWER(claim.email) = LOWER(${email})
+      AND EXISTS (
+        SELECT 1
+        FROM app.login AS login
+        JOIN app.oauth_accounts AS oauth ON oauth.user_id = login.user_id
+        WHERE login.user_id = ${userId}::uuid
+          AND login.email_verified = true
+          AND login.created_at >= claim.created_at
+          AND LOWER(login.email) = LOWER(claim.email)
+          AND LOWER(oauth.email) = LOWER(claim.email)
+      )
+    RETURNING claim.id, claim.email, claim.status, claim.expires_at,
+              claim.created_user_id, claim.created_at
   `;
-}
-
-export async function markAgentRegistrationVerified(userId: string) {
-  await sql`
-    UPDATE app.agent_registration_claims
-    SET status = 'verified', verified_at = NOW()
-    WHERE created_user_id = ${userId}::uuid
-      AND status = 'registered'
-      AND expires_at > NOW()
-  `;
+  return claim ?? null;
 }

--- a/src/lib/agent-registration.ts
+++ b/src/lib/agent-registration.ts
@@ -1,0 +1,93 @@
+import crypto from "crypto";
+import sql from "@/database/pgsql.js";
+import { generateSecureToken, hashToken } from "@/lib/tokens";
+
+export const AGENT_REGISTRATION_CLAIM_TTL_MS = 15 * 60 * 1000;
+
+export type AgentRegistrationClaim = {
+  id: string;
+  email: string;
+  status: "pending" | "registered" | "verified";
+  expires_at: Date;
+  created_user_id: string | null;
+};
+
+export function generateUserCode(): string {
+  return crypto.randomInt(0, 1_000_000).toString().padStart(6, "0");
+}
+
+export async function findOpenAgentRegistrationByEmail(email: string) {
+  const [claim] = await sql<AgentRegistrationClaim[]>`
+    SELECT id, email, status, expires_at, created_user_id
+    FROM app.agent_registration_claims
+    WHERE LOWER(email) = LOWER(${email})
+      AND status IN ('pending', 'registered')
+      AND expires_at > NOW()
+    LIMIT 1
+  `;
+  return claim ?? null;
+}
+
+export async function createAgentRegistrationClaim(email: string) {
+  const claimToken = generateSecureToken();
+  const userCode = generateUserCode();
+  const expiresAt = new Date(Date.now() + AGENT_REGISTRATION_CLAIM_TTL_MS);
+  const [claim] = await sql<AgentRegistrationClaim[]>`
+    INSERT INTO app.agent_registration_claims (
+      email, claim_token_hash, user_code_hash, expires_at
+    ) VALUES (
+      ${email}, ${hashToken(claimToken)}, ${hashToken(userCode)}, ${expiresAt}
+    )
+    RETURNING id, email, status, expires_at, created_user_id
+  `;
+  return { claim, claimToken, userCode };
+}
+
+export async function findAgentRegistrationClaim(claimToken: string) {
+  const [claim] = await sql<AgentRegistrationClaim[]>`
+    SELECT id, email, status, expires_at, created_user_id
+    FROM app.agent_registration_claims
+    WHERE claim_token_hash = ${hashToken(claimToken)}
+    LIMIT 1
+  `;
+  return claim ?? null;
+}
+
+export async function validateAgentRegistrationForSignup(
+  claimToken: string,
+  userCode: string,
+  email: string,
+) {
+  const [claim] = await sql<AgentRegistrationClaim[]>`
+    SELECT id, email, status, expires_at, created_user_id
+    FROM app.agent_registration_claims
+    WHERE claim_token_hash = ${hashToken(claimToken)}
+      AND user_code_hash = ${hashToken(userCode)}
+      AND status = 'pending'
+      AND expires_at > NOW()
+      AND LOWER(email) = LOWER(${email})
+    LIMIT 1
+  `;
+  return claim ?? null;
+}
+
+export async function markAgentRegistrationRegistered(
+  claimId: string,
+  userId: string,
+) {
+  await sql`
+    UPDATE app.agent_registration_claims
+    SET status = 'registered', created_user_id = ${userId}::uuid, registered_at = NOW()
+    WHERE id = ${claimId}::uuid AND status = 'pending'
+  `;
+}
+
+export async function markAgentRegistrationVerified(userId: string) {
+  await sql`
+    UPDATE app.agent_registration_claims
+    SET status = 'verified', verified_at = NOW()
+    WHERE created_user_id = ${userId}::uuid
+      AND status = 'registered'
+      AND expires_at > NOW()
+  `;
+}

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -109,8 +109,18 @@ export async function login(email, password, rememberMe = false) {
   return apiPost("/api/auth/login", { email, password, rememberMe });
 }
 
-export async function register(email, password, marketing = undefined) {
-  return apiPost("/api/auth/register", { email, password, marketing });
+export async function register(
+  email,
+  password,
+  marketing = undefined,
+  agentRegistration = undefined,
+) {
+  return apiPost("/api/auth/register", {
+    email,
+    password,
+    marketing,
+    ...(agentRegistration || {}),
+  });
 }
 
 export async function logout() {

--- a/src/lib/auth-oauth.ts
+++ b/src/lib/auth-oauth.ts
@@ -3,9 +3,6 @@ import bcrypt from "bcryptjs";
 import crypto from "crypto";
 import logger from "@/lib/logger";
 
-// providers that always return verified emails
-const ALWAYS_VERIFIED_PROVIDERS = new Set(["google"]);
-
 export interface OAuthProfile {
   provider: string;
   providerAccountId: string;
@@ -35,8 +32,49 @@ export function isEmailVerifiedByProvider(
   provider: string,
   profile: Record<string, unknown>,
 ): boolean {
-  if (ALWAYS_VERIFIED_PROVIDERS.has(provider)) return true;
   return profile.email_verified === true;
+}
+
+export async function resolveVerifiedOAuthEmail(
+  provider: string,
+  profile: Record<string, unknown>,
+  accessToken?: string | null,
+): Promise<string | null> {
+  if (
+    provider === "google" &&
+    profile.email_verified === true &&
+    typeof profile.email === "string"
+  ) {
+    return profile.email.toLowerCase();
+  }
+
+  if (provider === "github" && accessToken) {
+    const response = await fetch("https://api.github.com/user/emails", {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${accessToken}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!response.ok) return null;
+
+    const emails = (await response.json()) as Array<{
+      email?: unknown;
+      primary?: unknown;
+      verified?: unknown;
+    }>;
+    const verifiedPrimary = emails.find(
+      (entry) =>
+        entry.primary === true &&
+        entry.verified === true &&
+        typeof entry.email === "string",
+    );
+    return typeof verifiedPrimary?.email === "string"
+      ? verifiedPrimary.email.toLowerCase()
+      : null;
+  }
+
+  return null;
 }
 
 /**
@@ -129,6 +167,14 @@ export async function findOrCreateOAuthUser(
   profile: OAuthProfile,
   providerProfile: Record<string, unknown>,
 ): Promise<string> {
+  const emailVerified = isEmailVerifiedByProvider(
+    profile.provider,
+    providerProfile,
+  );
+  if (!emailVerified || !profile.email) {
+    throw new Error("OAuth provider did not supply a verified email");
+  }
+
   // step 1: existing oauth account?
   const existing = await findOAuthAccount(
     profile.provider,
@@ -142,14 +188,16 @@ export async function findOrCreateOAuthUser(
       image: profile.image,
       locale: profile.locale,
     });
+    if (isEmailVerifiedByProvider(profile.provider, providerProfile)) {
+      await (sql as any)`
+        UPDATE app.login SET email_verified = true
+        WHERE user_id = ${existing.user_id}::uuid
+      `;
+    }
     return existing.user_id;
   }
 
   // step 2: auto-link by email (only if verified)
-  const emailVerified = isEmailVerifiedByProvider(
-    profile.provider,
-    providerProfile,
-  );
   if (emailVerified && profile.email) {
     const loginRows = await (sql as any)`
             SELECT user_id FROM app.login
@@ -165,6 +213,10 @@ export async function findOrCreateOAuthUser(
         image: profile.image,
         locale: profile.locale,
       });
+      await (sql as any)`
+        UPDATE app.login SET email_verified = true
+        WHERE user_id = ${userId}::uuid
+      `;
       logger.info("oauth account linked to existing user", {
         provider: profile.provider,
         userId,
@@ -180,13 +232,14 @@ export async function findOrCreateOAuthUser(
 
   // ON CONFLICT handles race condition: if another request just created the same email
   const insertResult = await (sql as any)`
-        INSERT INTO app.login (email, hashed_password, display_name, avatar_url, locale)
+        INSERT INTO app.login (email, hashed_password, display_name, avatar_url, locale, email_verified)
         VALUES (
             ${profile.email},
             ${hashedPassword},
             ${profile.name ?? null},
             ${profile.image ?? null},
-            ${profile.locale ?? null}
+            ${profile.locale ?? null},
+            ${emailVerified}
         )
         ON CONFLICT (email) DO NOTHING
         RETURNING user_id

--- a/src/lib/public/agent-content.js
+++ b/src/lib/public/agent-content.js
@@ -44,7 +44,7 @@ export const agentActions = [
     method: "POST",
     path: "/agent/identity",
     summary:
-      "Starts a 15-minute auth.md registration claim for an email that does not yet have an account. The person must complete password creation and email verification in the browser. No private API access is granted.",
+      "Starts a 15-minute auth.md registration claim for an email that does not yet have an account. The person completes matching verified Google/GitHub OAuth or password plus email-link verification in the browser. No private API access is granted.",
   },
   {
     name: "Create account",
@@ -1131,6 +1131,34 @@ export function buildAgentOpenApiJson(baseUrl = getBaseUrl()) {
           responses: {
             "200": { description: "Current claim status" },
             "400": { description: "Invalid or expired claim" },
+            "429": { description: "Rate limited" },
+          },
+        },
+      },
+      "/agent/identity/claim/complete": {
+        post: {
+          summary: "Complete an agent registration claim with OAuth",
+          description:
+            "Requires an Auth.js browser session whose provider-verified email matches the new-user claim. It never returns an API credential.",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["claim_token", "user_code"],
+                  properties: {
+                    claim_token: { type: "string", minLength: 64, maxLength: 64 },
+                    user_code: { type: "string", pattern: "^[0-9]{6}$" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Registration verified" },
+            "400": { description: "Mismatched or expired claim" },
+            "401": { description: "OAuth browser session required" },
             "429": { description: "Rate limited" },
           },
         },

--- a/src/lib/public/agent-content.js
+++ b/src/lib/public/agent-content.js
@@ -27,6 +27,7 @@ export const AGENT_RESOURCE_PATHS = [
   "/openapi.json",
   "/faq.md",
   "/pricing.md",
+  "/auth.md",
   "/agent-sitemap.xml",
 ];
 
@@ -38,6 +39,13 @@ export const agentFacts = [
 ];
 
 export const agentActions = [
+  {
+    name: "Start new-user registration",
+    method: "POST",
+    path: "/agent/identity",
+    summary:
+      "Starts a 15-minute auth.md registration claim for an email that does not yet have an account. The person must complete password creation and email verification in the browser. No private API access is granted.",
+  },
   {
     name: "Create account",
     method: "POST",
@@ -128,6 +136,11 @@ export const agentResourceComparison = [
     path: "/pricing.md",
     format: "text/markdown",
     purpose: "Pricing-only Markdown page for plan and launch-pricing questions.",
+  },
+  {
+    path: "/auth.md",
+    format: "text/markdown",
+    purpose: "Agent registration instructions for new OghmaNotes users. It does not grant agent access to private APIs.",
   },
 ];
 
@@ -733,6 +746,7 @@ const HTTP_METHODS = new Set([
 
 const SENSITIVE_OPERATIONS = new Set([
   "post /api/auth/register",
+  "post /agent/identity",
   "post /api/notes",
   "patch /api/notes/{id}",
   "delete /api/notes/{id}",
@@ -768,6 +782,7 @@ const PRIVATE_DATA_OPERATIONS = new Set([
 ]);
 
 const TAG_BY_PREFIX = [
+  ["/agent/identity", "Auth"],
   ["/api/auth", "Auth"],
   ["/api/notes", "Notes"],
   ["/api/search", "Search"],
@@ -1052,6 +1067,71 @@ export function buildAgentOpenApiJson(baseUrl = getBaseUrl()) {
                 "text/markdown": { schema: { type: "string" } },
               },
             },
+          },
+        },
+      },
+      "/auth.md": {
+        get: {
+          summary: "auth.md new-user registration instructions",
+          description:
+            "Agent registration instructions. This v1 flow never issues an API credential or private-data access.",
+          responses: {
+            "200": {
+              description: "auth.md instructions",
+              content: { "text/markdown": { schema: { type: "string" } } },
+            },
+          },
+        },
+      },
+      "/agent/identity": {
+        post: {
+          summary: "Start an agent-initiated new-user registration",
+          description:
+            "Creates a 15-minute claim for an email that does not already have an OghmaNotes account. The user must complete password creation and email verification in the browser. No access token is issued.",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["type", "login_hint"],
+                  properties: {
+                    type: { type: "string", enum: ["service_auth"] },
+                    login_hint: { type: "string", format: "email", maxLength: 255 },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "201": { description: "Claim URI and user code returned" },
+            "400": { description: "Invalid registration request" },
+            "409": { description: "Existing account or pending claim" },
+            "429": { description: "Rate limited" },
+          },
+        },
+      },
+      "/agent/identity/claim": {
+        post: {
+          summary: "Poll an agent registration claim",
+          description:
+            "Reports pending, registered, or verified status. It never returns an API credential.",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["claim_token"],
+                  properties: { claim_token: { type: "string", minLength: 64, maxLength: 64 } },
+                },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Current claim status" },
+            "400": { description: "Invalid or expired claim" },
+            "429": { description: "Rate limited" },
           },
         },
       },

--- a/src/lib/rateLimitConfig.ts
+++ b/src/lib/rateLimitConfig.ts
@@ -25,6 +25,8 @@ export const RATE_LIMITS: Record<string, RateLimitRule> = {
   'password-verify':{ limit: 10,  windowSeconds: 3600,  keyType: 'ip',    failClosedOnStoreError: true },
   'resend-verification': { limit: 3,  windowSeconds: 3600, keyType: 'email', failClosedOnStoreError: true },
   'verify-email':   { limit: 10,  windowSeconds: 3600,  keyType: 'ip',    failClosedOnStoreError: true },
+  'agent-registration': { limit: 3, windowSeconds: 3600, keyType: 'ip', failClosedOnStoreError: true },
+  'agent-registration-claim': { limit: 60, windowSeconds: 3600, keyType: 'ip', failClosedOnStoreError: true },
 
   // tier 3 — resource protection
   'upload':         { limit: 30,  windowSeconds: 3600,  keyType: 'userId' },

--- a/src/lib/validations/schemas.ts
+++ b/src/lib/validations/schemas.ts
@@ -56,6 +56,11 @@ export const agentRegistrationClaimSchema = z.object({
   claim_token: z.string().length(64),
 });
 
+export const agentRegistrationCompleteSchema = z.object({
+  claim_token: z.string().length(64),
+  user_code: z.string().regex(/^\d{6}$/),
+});
+
 export const quizSessionCreateSchema = z.object({
   filterType: z.enum([
     "course",

--- a/src/lib/validations/schemas.ts
+++ b/src/lib/validations/schemas.ts
@@ -40,6 +40,20 @@ export const loginSchema = z.object({
 export const registerSchema = z.object({
   email: z.string().email().max(255).trim(),
   password: z.string().min(8).max(128),
+  agentClaimToken: z.string().length(64).optional(),
+  agentUserCode: z.string().regex(/^\d{6}$/).optional(),
+}).refine(
+  (data) => Boolean(data.agentClaimToken) === Boolean(data.agentUserCode),
+  { message: "Agent registration claims require both a token and a six-digit code" },
+);
+
+export const agentRegistrationSchema = z.object({
+  type: z.literal("service_auth"),
+  login_hint: z.string().email().max(255).trim(),
+});
+
+export const agentRegistrationClaimSchema = z.object({
+  claim_token: z.string().length(64),
 });
 
 export const quizSessionCreateSchema = z.object({

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -59,9 +59,12 @@ export async function proxy(request: NextRequest) {
     const nextAuthSession = request.cookies.get("authjs.session-token")?.value
         || request.cookies.get("__Secure-authjs.session-token")?.value;
     const isAuthenticated = !!(session || nextAuthSession);
+    const isAgentRegistration =
+        pathname === "/register" &&
+        request.nextUrl.searchParams.has("agent_claim_token");
 
     // redirect authenticated users away from login/register (skip the page load)
-    if (isAuthenticated && (pathname === "/login" || pathname === "/register")) {
+    if (isAuthenticated && !isAgentRegistration && (pathname === "/login" || pathname === "/register")) {
         const response = NextResponse.redirect(new URL("/notes", request.url));
         Object.entries(corsHeaders).forEach(([key, value]) => response.headers.set(key, value));
         return response;


### PR DESCRIPTION
## What changed

Adds an isolated `auth.md` v1 flow for agent-initiated registration of previously unknown OghmaNotes users.

- Publishes `auth.md` and protected-resource/authorization-server discovery metadata.
- Adds short-lived, hashed registration claims with an agent-provided six-digit code.
- Lets the user prove ownership with verified Google/GitHub OAuth or password plus OghmaNotes email-link verification.
- Requires GitHub's authenticated primary verified email and Google's signed `email_verified` claim.
- Commits email verification and agent-claim completion atomically so failed claim tracking cannot consume a verification link.
- Lets agents poll registration state, but deliberately issues no API credential or private-data access.

## Why

Agents can begin account registration without collecting a user's password, OAuth token, or browser session. The user retains account ownership and explicitly completes identity proof in the normal OghmaNotes browser surface.

## Safety boundaries

- New email addresses only; OAuth completion rejects accounts created before the claim.
- The provider-verified OAuth email must match the claimed email.
- Claims expire after 15 minutes and are rate limited.
- No bearer token, note access, Canvas access, chat access, or internal MCP access is introduced.

## Validation

- `npm run typecheck`
- Focused auth.md, OAuth, proxy, and atomic email-verification tests
- `npm run test:ci` — 103 files / 744 tests passed
- `npm run build`
- Pre-commit lint, i18n audit, typecheck, and full test suite passed
