### PR TITLE
draft: tests — refresh stale smoke locators

### DIFF
--- a/tests/e2e/smoke/auth-notes.spec.ts
+++ b/tests/e2e/smoke/auth-notes.spec.ts
@@ -32,10 +32,8 @@ test.describe("auth and notes smoke", () => {
       await page.getByTitle("Toggle metadata panel").click();
       const inspector = page.getByRole("dialog");
       await expect(inspector).toBeVisible();
-      await inspector.getByRole("tab", { name: "Tasks" }).click();
-      await expect(
-        inspector.getByRole("tab", { name: "Tasks" }),
-      ).toHaveAttribute("aria-selected", "true");
+      await inspector.getByRole("button", { name: "Global Tasks" }).click();
+      await expect(page.getByRole("dialog", { name: "Global Tasks" })).toBeVisible();
       await inspector.getByRole("button", { name: "Close" }).first().click();
       await expect(inspector).not.toBeVisible();
     }

--- a/tests/e2e/smoke/public.spec.ts
+++ b/tests/e2e/smoke/public.spec.ts
@@ -11,7 +11,9 @@ test.describe("public smoke", () => {
 
     await page.goto("/pricing");
     await expect(
-      page.getByRole("heading", { name: /Pricing built around semesters/i }),
+      page.getByRole("heading", {
+        name: /Pricing built around the academic term/i,
+      }),
     ).toBeVisible();
 
     await page.goto("/login");


### PR DESCRIPTION
## repo-agent validation

- **Lane:** tests
- **Goal:** align stale Playwright smoke locators with the current pricing and mobile notes UI.
- **Base branch:** `dev`
- **Source:** failing PR #364 smoke E2E checks
- **Risk:** low
- **Changed files:**
  - `tests/e2e/smoke/public.spec.ts`
  - `tests/e2e/smoke/auth-notes.spec.ts`
- **Checks run:** `npm ci`; focused ESLint; `npm run typecheck`; `git diff --check`
- **Test result:** passed. Full E2E requires the CI service stack and remains for GitHub CI.
- **Opus verdict:** `PASS_OPEN_PR`
- **Known limitations:** unrelated intermittent `ERR_ABORTED` smoke retries were deliberately not changed.

Status: awaiting maintainer review/merge.
