### PR TITLE
Add persistent focus timer control

### DIFF
--- a/src/__tests__/components/navigation/primary-navigation.test.ts
+++ b/src/__tests__/components/navigation/primary-navigation.test.ts
@@ -11,6 +11,8 @@ const mocks = vi.hoisted(() => {
     openRightPanelTab: vi.fn(),
     globalSearchOpen: vi.fn(),
     pathname: "/notes",
+    pomodoroStart: vi.fn(),
+    pomodoroPhase: "idle",
   };
 });
 
@@ -47,12 +49,19 @@ vi.mock("@/lib/global-search/state", () => ({
   },
 }));
 
+vi.mock("@/lib/notes/state/pomodoro.zustand", () => ({
+  __esModule: true,
+  default: (selector: (value: unknown) => unknown) =>
+    selector({ phase: mocks.pomodoroPhase, start: mocks.pomodoroStart }),
+}));
+
 import PrimaryNavigation from "@/components/navigation/primary-navigation";
 
 describe("PrimaryNavigation AI chat entry", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.pathname = "/notes";
+    mocks.pomodoroPhase = "idle";
   });
 
   it("opens a fresh full-screen chat from the navigation rail", async () => {
@@ -97,5 +106,46 @@ describe("PrimaryNavigation AI chat entry", () => {
     expect(onNavigate).toHaveBeenCalledTimes(1);
     expect(mocks.globalSearchOpen).toHaveBeenCalledTimes(1);
     expect(screen.getByText("Calendar")).toBeTruthy();
+  });
+
+  it("starts a generic focus session from the navigation rail", () => {
+    render(React.createElement(PrimaryNavigation));
+
+    fireEvent.click(screen.getByRole("button", { name: "Focus" }));
+
+    expect(mocks.pomodoroStart).toHaveBeenCalledTimes(1);
+    expect(mocks.pomodoroStart).toHaveBeenCalledWith({});
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  it("disables the focus button while a session is running", () => {
+    mocks.pomodoroPhase = "focus";
+    render(React.createElement(PrimaryNavigation));
+
+    const button = screen.getByRole("button", {
+      name: "Focus",
+    }) as HTMLButtonElement;
+
+    expect(button.disabled).toBe(true);
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+    expect(button.getAttribute("title")).toBe("Focus session in progress");
+
+    fireEvent.click(button);
+    expect(mocks.pomodoroStart).not.toHaveBeenCalled();
+  });
+
+  it("starts a focus session from the drawer and closes it", () => {
+    const onNavigate = vi.fn();
+    render(
+      React.createElement(PrimaryNavigation, {
+        variant: "drawer",
+        onNavigate,
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Focus" }));
+
+    expect(mocks.pomodoroStart).toHaveBeenCalledWith({});
+    expect(onNavigate).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/navigation/primary-navigation.tsx
+++ b/src/components/navigation/primary-navigation.tsx
@@ -6,6 +6,7 @@ import { useRouter, usePathname } from "next/navigation";
 import useLayoutStore from "@/lib/notes/state/layout.zustand";
 import useI18n from "@/lib/notes/hooks/use-i18n";
 import useGlobalSearchStore from "@/lib/global-search/state";
+import usePomodoroStore from "@/lib/notes/state/pomodoro.zustand";
 import {
   DocumentTextIcon,
   MagnifyingGlassIcon,
@@ -13,6 +14,7 @@ import {
   SparklesIcon,
   Cog6ToothIcon,
   AcademicCapIcon,
+  ClockIcon,
 } from "@heroicons/react/24/outline";
 
 interface NavItem {
@@ -85,6 +87,18 @@ const PrimaryNavigation: FC<PrimaryNavigationProps> = ({
   const rightPanelOpen = useLayoutStore((state) => state.rightPanelOpen);
   const rightPanelTab = useLayoutStore((state) => state.rightPanelTab);
   const { t } = useI18n();
+  const pomodoroPhase = usePomodoroStore((state) => state.phase);
+  const startPomodoro = usePomodoroStore((state) => state.start);
+
+  const focusActive = pomodoroPhase !== "idle";
+  const focusLabel = t("Focus");
+  const focusTitle = focusActive ? t("Focus session in progress") : focusLabel;
+
+  const handleFocusClick = () => {
+    if (focusActive) return;
+    onNavigate?.();
+    void startPomodoro({});
+  };
 
   const derivedActiveSection: NavItem["section"] = pathname?.startsWith(
     "/settings",
@@ -162,6 +176,23 @@ const PrimaryNavigation: FC<PrimaryNavigationProps> = ({
               </button>
             );
           })}
+
+          <button
+            type="button"
+            onClick={handleFocusClick}
+            disabled={focusActive}
+            aria-label={focusLabel}
+            aria-pressed={focusActive}
+            className={`flex min-h-11 w-full items-center gap-3 rounded-radius-md px-3 text-sm font-medium transition-colors ${
+              focusActive
+                ? "bg-primary-500/10 text-primary-400"
+                : "text-text-tertiary hover:bg-subtle hover:text-text-secondary"
+            }`}
+            title={focusTitle}
+          >
+            <ClockIcon className="h-5 w-5 shrink-0" />
+            <span>{focusLabel}</span>
+          </button>
         </div>
 
         <div className="mt-auto border-t border-border-subtle pt-3">
@@ -231,6 +262,30 @@ const PrimaryNavigation: FC<PrimaryNavigationProps> = ({
             </button>
           );
         })}
+
+        <button
+          type="button"
+          onClick={handleFocusClick}
+          disabled={focusActive}
+          aria-label={focusLabel}
+          aria-pressed={focusActive}
+          aria-describedby="tooltip-focus"
+          className={`group relative flex h-10 min-h-[44px] w-10 min-w-[44px] items-center justify-center rounded-radius-md transition-colors ${
+            focusActive
+              ? "bg-primary-500/10 text-primary-400"
+              : "text-text-tertiary hover:bg-subtle hover:text-text"
+          }`}
+          title={focusTitle}
+        >
+          <ClockIcon className="h-5 w-5" />
+          <div
+            id="tooltip-focus"
+            role="tooltip"
+            className="pointer-events-none absolute left-full z-50 ml-2 whitespace-nowrap rounded-radius-md border border-border-subtle bg-surface px-2 py-1 text-xs text-text-secondary opacity-0 transition-opacity group-hover:opacity-100"
+          >
+            {focusTitle}
+          </div>
+        </button>
       </div>
 
       <div className="my-2 h-px w-8 bg-border" />


### PR DESCRIPTION
## What changed

- add a persistent **Focus** action to the desktop navigation rail and mobile drawer
- start a generic 25-minute Pomodoro session using the existing timer store
- show and disable the action while a focus session is already active
- add focused component coverage for idle, active, rail, and drawer behavior

## Why

The Pomodoro timer was only discoverable through unlabeled play icons on assignment cards and disappeared entirely while idle. This gives it a clear, always-available entry point without adding a new page or configuration flow.

## User impact

Users can start a task-independent focus session directly from the main navigation. Assignment-linked focus sessions continue to work as before.

## Validation

- `npm run test:ci -- src/__tests__/components/navigation/primary-navigation.test.ts`
- `npm run lint -- src/components/navigation/primary-navigation.tsx src/__tests__/components/navigation/primary-navigation.test.ts`
- `npm run typecheck`
- `git diff --check`