### PR TITLE
fix(e2e): apply chat schema migrations during reset

### DIFF
--- a/scripts/e2e/reset-db.mjs
+++ b/scripts/e2e/reset-db.mjs
@@ -262,7 +262,10 @@ async function applyCurrentSchemaPatch(sql) {
 }
 
 function qdrantUrl() {
-  return (process.env.QDRANT_URL || "http://127.0.0.1:56333").replace(/\/+$/, "");
+  return (process.env.QDRANT_URL || "http://127.0.0.1:56333").replace(
+    /\/+$/,
+    "",
+  );
 }
 
 function qdrantHeaders() {
@@ -280,7 +283,9 @@ async function qdrantFetch(path, init = {}) {
   });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(`Qdrant ${init.method || "GET"} ${path} failed: ${res.status} ${body}`);
+    throw new Error(
+      `Qdrant ${init.method || "GET"} ${path} failed: ${res.status} ${body}`,
+    );
   }
   if (res.status === 204) return undefined;
   return await res.json();
@@ -380,15 +385,17 @@ async function seedUser(sql) {
   await qdrantFetch(`/collections/${qdrantCollection}/points?wait=true`, {
     method: "PUT",
     body: JSON.stringify({
-      points: [{
-        id: chunkId,
-        vector: vector4096,
-        payload: {
-          chunk_id: chunkId,
-          document_id: noteId,
-          user_id: seedUserId,
+      points: [
+        {
+          id: chunkId,
+          vector: vector4096,
+          payload: {
+            chunk_id: chunkId,
+            document_id: noteId,
+            user_id: seedUserId,
+          },
         },
-      }],
+      ],
     }),
   });
 
@@ -525,7 +532,9 @@ async function main() {
   assertSafeDatabaseUrl(databaseUrl);
 
   const sql = postgres(databaseUrl, {
-    ssl: databaseUrl.includes("sslmode=require") ? { rejectUnauthorized: false } : false,
+    ssl: databaseUrl.includes("sslmode=require")
+      ? { rejectUnauthorized: false }
+      : false,
     max: 1,
   });
 
@@ -533,16 +542,25 @@ async function main() {
     await sql.unsafe("DROP SCHEMA IF EXISTS app CASCADE; CREATE SCHEMA app;");
     await sql.unsafe(MIGRATION_SQL);
     await applyCurrentSchemaPatch(sql);
-    await sql.unsafe(
-      await readFile(
-        new URL("../../database/migrations/045_imported_file_cache.sql", import.meta.url),
-        "utf8",
-      ),
-    );
+    for (const migration of [
+      "041_chat_generation_status.sql",
+      "042_resumable_chat_generations.sql",
+      "043_chat_session_pinning.sql",
+      "045_imported_file_cache.sql",
+    ]) {
+      await sql.unsafe(
+        await readFile(
+          new URL(`../../database/migrations/${migration}`, import.meta.url),
+          "utf8",
+        ),
+      );
+    }
     await resetQdrant();
     await seedUser(sql);
     await flushRedis();
-    console.log(`[e2e] reset complete for ${new URL(databaseUrl).pathname.slice(1)}`);
+    console.log(
+      `[e2e] reset complete for ${new URL(databaseUrl).pathname.slice(1)}`,
+    );
   } finally {
     await sql.end();
   }

--- a/tests/integration/db/schema-contract.test.ts
+++ b/tests/integration/db/schema-contract.test.ts
@@ -30,6 +30,7 @@ describe("E2E database schema contract", () => {
           "rate_limit_log",
           "chat_sessions",
           "chat_messages",
+          "chat_generations",
           "imported_file_cache",
           "imported_file_cache_chunks",
           "imported_file_cache_assets",
@@ -40,6 +41,7 @@ describe("E2E database schema contract", () => {
     expect(rows.map((row) => row.table_name).sort()).toEqual([
       "attachments",
       "canvas_import_jobs",
+      "chat_generations",
       "chat_messages",
       "chat_sessions",
       "imported_file_cache",
@@ -63,7 +65,7 @@ describe("E2E database schema contract", () => {
     expect(row.embeddings_table).toBeNull();
   });
 
-  it("matches runtime column names and types for calendar and ingestion", async () => {
+  it("matches runtime column names and types for calendar, ingestion, and chat", async () => {
     const rows = await sql`
       SELECT table_name, column_name, data_type, udt_name
       FROM information_schema.columns
@@ -77,12 +79,30 @@ describe("E2E database schema contract", () => {
             "created_at",
             "updated_at",
           ]}))
+ OR (table_name = 'chat_sessions' AND column_name = ANY(${[
+   "generation_status",
+   "pinned",
+ ]}))
+ OR (table_name = 'chat_generations' AND column_name = ANY(${[
+   "session_id",
+   "status",
+ ]}))
         )
     `;
 
-    const byColumn = new Map(rows.map((row) => [`${row.table_name}.${row.column_name}`, row]));
+    const byColumn = new Map(
+      rows.map((row) => [`${row.table_name}.${row.column_name}`, row]),
+    );
     expect(byColumn.get("login.calendar_export_token")?.udt_name).toBe("uuid");
-    expect(byColumn.get("ingestion_jobs.chunks_stored")?.data_type).toBe("integer");
+    expect(byColumn.get("ingestion_jobs.chunks_stored")?.data_type).toBe(
+      "integer",
+    );
     expect(byColumn.get("ingestion_jobs.error")?.data_type).toBe("text");
+    expect(byColumn.get("chat_sessions.generation_status")?.data_type).toBe(
+      "text",
+    );
+    expect(byColumn.get("chat_sessions.pinned")?.data_type).toBe("boolean");
+    expect(byColumn.get("chat_generations.session_id")?.udt_name).toBe("uuid");
+    expect(byColumn.get("chat_generations.status")?.data_type).toBe("text");
   });
 });


### PR DESCRIPTION
## What
Align the E2E reset schema with the chat runtime by applying migrations 041–043 before the existing imported-file cache migration. Add a schema-contract regression test for chat generation and pinning columns.

## Verification
- `npm run e2e:reset`
- `npm run test:integration -- tests/integration/db/schema-contract.test.ts`
- `npm run lint -- scripts/e2e/reset-db.mjs tests/integration/db/schema-contract.test.ts`
- `npx prettier --check scripts/e2e/reset-db.mjs tests/integration/db/schema-contract.test.ts`

`npm run e2e:smoke -- --workers=1` still has six unrelated existing failures (auth/public/mobile paths), but the prior missing `generation_status` schema error is cleared.