### PR TITLE
draft: tests — align E2E reset cache schema

### DIFF
--- a/scripts/e2e/reset-db.mjs
+++ b/scripts/e2e/reset-db.mjs
@@ -4,6 +4,7 @@ import bcrypt from "bcryptjs";
 import IORedis from "ioredis";
 import postgres from "postgres";
 import { randomUUID } from "crypto";
+import { readFile } from "fs/promises";
 import { MIGRATION_SQL } from "../standalone-migration.mjs";
 import { loadE2EEnvFiles } from "./lib/env.mjs";
 
@@ -532,6 +533,12 @@ async function main() {
     await sql.unsafe("DROP SCHEMA IF EXISTS app CASCADE; CREATE SCHEMA app;");
     await sql.unsafe(MIGRATION_SQL);
     await applyCurrentSchemaPatch(sql);
+    await sql.unsafe(
+      await readFile(
+        new URL("../../database/migrations/045_imported_file_cache.sql", import.meta.url),
+        "utf8",
+      ),
+    );
     await resetQdrant();
     await seedUser(sql);
     await flushRedis();


### PR DESCRIPTION
## repo-agent validation

- **Lane:** tests
- **Goal:** keep the disposable E2E reset schema aligned with migration 045 so the schema contract sees the imported-file cache tables.
- **Base branch:** `dev`
- **Source:** failing PR #364 smoke check (`schema-contract.test.ts`: expected 14 tables, received 10)
- **Risk:** low — E2E reset path only; production migration/deploy paths unchanged.
- **Changed files:** `scripts/e2e/reset-db.mjs`
- **Checks run:** `node --check scripts/e2e/reset-db.mjs`; `npm run e2e:reset`; focused `npm run test:integration -- tests/integration/db/schema-contract.test.ts`; pre-commit `lint:all` (129 files / 855 tests passed).
- **Test result:** passed. The reset completes against disposable `oghma_e2e`; schema contract passes 3/3.
- **Opus verdict:** `PASS_OPEN_PR`
- **Known limitations:** later migrations needed by browser/integration flows must be deliberately added to this reset path; this change does not make it a generic migration runner.

**Status:** awaiting maintainer review/merge.
