### PR TITLE
Promote fair imports and chat cancellation to production

### DIFF
--- a/database/migrations/047_import_queue_fairness.sql
+++ b/database/migrations/047_import_queue_fairness.sql
@@ -1,0 +1,32 @@
+-- Weighted fair scheduling for Canvas per-file work.
+ALTER TABLE app.login
+  ADD COLUMN IF NOT EXISTS import_service_class TEXT NOT NULL DEFAULT 'free';
+
+ALTER TABLE app.login
+  DROP CONSTRAINT IF EXISTS login_import_service_class_check;
+ALTER TABLE app.login
+  ADD CONSTRAINT login_import_service_class_check
+  CHECK (import_service_class IN ('free', 'semester', 'academic_year'));
+
+ALTER TABLE app.canvas_imports
+  ADD COLUMN IF NOT EXISTS dispatched_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_canvas_imports_fair_dispatch
+  ON app.canvas_imports (status, dispatched_at, created_at)
+  WHERE status = 'pending';
+
+CREATE TABLE IF NOT EXISTS app.import_scheduler_classes (
+  service_class TEXT PRIMARY KEY
+    CHECK (service_class IN ('free', 'semester', 'academic_year')),
+  current_weight INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO app.import_scheduler_classes (service_class)
+VALUES ('free'), ('semester'), ('academic_year')
+ON CONFLICT (service_class) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS app.import_scheduler_users (
+  user_id UUID PRIMARY KEY,
+  last_dispatched_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/docs/engineering/import-pipeline.md
+++ b/docs/engineering/import-pipeline.md
@@ -18,7 +18,7 @@ names, tuning values, and live troubleshooting belong in the
 3. Files are downloaded and deduplicated, note/tree rows are created, and binary objects are stored through the S3-compatible provider.
 4. Extraction uses supported text parsers and optional Marker OCR. Extraction coverage records whether the result is partial.
 5. Text is normalized, chunked, and embedded. Chunk text stays in PostgreSQL; vectors are upserted to Qdrant.
-6. Job and per-file status rows drive UI progress. Extraction failures may enter the delayed `extract-retry` lane.
+6. Job and per-file status rows drive UI progress. Extraction failures re-enter the shared import lane after a delayed retry backoff.
 
 Files can appear before semantic indexing completes. Product copy must distinguish visible material from search/chat-ready material.
 
@@ -56,7 +56,7 @@ embedding model plus the current cache format version.
 
 [`src/lib/queue.ts`](../../src/lib/queue.ts) owns the provider switch:
 
-- **BullMQ** is the default and current homelab provider. Redis carries environment-prefixed `canvas-import` and `extract-retry` queues.
+- **BullMQ** is the default and current homelab provider. New work, including delayed extraction retries, uses the environment-prefixed `canvas-import` queue. The `extract-retry` consumer remains temporarily for messages created before the fairness rollout.
 - **Cloudflare Queues** is implemented as an alternate HTTP publish/pull provider selected by `QUEUE_PROVIDER=cloudflare`. It is the target migration path, not the assumed live value.
 - The same Node worker dispatches both providers and retains a PostgreSQL
   poller that reclaims Canvas import/sync discovery jobs whose enqueue was
@@ -67,6 +67,15 @@ Default BullMQ jobs use three attempts with exponential backoff. Vault import
 and export enqueue sites override this to one attempt; in particular, a
 partial vault-import retry is not yet idempotent and can create duplicate
 notes.
+
+Canvas discovery does not fan every file directly into the provider queue.
+Pending files pass through a provider-neutral scheduler using smooth weighted
+round robin across `free`, `semester`, and `academic_year` service classes with
+weights 1:3:5. Within a class, the least-recently served eligible user goes
+next, and each user has at most one dispatched file at a time. This preserves a
+paid queue advantage without allowing one large import or one class to starve
+the rest. `app.login.import_service_class` is local entitlement state and
+defaults to `free`.
 
 ## Concurrency and timing
 

--- a/docs/operations/import-worker.md
+++ b/docs/operations/import-worker.md
@@ -38,8 +38,16 @@ should not bypass it with provider-specific calls.
 
 The Canvas queue handles `canvas-discover`, `canvas-file`, `extract`,
 `marker-complete`, `vault-import`, `vault-export`, and the legacy
-`canvas-import` job name retained for in-flight compatibility. The retry queue
-handles delayed extraction retries.
+`canvas-import` job name retained for in-flight compatibility. New delayed
+extraction retries return to the Canvas queue so fresh and retried work share
+worker capacity. The retry queue consumer remains enabled to drain messages
+created before this change.
+
+Canvas per-file work is released by a database-backed weighted fair scheduler.
+The `free`, `semester`, and `academic_year` service classes receive 1:3:5
+shares, users rotate within a class, and only one file per user is dispatched
+at once. Paid entitlement comes from verified local
+`app.login.import_service_class` state.
 
 The worker also polls the database as a safety net for Canvas import/sync
 discovery jobs that were accepted but not enqueued cleanly. It cannot recreate
@@ -152,6 +160,14 @@ SELECT status, COUNT(*)
   FROM app.canvas_import_jobs
  GROUP BY status
  ORDER BY status;
+
+SELECT COALESCE(l.import_service_class, 'free') AS service_class,
+       COUNT(*) FILTER (WHERE ci.status = 'pending' AND ci.dispatched_at IS NULL) AS waiting,
+       COUNT(*) FILTER (WHERE ci.dispatched_at IS NOT NULL AND ci.status IN ('pending', 'downloading', 'processing', 'indexing')) AS active
+  FROM app.canvas_imports ci
+  JOIN app.login l ON l.user_id = ci.user_id
+ GROUP BY 1
+ ORDER BY 1;
 ```
 
 ## Dev Smoke Test

--- a/src/__tests__/lib/auth.test.js
+++ b/src/__tests__/lib/auth.test.js
@@ -1,10 +1,19 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/auth", () => ({
   auth: vi.fn().mockResolvedValue(null),
 }));
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+}));
 
-import { generateJWTToken, verifyJWTToken } from "@/lib/auth";
+import { auth } from "@/auth";
+import { cookies } from "next/headers";
+import {
+  generateJWTToken,
+  verifyJWTToken,
+  validateSessionLite,
+} from "@/lib/auth";
 
 // JWT_SECRET is set in setup.ts
 
@@ -55,5 +64,44 @@ describe("verifyJWTToken", () => {
     delete process.env.JWT_SECRET;
     expect(() => verifyJWTToken(token)).toThrow();
     process.env.JWT_SECRET = original;
+  });
+});
+
+describe("validateSessionLite", () => {
+  beforeEach(() => {
+    vi.mocked(auth).mockResolvedValue(null);
+    vi.mocked(cookies).mockResolvedValue({ get: () => undefined });
+  });
+
+  it("resolves the user from a valid session cookie without any db call", async () => {
+    const token = generateJWTToken({ user_id: "user-123" });
+    vi.mocked(cookies).mockResolvedValue({
+      get: (name) => (name === "session" ? { value: token } : undefined),
+    });
+
+    await expect(validateSessionLite()).resolves.toEqual({
+      user_id: "user-123",
+    });
+  });
+
+  it("rejects a tampered session cookie", async () => {
+    const token = generateJWTToken({ user_id: "user-123" });
+    vi.mocked(cookies).mockResolvedValue({
+      get: () => ({ value: token.slice(0, -3) + "xxx" }),
+    });
+
+    await expect(validateSessionLite()).resolves.toBeNull();
+  });
+
+  it("falls back to the NextAuth session for OAuth users", async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { id: "oauth-user-9" } });
+
+    await expect(validateSessionLite()).resolves.toEqual({
+      user_id: "oauth-user-9",
+    });
+  });
+
+  it("returns null when no credential is present", async () => {
+    await expect(validateSessionLite()).resolves.toBeNull();
   });
 });

--- a/src/__tests__/lib/chat/final-answer.test.ts
+++ b/src/__tests__/lib/chat/final-answer.test.ts
@@ -93,6 +93,37 @@ describe("streamFinalAnswer", () => {
     });
     expect(model.doStreamCalls[0]?.prompt).toHaveLength(4);
   });
+
+  it("passes the caller's abort signal through to the model call", async () => {
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: "stream-start" as const, warnings: [] },
+            { type: "text-start" as const, id: "answer" },
+            { type: "text-delta" as const, id: "answer", delta: "ok" },
+            { type: "text-end" as const, id: "answer" },
+            {
+              type: "finish" as const,
+              finishReason: { unified: "stop" as const, raw: "stop" },
+              usage,
+            },
+          ],
+        }),
+      }),
+    });
+    const controller = new AbortController();
+
+    await streamFinalAnswer({
+      model,
+      abortSignal: controller.signal,
+      messages: [{ role: "user", content: "hi" }],
+      maxOutputTokens: 64,
+      onTextDelta: vi.fn(),
+    });
+
+    expect(model.doStreamCalls[0]?.abortSignal).toBe(controller.signal);
+  });
 });
 
 describe("shouldSynthesizeFinalAnswer", () => {

--- a/src/__tests__/lib/chat/generation-store.test.ts
+++ b/src/__tests__/lib/chat/generation-store.test.ts
@@ -6,7 +6,9 @@ const sqlMock = vi.hoisted(() =>
 const redisMock = vi.hoisted(() => ({
   call: vi.fn(),
   del: vi.fn(),
+  exists: vi.fn(),
   expire: vi.fn(),
+  set: vi.fn(),
   xadd: vi.fn(),
 }));
 
@@ -18,10 +20,13 @@ vi.mock("@/lib/utils/uuid", () => ({
 
 import {
   appendChatGenerationEvent,
+  cancelChatGeneration,
   createChatGeneration,
+  isChatGenerationCancelRequested,
   loadChatGeneration,
   loadOwnedChatGeneration,
   readChatGenerationEvents,
+  requestChatGenerationCancel,
 } from "@/lib/chat/generation-store";
 
 describe("resumable chat generation store", () => {
@@ -155,5 +160,36 @@ describe("resumable chat generation store", () => {
       expect.stringContaining("chat-generation:"),
       "1720000000000-1",
     );
+  });
+
+  it("records and reads back a cancel request flag", async () => {
+    redisMock.set.mockResolvedValue("OK");
+    await requestChatGenerationCancel("11111111-1111-1111-1111-111111111111");
+    expect(redisMock.set).toHaveBeenCalledWith(
+      "chat-generation:11111111-1111-1111-1111-111111111111:cancel",
+      "1",
+      "EX",
+      3600,
+    );
+
+    redisMock.exists.mockResolvedValueOnce(1);
+    await expect(
+      isChatGenerationCancelRequested("11111111-1111-1111-1111-111111111111"),
+    ).resolves.toBe(true);
+
+    redisMock.exists.mockResolvedValueOnce(0);
+    await expect(
+      isChatGenerationCancelRequested("11111111-1111-1111-1111-111111111111"),
+    ).resolves.toBe(false);
+  });
+
+  it("cancels the generation and returns the session to idle", async () => {
+    await cancelChatGeneration("11111111-1111-1111-1111-111111111111");
+
+    expect(sqlMock).toHaveBeenCalledTimes(2);
+    const [generationUpdate] = sqlMock.mock.calls[0] as [readonly string[]];
+    const [sessionUpdate] = sqlMock.mock.calls[1] as [readonly string[]];
+    expect(generationUpdate.join("?")).toContain("status = 'cancelled'");
+    expect(sessionUpdate.join("?")).toContain("generation_status = 'idle'");
   });
 });

--- a/src/__tests__/lib/chat/presence.test.ts
+++ b/src/__tests__/lib/chat/presence.test.ts
@@ -4,6 +4,7 @@ const redisMock = vi.hoisted(() => ({
   hset: vi.fn(),
   hdel: vi.fn(),
   hgetall: vi.fn(),
+  hlen: vi.fn(),
   expire: vi.fn(),
 }));
 
@@ -27,6 +28,7 @@ describe("chat presence store", () => {
     vi.clearAllMocks();
     redisMock.hset.mockResolvedValue(1);
     redisMock.hdel.mockResolvedValue(1);
+    redisMock.hlen.mockResolvedValue(1);
     redisMock.expire.mockResolvedValue(1);
     redisMock.hgetall.mockResolvedValue({});
   });
@@ -43,6 +45,44 @@ describe("chat presence store", () => {
       `chat:presence:{${USER}}`,
       15 * 60,
     );
+    // small hash: the prune read must not run — heartbeats stay cheap
+    expect(redisMock.hgetall).not.toHaveBeenCalled();
+  });
+
+  it("prunes dead tab fields once the hash grows past the threshold", async () => {
+    const now = Date.now();
+    redisMock.hlen.mockResolvedValue(9);
+    redisMock.hgetall.mockResolvedValue({
+      [TAB]: String(now),
+      "fresh-tab": String(now - 5_000),
+      "dead-tab-1": String(now - PRESENCE_STALE_MS - 1_000),
+      "dead-tab-2": "not-a-timestamp",
+    });
+
+    await recordChatPresence(USER, TAB);
+
+    expect(redisMock.hdel).toHaveBeenCalledWith(
+      `chat:presence:{${USER}}`,
+      "dead-tab-1",
+      "dead-tab-2",
+    );
+  });
+
+  it("never prunes the tab that just heartbeated", async () => {
+    redisMock.hlen.mockResolvedValue(9);
+    redisMock.hgetall.mockResolvedValue({
+      [TAB]: "not-a-timestamp-yet-still-current",
+    });
+
+    await recordChatPresence(USER, TAB);
+
+    expect(redisMock.hdel).not.toHaveBeenCalled();
+  });
+
+  it("treats prune failures as harmless", async () => {
+    redisMock.hlen.mockRejectedValue(new Error("redis down"));
+
+    await expect(recordChatPresence(USER, TAB)).resolves.toBeUndefined();
   });
 
   it("removes only the disconnecting tab's field", async () => {

--- a/src/__tests__/lib/chat/presence.test.ts
+++ b/src/__tests__/lib/chat/presence.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const redisMock = vi.hoisted(() => ({
+  hset: vi.fn(),
+  hdel: vi.fn(),
+  hgetall: vi.fn(),
+  expire: vi.fn(),
+}));
+
+vi.mock("@/lib/redis", () => ({ redis: redisMock }));
+
+import {
+  DISCONNECT_GRACE_MS,
+  PRESENCE_STALE_MS,
+  hasFreshChatPresence,
+  isValidPresenceTabId,
+  recordChatPresence,
+  removeChatPresence,
+  resolveAbortReason,
+} from "@/lib/chat/presence";
+
+const USER = "22222222-2222-2222-2222-222222222222";
+const TAB = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+describe("chat presence store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisMock.hset.mockResolvedValue(1);
+    redisMock.hdel.mockResolvedValue(1);
+    redisMock.expire.mockResolvedValue(1);
+    redisMock.hgetall.mockResolvedValue({});
+  });
+
+  it("records a tab heartbeat under the user's presence hash", async () => {
+    await recordChatPresence(USER, TAB);
+
+    expect(redisMock.hset).toHaveBeenCalledWith(
+      `chat:presence:{${USER}}`,
+      TAB,
+      expect.any(Number),
+    );
+    expect(redisMock.expire).toHaveBeenCalledWith(
+      `chat:presence:{${USER}}`,
+      15 * 60,
+    );
+  });
+
+  it("removes only the disconnecting tab's field", async () => {
+    await removeChatPresence(USER, TAB);
+
+    expect(redisMock.hdel).toHaveBeenCalledWith(
+      `chat:presence:{${USER}}`,
+      TAB,
+    );
+  });
+
+  it("treats a recent heartbeat from any tab as presence", async () => {
+    redisMock.hgetall.mockResolvedValue({
+      [TAB]: String(Date.now() - PRESENCE_STALE_MS + 5_000),
+      "stale-tab": String(Date.now() - PRESENCE_STALE_MS - 60_000),
+    });
+
+    await expect(hasFreshChatPresence(USER)).resolves.toBe(true);
+  });
+
+  it("ignores stale, malformed, and missing entries", async () => {
+    redisMock.hgetall.mockResolvedValue({
+      "old-tab": String(Date.now() - PRESENCE_STALE_MS - 1_000),
+      "bad-tab": "not-a-timestamp",
+    });
+    await expect(hasFreshChatPresence(USER)).resolves.toBe(false);
+
+    redisMock.hgetall.mockResolvedValue({});
+    await expect(hasFreshChatPresence(USER)).resolves.toBe(false);
+  });
+});
+
+describe("isValidPresenceTabId", () => {
+  it("accepts uuid-shaped ids and rejects anything unusual", () => {
+    expect(isValidPresenceTabId(TAB)).toBe(true);
+    expect(isValidPresenceTabId("short-id")).toBe(true);
+    expect(isValidPresenceTabId("")).toBe(false);
+    expect(isValidPresenceTabId(null)).toBe(false);
+    expect(isValidPresenceTabId(42)).toBe(false);
+    expect(isValidPresenceTabId("a".repeat(65))).toBe(false);
+    expect(isValidPresenceTabId("bad*chars")).toBe(false);
+  });
+});
+
+describe("resolveAbortReason", () => {
+  const now = 1_800_000_000_000;
+  const base = {
+    cancelRequested: false,
+    present: true,
+    sawPresence: true,
+    firstAbsentAt: null,
+    now,
+  };
+
+  it("always honours an explicit cancel", () => {
+    expect(resolveAbortReason({ ...base, cancelRequested: true })).toBe(
+      "stopped",
+    );
+    expect(
+      resolveAbortReason({
+        ...base,
+        cancelRequested: true,
+        present: false,
+        sawPresence: false,
+      }),
+    ).toBe("stopped");
+  });
+
+  it("never aborts while the user is present", () => {
+    expect(resolveAbortReason(base)).toBeNull();
+  });
+
+  it("aborts only after a full grace window of continuous absence", () => {
+    const absent = { ...base, present: false };
+    expect(
+      resolveAbortReason({
+        ...absent,
+        firstAbsentAt: now - DISCONNECT_GRACE_MS + 1_000,
+      }),
+    ).toBeNull();
+    expect(
+      resolveAbortReason({
+        ...absent,
+        firstAbsentAt: now - DISCONNECT_GRACE_MS,
+      }),
+    ).toBe("disconnected");
+  });
+
+  it("never disconnect-aborts a user that was never present (API usage)", () => {
+    expect(
+      resolveAbortReason({
+        ...base,
+        present: false,
+        sawPresence: false,
+        firstAbsentAt: now - DISCONNECT_GRACE_MS * 10,
+      }),
+    ).toBeNull();
+  });
+
+  it("requires an absence start before the grace window can elapse", () => {
+    expect(
+      resolveAbortReason({ ...base, present: false, firstAbsentAt: null }),
+    ).toBeNull();
+  });
+});

--- a/src/__tests__/lib/import-scheduler.test.ts
+++ b/src/__tests__/lib/import-scheduler.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { chooseWeightedClass } from "@/lib/canvas/import-scheduler";
+
+describe("import weighted fair scheduling", () => {
+  it("gives paid classes more turns without starving free work", () => {
+    let state = { free: 0, semester: 0, academic_year: 0 };
+    const counts = { free: 0, semester: 0, academic_year: 0 };
+    for (let index = 0; index < 90; index += 1) {
+      const result = chooseWeightedClass(state, ["free", "semester", "academic_year"]);
+      expect(result).not.toBeNull();
+      state = result!.next;
+      counts[result!.chosen] += 1;
+    }
+    expect(counts).toEqual({ free: 10, semester: 30, academic_year: 50 });
+  });
+
+  it("uses all capacity when only one class has eligible work", () => {
+    let state = { free: -4, semester: 2, academic_year: 2 };
+    for (let index = 0; index < 10; index += 1) {
+      const result = chooseWeightedClass(state, ["free"]);
+      expect(result?.chosen).toBe("free");
+      state = result!.next;
+    }
+  });
+});

--- a/src/__tests__/lib/queue-bullmq-prefix.test.ts
+++ b/src/__tests__/lib/queue-bullmq-prefix.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const queueAdd = vi.hoisted(() => vi.fn());
 const queueConstructor = vi.hoisted(() =>
   vi.fn().mockImplementation(function QueueMock() {
     return {
-      add: vi.fn(),
+      add: queueAdd,
       addBulk: vi.fn(),
     };
   }),
@@ -30,7 +31,26 @@ describe("BullMQ queue prefixing", () => {
     vi.unstubAllEnvs();
     vi.resetModules();
     queueConstructor.mockClear();
+    queueAdd.mockClear();
     redisConstructor.mockClear();
+  });
+
+  it("puts delayed extraction retries on the shared Canvas queue", async () => {
+    vi.stubEnv("QUEUE_PREFIX", "oghma-dev");
+
+    const { enqueueExtractRetryJob } = await import("@/lib/queue");
+    await enqueueExtractRetryJob({ noteId: "note-1" }, 120);
+
+    expect(queueConstructor).toHaveBeenCalledTimes(1);
+    expect(queueConstructor).toHaveBeenCalledWith(
+      "oghma-dev-canvas-import",
+      expect.objectContaining({ connection: expect.anything() }),
+    );
+    expect(queueAdd).toHaveBeenCalledWith(
+      "extract-retry",
+      { type: "extract-retry", noteId: "note-1" },
+      expect.objectContaining({ delay: 120_000 }),
+    );
   });
 
   it("uses QUEUE_PREFIX in the queue names shared by producers and workers", async () => {

--- a/src/__tests__/lib/queue-cloudflare.test.ts
+++ b/src/__tests__/lib/queue-cloudflare.test.ts
@@ -45,7 +45,7 @@ describe("Cloudflare queue adapter", () => {
     );
   });
 
-  it("publishes delayed extraction retries to the retry queue", async () => {
+  it("publishes delayed extraction retries to the shared import queue", async () => {
     setCloudflareQueueEnv();
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -56,7 +56,7 @@ describe("Cloudflare queue adapter", () => {
     await enqueueExtractRetryJob({ noteId: "note-1" }, 120);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.cloudflare.com/client/v4/accounts/account-1/queues/retry-queue-id/messages",
+      "https://api.cloudflare.com/client/v4/accounts/account-1/queues/canvas-queue-id/messages",
       expect.objectContaining({
         body: JSON.stringify({
           body: { type: "extract-retry", noteId: "note-1" },

--- a/src/app/api/chat/generations/[id]/cancel/route.ts
+++ b/src/app/api/chat/generations/[id]/cancel/route.ts
@@ -1,0 +1,45 @@
+// Hard cancel for a chat generation (the Stop button). Queued generations are
+// cancelled immediately; running ones get a Redis flag that the worker
+// watchdog observes within one tick (~5s), aborting the LLM stream and
+// persisting whatever partial answer already streamed.
+import { NextRequest, NextResponse } from "next/server";
+import { withErrorHandler, requireAuth, tracedError } from "@/lib/api-error";
+import { checkRateLimit } from "@/lib/rateLimiter";
+import { isValidUUID } from "@/lib/utils/uuid";
+import {
+  cancelChatGeneration,
+  loadOwnedChatGeneration,
+  requestChatGenerationCancel,
+} from "@/lib/chat/generation-store";
+
+export const POST = withErrorHandler(
+  async (
+    _request: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+  ) => {
+    const session = await requireAuth();
+
+    const limited = await checkRateLimit("chat-cancel", session.user_id);
+    if (limited) return limited;
+
+    const { id } = await params;
+    if (!isValidUUID(id)) return tracedError("Invalid generation id", 400);
+
+    const generation = await loadOwnedChatGeneration(id, session.user_id);
+    if (!generation) return tracedError("Generation not found", 404);
+
+    if (generation.status === "completed" || generation.status === "cancelled") {
+      return NextResponse.json({ success: true, status: generation.status });
+    }
+
+    await requestChatGenerationCancel(id);
+
+    if (generation.status === "queued") {
+      // not claimed by the worker yet — settle it right now
+      await cancelChatGeneration(id);
+      return NextResponse.json({ success: true, status: "cancelled" });
+    }
+
+    return NextResponse.json({ success: true, status: "cancelling" });
+  },
+);

--- a/src/app/api/chat/presence/disconnect/route.ts
+++ b/src/app/api/chat/presence/disconnect/route.ts
@@ -1,0 +1,33 @@
+// Tab-close beacon. Fired via navigator.sendBeacon from `pagehide`, so the
+// tab id travels as a query parameter and the body stays empty (beacons can't
+// reliably set a JSON content type). Removing the tab's presence field starts
+// the disconnect grace window for any in-flight chat generation.
+import { NextRequest, NextResponse } from "next/server";
+import { withErrorHandler, requireAuth, tracedError } from "@/lib/api-error";
+import { checkRateLimit } from "@/lib/rateLimiter";
+import { isValidPresenceTabId, removeChatPresence } from "@/lib/chat/presence";
+import logger from "@/lib/logger";
+
+export const POST = withErrorHandler(async (request: NextRequest) => {
+  const session = await requireAuth();
+
+  const limited = await checkRateLimit("chat-presence", session.user_id);
+  if (limited) return limited;
+
+  const tabId = request.nextUrl.searchParams.get("tab");
+  if (!isValidPresenceTabId(tabId)) {
+    return tracedError("Invalid tab id", 400);
+  }
+
+  try {
+    await removeChatPresence(session.user_id, tabId);
+  } catch (err) {
+    // Missing the beacon only means the stale-presence fallback (~90s)
+    // cancels instead of the fast path — never fail the unload request.
+    logger.warn("chat presence disconnect failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return NextResponse.json({ success: true });
+});

--- a/src/app/api/chat/presence/disconnect/route.ts
+++ b/src/app/api/chat/presence/disconnect/route.ts
@@ -3,13 +3,14 @@
 // reliably set a JSON content type). Removing the tab's presence field starts
 // the disconnect grace window for any in-flight chat generation.
 import { NextRequest, NextResponse } from "next/server";
-import { withErrorHandler, requireAuth, tracedError } from "@/lib/api-error";
+import { withErrorHandler, requireAuthLite, tracedError } from "@/lib/api-error";
 import { checkRateLimit } from "@/lib/rateLimiter";
 import { isValidPresenceTabId, removeChatPresence } from "@/lib/chat/presence";
 import logger from "@/lib/logger";
 
 export const POST = withErrorHandler(async (request: NextRequest) => {
-  const session = await requireAuth();
+  // same token-only auth as the heartbeat — see presence/route.ts
+  const session = await requireAuthLite();
 
   const limited = await checkRateLimit("chat-presence", session.user_id);
   if (limited) return limited;

--- a/src/app/api/chat/presence/route.ts
+++ b/src/app/api/chat/presence/route.ts
@@ -2,14 +2,16 @@
 // chat worker can tell a real disconnect (tab closed) apart from in-app
 // navigation. Losing a heartbeat is never an error worth failing loudly for.
 import { NextRequest, NextResponse } from "next/server";
-import { withErrorHandler, requireAuth, tracedError } from "@/lib/api-error";
+import { withErrorHandler, requireAuthLite, tracedError } from "@/lib/api-error";
 import { checkRateLimit } from "@/lib/rateLimiter";
 import { parseJsonBody } from "@/lib/auth";
 import { isValidPresenceTabId, recordChatPresence } from "@/lib/chat/presence";
 import logger from "@/lib/logger";
 
 export const POST = withErrorHandler(async (request: NextRequest) => {
-  const session = await requireAuth();
+  // token-only auth: heartbeats fire every ~10s per tab, so they must not
+  // cost a Postgres session lookup each — presence is low-stakes by design
+  const session = await requireAuthLite();
 
   const limited = await checkRateLimit("chat-presence", session.user_id);
   if (limited) return limited;

--- a/src/app/api/chat/presence/route.ts
+++ b/src/app/api/chat/presence/route.ts
@@ -1,0 +1,36 @@
+// Tab presence heartbeat. Every open app tab reports itself every ~10s so the
+// chat worker can tell a real disconnect (tab closed) apart from in-app
+// navigation. Losing a heartbeat is never an error worth failing loudly for.
+import { NextRequest, NextResponse } from "next/server";
+import { withErrorHandler, requireAuth, tracedError } from "@/lib/api-error";
+import { checkRateLimit } from "@/lib/rateLimiter";
+import { parseJsonBody } from "@/lib/auth";
+import { isValidPresenceTabId, recordChatPresence } from "@/lib/chat/presence";
+import logger from "@/lib/logger";
+
+export const POST = withErrorHandler(async (request: NextRequest) => {
+  const session = await requireAuth();
+
+  const limited = await checkRateLimit("chat-presence", session.user_id);
+  if (limited) return limited;
+
+  const { data, error } = await parseJsonBody(request);
+  if (error) return error;
+  if (!isValidPresenceTabId(data?.tabId)) {
+    return tracedError("Invalid tabId", 400);
+  }
+
+  let recorded = true;
+  try {
+    await recordChatPresence(session.user_id, data.tabId);
+  } catch (err) {
+    // Redis being unavailable also disables disconnect-cancel in the worker,
+    // so a dropped heartbeat is harmless — don't surface it to the client.
+    recorded = false;
+    logger.warn("chat presence heartbeat failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return NextResponse.json({ success: true, recorded });
+});

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -198,9 +198,14 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     let lastEvent = "init";
     let activeSessionId: string | null = null;
 
+    // Aborts the in-flight LLM stream when the client goes away, so a dropped
+    // inline connection stops billing instead of generating into the void.
+    const inlineAbort = new AbortController();
+
     const markClientDisconnected = (reason: unknown) => {
       if (clientDisconnected) return;
       clientDisconnected = true;
+      inlineAbort.abort();
       logger.warn("Chat stream client disconnected", {
         chatStreamId,
         elapsedMs: Date.now() - startedAt,
@@ -214,6 +219,9 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
               : String(reason ?? "unknown"),
       });
     };
+    request.signal.addEventListener("abort", () =>
+      markClientDisconnected("request aborted"),
+    );
 
     return new NextResponse(
       new ReadableStream({
@@ -410,6 +418,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
               try {
                 const result = streamText({
                   model: model!,
+                  abortSignal: inlineAbort.signal,
                   ...llmCallOptions,
                 });
                 for await (const part of result.fullStream) {
@@ -450,6 +459,8 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
                   } else if (part.type === "finish") {
                     finishReason = part.finishReason;
                     rawFinishReason = part.rawFinishReason;
+                  } else if (part.type === "abort") {
+                    throw new Error("Generation aborted: client disconnected");
                   } else if (part.type === "error") {
                     throw part.error instanceof Error
                       ? part.error
@@ -563,6 +574,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
                 closeThinkingWindow();
                 const finalAnswer = await streamFinalAnswer({
                   model: model!,
+                  abortSignal: inlineAbort.signal,
                   messages: [
                     ...llmCallOptions.messages,
                     ...responseMessages,

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -2,6 +2,7 @@ import { DM_Sans, Source_Serif_4 } from "next/font/google";
 import I18nRootProvider from "@/components/providers/i18n-root-provider";
 import ThemeProvider from "@/components/providers/theme-provider";
 import PomodoroTimerController from "@/components/pomodoro/pomodoro-timer-controller";
+import ChatPresenceController from "@/components/chat/chat-presence-controller";
 import GlobalSearchRoot from "@/components/search/global-search-root";
 import { Toaster } from "sonner";
 import "katex/dist/katex.min.css";
@@ -148,6 +149,7 @@ export default function RootLayout({ children }) {
         <I18nRootProvider>
           <ThemeProvider>
             <PomodoroTimerController />
+            <ChatPresenceController />
             <GlobalSearchRoot />
             {children}
             <Toaster position="bottom-center" />

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -165,6 +165,17 @@ const ChatInterface: FC<ChatInterfaceProps> = ({
     onStreamComplete,
   });
   const busy = loading || backgroundLoading;
+
+  // Stop must reach the worker even before the background resume attaches,
+  // when the hook doesn't know the generation id yet.
+  const stopGenerating = () => {
+    if (backgroundGenerationId) {
+      void fetch(`/api/chat/generations/${backgroundGenerationId}/cancel`, {
+        method: "POST",
+      }).catch(() => {});
+    }
+    cancel();
+  };
   const resumedGenerationRef = useRef<string | null>(null);
   const ownsLiveStreamRef = useRef(false);
 
@@ -484,14 +495,9 @@ const ChatInterface: FC<ChatInterfaceProps> = ({
             {busy ? (
               <button
                 type="button"
-                onClick={loading ? cancel : undefined}
-                disabled={backgroundLoading}
-                className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-radius-md bg-error-500/15 text-error-400 transition-colors hover:bg-error-500/25 hover:text-error-300 disabled:cursor-wait disabled:opacity-60 md:h-8 md:w-8"
-                title={
-                  backgroundLoading
-                    ? t("Generating in background")
-                    : t("Stop generating")
-                }
+                onClick={stopGenerating}
+                className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-radius-md bg-error-500/15 text-error-400 transition-colors hover:bg-error-500/25 hover:text-error-300 md:h-8 md:w-8"
+                title={t("Stop generating")}
               >
                 <StopCircleIcon
                   className={`h-4 w-4 ${backgroundLoading ? "animate-pulse" : ""}`}

--- a/src/components/chat/chat-presence-controller.tsx
+++ b/src/components/chat/chat-presence-controller.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+/**
+ * App-wide tab presence for chat generation cancellation.
+ *
+ * Every open tab heartbeats its own id so the chat worker can tell a real
+ * disconnect (tab closed → pagehide beacon, or heartbeats going stale) apart
+ * from in-app navigation, which never unloads the page. Hidden tabs keep
+ * beating — the browser throttles their timers to ~1/min, which the server's
+ * staleness window tolerates — so a second open tab keeps a generation alive.
+ */
+
+// Mirrors PRESENCE_HEARTBEAT_MS in src/lib/chat/presence.ts (server-only
+// module — it pulls in the Redis client, so it can't be imported here).
+const HEARTBEAT_MS = 10_000;
+const TAB_ID_STORAGE_KEY = "oghma-tab-id";
+
+function getTabId(): string | null {
+  try {
+    const existing = sessionStorage.getItem(TAB_ID_STORAGE_KEY);
+    if (existing) return existing;
+    const id = crypto.randomUUID();
+    sessionStorage.setItem(TAB_ID_STORAGE_KEY, id);
+    return id;
+  } catch {
+    // sessionStorage unavailable (rare privacy modes) — presence simply stays
+    // off and generations fall back to running to completion.
+    return null;
+  }
+}
+
+export default function ChatPresenceController() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const tabId = getTabId();
+    if (!tabId) return;
+
+    // 401 pauses the loop so logged-out visitors don't spam the endpoint;
+    // any wake signal (visibility, pageshow, route change) retries once.
+    let paused = false;
+    let stopped = false;
+
+    const beat = () => {
+      if (paused || stopped) return;
+      void fetch("/api/chat/presence", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tabId }),
+      })
+        .then((res) => {
+          if (res.status === 401) paused = true;
+        })
+        .catch(() => {});
+    };
+
+    const wake = () => {
+      if (stopped) return;
+      paused = false;
+      beat();
+    };
+
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") wake();
+    };
+
+    const onPageHide = () => {
+      try {
+        navigator.sendBeacon(
+          `/api/chat/presence/disconnect?tab=${encodeURIComponent(tabId)}`,
+        );
+      } catch {
+        // stale-presence fallback on the server covers a lost beacon
+      }
+    };
+
+    beat();
+    const interval = setInterval(beat, HEARTBEAT_MS);
+    window.addEventListener("pageshow", wake);
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("pagehide", onPageHide);
+
+    return () => {
+      stopped = true;
+      clearInterval(interval);
+      window.removeEventListener("pageshow", wake);
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("pagehide", onPageHide);
+    };
+    // pathname dependency: a route change is the only signal that a login may
+    // have happened, which must clear the 401 pause. The effect re-runs and
+    // beats immediately, so presence recovers right after sign-in.
+  }, [pathname]);
+
+  return null;
+}

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import logger from "./logger";
 import { getTraceId, withTrace } from "./trace";
-import { validateSession } from "./auth";
+import { validateSession, validateSessionLite } from "./auth";
 import { isValidUUID } from "./utils/uuid";
 
 // ── Error classes ────────────────────────────────────────────────────────────
@@ -141,6 +141,17 @@ export async function requireAuth(): Promise<AuthUser> {
   const user = await validateSession();
   if (!user) throw new ApiError(401, "Unauthorized");
   return user as AuthUser;
+}
+
+/**
+ * Token-only variant of requireAuth for high-frequency, low-stakes routes
+ * (presence heartbeats): skips the per-request Postgres revalidation that
+ * validateSession performs. Never use it where user data is read or mutated.
+ */
+export async function requireAuthLite(): Promise<{ user_id: string }> {
+  const user = await validateSessionLite();
+  if (!user) throw new ApiError(401, "Unauthorized");
+  return user;
 }
 
 /**

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -68,6 +68,36 @@ export async function clearSessionCookie(): Promise<void> {
   (await cookies()).delete("session");
 }
 
+/**
+ * Token-only session check for high-frequency, low-stakes endpoints
+ * (presence heartbeats). Trusts the signed session cookie / NextAuth JWT
+ * without revalidating is_active / deleted_at in Postgres, so it costs no
+ * database query per call. Never use it on endpoints that read or mutate
+ * user data — those must go through validateSession/requireAuth.
+ */
+export async function validateSessionLite(): Promise<{
+  user_id: string;
+} | null> {
+  const token = await getSessionCookie();
+  if (token) {
+    const payload = verifyJWTToken(token);
+    if (typeof payload?.user_id === "string") {
+      return { user_id: payload.user_id };
+    }
+  }
+
+  try {
+    const session = await auth();
+    if (session?.user?.id) {
+      return { user_id: session.user.id };
+    }
+  } catch {
+    // NextAuth session invalid or expired
+  }
+
+  return null;
+}
+
 export async function validateSession(
   _request?: unknown,
 ): Promise<SessionUser | null> {

--- a/src/lib/canvas/import-discovery.js
+++ b/src/lib/canvas/import-discovery.js
@@ -7,7 +7,7 @@
  */
 
 import sql from "../../database/pgsql.js";
-import { enqueueCanvasJobBatch } from "../queue.ts";
+import { dispatchFairCanvasFiles } from "./import-scheduler.ts";
 import { CanvasClient } from "./client.js";
 import { pooled } from "./async-limiter.js";
 import {
@@ -44,20 +44,6 @@ export function parseJobCourses(job) {
           term: c.term ?? null,
         }
       : { id: c, name: String(c), course_code: "", term: null },
-  );
-}
-
-// ── BullMQ fan-out ──────────────────────────────────────────────────────────
-
-async function sendFileMessages(records, jobId, userId) {
-  if (records.length === 0) return;
-  await enqueueCanvasJobBatch(
-    "canvas-file",
-    records.map((record) => ({
-      importRecordId: record.id,
-      jobId,
-      userId,
-    })),
   );
 }
 
@@ -524,7 +510,7 @@ export async function processDiscoverJob(jobId) {
 
     const pendingRecords =
       await sql`SELECT id FROM app.canvas_imports WHERE job_id = ${jobId}::uuid AND status = 'pending'`;
-    await sendFileMessages(pendingRecords, jobId, job.user_id);
+    await dispatchFairCanvasFiles();
 
     const startTime = job.started_at ? new Date(job.started_at) : new Date();
     const elapsedMs = Date.now() - startTime.getTime();
@@ -540,7 +526,7 @@ export async function processDiscoverJob(jobId) {
     });
 
     console.log(
-      `[${new Date().toISOString()}] Discovery done: ${total} total, ${pendingRecords.length} queued for job ${jobId}`,
+      `[${new Date().toISOString()}] Discovery done: ${total} total, ${pendingRecords.length} ready for fair scheduling for job ${jobId}`,
     );
     return true;
   } catch (error) {

--- a/src/lib/canvas/import-extraction.js
+++ b/src/lib/canvas/import-extraction.js
@@ -18,6 +18,7 @@ import { decrypt } from "../crypto.ts";
 import logger from "../logger.ts";
 import { sanitizePostgresText } from "../text-sanitize.ts";
 import { recordActivationMilestone } from "../marketing/events.ts";
+import { dispatchFairCanvasFiles } from "./import-scheduler.ts";
 import {
   cloneImportedPdfCacheToNote,
   canvasFileSource,
@@ -684,6 +685,10 @@ export async function processCanvasFile({ importRecordId, jobId, userId }) {
     } catch {}
     await checkAndCompleteJob(jobId, userId);
     return false;
+  } finally {
+    await dispatchFairCanvasFiles(1).catch((dispatchError) => {
+      console.error("Failed to release next fair import file:", dispatchError);
+    });
   }
 }
 

--- a/src/lib/canvas/import-scheduler.ts
+++ b/src/lib/canvas/import-scheduler.ts
@@ -1,0 +1,143 @@
+import sql from "../../database/pgsql.js";
+import { enqueueCanvasJob } from "../queue.ts";
+
+export type ImportServiceClass = "free" | "semester" | "academic_year";
+
+export const IMPORT_CLASS_WEIGHTS: Record<ImportServiceClass, number> = {
+  free: 1,
+  semester: 3,
+  academic_year: 5,
+};
+
+export function chooseWeightedClass(
+  current: Partial<Record<ImportServiceClass, number>>,
+  eligible: ImportServiceClass[],
+): { chosen: ImportServiceClass; next: Record<ImportServiceClass, number> } | null {
+  if (eligible.length === 0) return null;
+  const next = {
+    free: current.free ?? 0,
+    semester: current.semester ?? 0,
+    academic_year: current.academic_year ?? 0,
+  };
+  for (const serviceClass of eligible) {
+    next[serviceClass] += IMPORT_CLASS_WEIGHTS[serviceClass];
+  }
+  const chosen = eligible.reduce((best, candidate) =>
+    next[candidate] > next[best] ? candidate : best,
+  );
+  next[chosen] -= eligible.reduce(
+    (sum, serviceClass) => sum + IMPORT_CLASS_WEIGHTS[serviceClass],
+    0,
+  );
+  return { chosen, next };
+}
+
+interface DispatchRecord {
+  id: string;
+  job_id: string;
+  user_id: string;
+}
+
+/**
+ * Releases a bounded number of Canvas files into the provider queue. Classes
+ * use smooth weighted round robin; users within a class use least-recently
+ * served order. One in-flight file per user prevents a large import monopolising
+ * worker slots. The advisory lock makes selection safe across worker replicas.
+ */
+export async function dispatchFairCanvasFiles(limit = 10): Promise<number> {
+  const selected = await sql.begin(async (tx: any) => {
+    await tx`SELECT pg_advisory_xact_lock(hashtext('oghma-import-fair-dispatch'))`;
+    const records: DispatchRecord[] = [];
+
+    for (let slot = 0; slot < Math.max(0, limit); slot += 1) {
+      const eligibleRows = await tx`
+        SELECT DISTINCT COALESCE(l.import_service_class, 'free') AS service_class
+        FROM app.canvas_imports ci
+        JOIN app.canvas_import_jobs cij ON cij.id = ci.job_id
+        JOIN app.login l ON l.user_id = ci.user_id
+        WHERE ci.status = 'pending'
+          AND ci.dispatched_at IS NULL
+          AND cij.status = 'processing'
+          AND NOT EXISTS (
+            SELECT 1 FROM app.canvas_imports active
+            WHERE active.user_id = ci.user_id
+              AND active.dispatched_at IS NOT NULL
+              AND active.status IN ('pending', 'downloading', 'processing', 'indexing')
+          )
+      `;
+      const eligible = eligibleRows.map((row: { service_class: ImportServiceClass }) => row.service_class);
+      if (eligible.length === 0) break;
+
+      const stateRows = await tx`
+        SELECT service_class, current_weight FROM app.import_scheduler_classes
+        FOR UPDATE
+      `;
+      const state = Object.fromEntries(
+        stateRows.map((row: { service_class: ImportServiceClass; current_weight: number }) => [
+          row.service_class,
+          Number(row.current_weight),
+        ]),
+      );
+      const decision = chooseWeightedClass(state, eligible);
+      if (!decision) break;
+
+      for (const serviceClass of Object.keys(decision.next) as ImportServiceClass[]) {
+        await tx`
+          UPDATE app.import_scheduler_classes
+          SET current_weight = ${decision.next[serviceClass]}, updated_at = NOW()
+          WHERE service_class = ${serviceClass}
+        `;
+      }
+
+      const [record] = await tx`
+        SELECT ci.id, ci.job_id, ci.user_id
+        FROM app.canvas_imports ci
+        JOIN app.canvas_import_jobs cij ON cij.id = ci.job_id
+        JOIN app.login l ON l.user_id = ci.user_id
+        LEFT JOIN app.import_scheduler_users isu ON isu.user_id = ci.user_id
+        WHERE ci.status = 'pending'
+          AND ci.dispatched_at IS NULL
+          AND cij.status = 'processing'
+          AND COALESCE(l.import_service_class, 'free') = ${decision.chosen}
+          AND NOT EXISTS (
+            SELECT 1 FROM app.canvas_imports active
+            WHERE active.user_id = ci.user_id
+              AND active.dispatched_at IS NOT NULL
+              AND active.status IN ('pending', 'downloading', 'processing', 'indexing')
+          )
+        ORDER BY isu.last_dispatched_at ASC NULLS FIRST, ci.created_at ASC
+        LIMIT 1
+        FOR UPDATE OF ci SKIP LOCKED
+      `;
+      if (!record) continue;
+
+      await tx`UPDATE app.canvas_imports SET dispatched_at = NOW() WHERE id = ${record.id}::uuid`;
+      await tx`
+        INSERT INTO app.import_scheduler_users (user_id, last_dispatched_at)
+        VALUES (${record.user_id}::uuid, NOW())
+        ON CONFLICT (user_id) DO UPDATE SET last_dispatched_at = EXCLUDED.last_dispatched_at
+      `;
+      records.push(record as DispatchRecord);
+    }
+    return records;
+  });
+
+  let enqueued = 0;
+  for (const record of selected) {
+    try {
+      await enqueueCanvasJob("canvas-file", {
+        importRecordId: record.id,
+        jobId: record.job_id,
+        userId: record.user_id,
+      });
+      enqueued += 1;
+    } catch (error) {
+      await sql`
+        UPDATE app.canvas_imports SET dispatched_at = NULL
+        WHERE id = ${record.id}::uuid AND status = 'pending'
+      `;
+      console.error(`Fair import dispatch failed for ${record.id}:`, error);
+    }
+  }
+  return enqueued;
+}

--- a/src/lib/canvas/worker-entry.ts
+++ b/src/lib/canvas/worker-entry.ts
@@ -32,6 +32,7 @@ import {
 import { processVaultImport } from "../vault/import-worker";
 import { processVaultExport } from "../vault/export-worker.js";
 import { cleanupMarketingData } from "../marketing/retention";
+import { dispatchFairCanvasFiles } from "./import-scheduler";
 
 const STUCK_JOB_THRESHOLD = "1 hour";
 const STUCK_JOB_CHECK_INTERVAL_MS = 5 * 60 * 1000;
@@ -202,6 +203,7 @@ setInterval(runMarketingCleanup, MARKETING_CLEANUP_INTERVAL_MS);
 setInterval(async () => {
   try {
     await claimOrphanedJobs();
+    await dispatchFairCanvasFiles(MAX_CONCURRENT_JOBS);
   } catch (err) {
     console.error(`[${new Date().toISOString()}] DB poll error:`, errorMessage(err));
   }

--- a/src/lib/chat/final-answer.ts
+++ b/src/lib/chat/final-answer.ts
@@ -27,6 +27,7 @@ export async function streamFinalAnswer(options: {
   messages: ModelMessage[];
   maxOutputTokens: number;
   onTextDelta: (text: string) => void;
+  abortSignal?: AbortSignal;
 }): Promise<FinalAnswerResult> {
   const [firstMessage, ...remainingMessages] = options.messages;
   const messages: ModelMessage[] =
@@ -47,6 +48,7 @@ export async function streamFinalAnswer(options: {
     model: options.model,
     messages,
     maxOutputTokens: options.maxOutputTokens,
+    abortSignal: options.abortSignal,
     providerOptions: {
       openrouter: { reasoning: { enabled: false, effort: "none" } },
     },

--- a/src/lib/chat/generate-background.ts
+++ b/src/lib/chat/generate-background.ts
@@ -50,14 +50,23 @@ import {
 } from "@/lib/chat/stream-events";
 import {
   appendChatGenerationEvent,
+  cancelChatGeneration,
   claimChatGeneration,
   completeChatGeneration,
   failChatGeneration,
+  isChatGenerationCancelRequested,
   loadChatGeneration,
   requeueChatGeneration,
   resetChatGenerationEvents,
 } from "@/lib/chat/generation-store";
+import {
+  hasFreshChatPresence,
+  resolveAbortReason,
+  type AbortReason,
+} from "@/lib/chat/presence";
 import { toSseEvent } from "@/lib/chat/sse";
+
+const WATCHDOG_INTERVAL_MS = 5_000;
 
 const EMPTY_RAG_RESULT: RagResult = {
   searchResults: [],
@@ -109,7 +118,73 @@ export async function processChatGeneration(
     | Awaited<ReturnType<typeof buildLlmCall>>["canvasMcpClient"]
     | undefined;
 
+  // Watchdog: aborts the LLM stream on explicit stop or real disconnect.
+  // A user who never had browser presence (pure API usage) is never
+  // disconnect-cancelled — only the explicit cancel flag applies to them.
+  const abortController = new AbortController();
+  let abortReason: AbortReason = null;
+  let sawPresence = false;
+  let firstAbsentAt: number | null = null;
+  let watchdogBusy = false;
+  const watchdogTick = async (): Promise<void> => {
+    if (watchdogBusy || abortReason) return;
+    watchdogBusy = true;
+    try {
+      const cancelRequested = await isChatGenerationCancelRequested(generationId);
+      const present = cancelRequested ? false : await hasFreshChatPresence(userId);
+      if (present) {
+        sawPresence = true;
+        firstAbsentAt = null;
+      } else if (firstAbsentAt === null) {
+        firstAbsentAt = Date.now();
+      }
+      const reason = resolveAbortReason({
+        cancelRequested,
+        present,
+        sawPresence,
+        firstAbsentAt,
+        now: Date.now(),
+      });
+      if (reason) {
+        abortReason = reason;
+        abortController.abort();
+      }
+    } catch {
+      // presence/redis hiccups must never abort a generation
+    } finally {
+      watchdogBusy = false;
+    }
+  };
+  const watchdog = setInterval(() => void watchdogTick(), WATCHDOG_INTERVAL_MS);
+  void watchdogTick();
+
+  // Assigned once streamed state exists so the catch path can persist the
+  // partial answer; before that a cancel simply finishes with no message.
+  let finalizeCancelled: (() => Promise<void>) | null = null;
+  let cancelFinalized = false;
+  const finishCancelled = async (): Promise<void> => {
+    if (cancelFinalized) return;
+    cancelFinalized = true;
+    if (finalizeCancelled) {
+      await finalizeCancelled();
+      return;
+    }
+    sendDone(writer);
+    await writer.flush();
+    await cancelChatGeneration(generationId);
+    logger.info("Background chat generation cancelled", {
+      generationId,
+      sessionId,
+      reason: abortReason ?? "stopped",
+      elapsedMs: Date.now() - startedAt,
+    });
+  };
+
   try {
+    if (await isChatGenerationCancelRequested(generationId)) {
+      await finishCancelled();
+      return;
+    }
     if (attempt > 1) {
       await resetChatGenerationEvents(generationId);
       await appendChatGenerationEvent(generationId, toSseEvent("reset", {}));
@@ -205,7 +280,45 @@ export async function processChatGeneration(
       ...overrides,
     });
 
-    const result = streamText({ model: llm.model, ...llm.llmCallOptions });
+    finalizeCancelled = async () => {
+      closeThinkingWindow();
+      flushText();
+      if (reply.trim() || parts.length > 0) {
+        await persistMessage(sessionId, "assistant", reply, {
+          parts,
+          sources: uniqueSources,
+          metadata: metadata({
+            partial: true,
+            cancelled: true,
+            error:
+              abortReason === "disconnected"
+                ? "Interrupted — you left the chat"
+                : "Stopped",
+          }),
+        });
+      }
+      sendDone(writer);
+      await writer.flush();
+      await cancelChatGeneration(generationId);
+      logger.info("Background chat generation cancelled", {
+        generationId,
+        sessionId,
+        reason: abortReason ?? "stopped",
+        elapsedMs: Date.now() - startedAt,
+        replyLength: reply.length,
+      });
+    };
+
+    if (abortReason) {
+      await finishCancelled();
+      return;
+    }
+
+    const result = streamText({
+      model: llm.model,
+      abortSignal: abortController.signal,
+      ...llm.llmCallOptions,
+    });
     for await (const part of result.fullStream) {
       if (part.type === "reasoning-delta") {
         if (!thinkingStartedAt) thinkingStartedAt = Date.now();
@@ -236,9 +349,15 @@ export async function processChatGeneration(
       } else if (part.type === "finish") {
         finishReason = part.finishReason;
         rawFinishReason = part.rawFinishReason;
+      } else if (part.type === "abort") {
+        break;
       } else if (part.type === "error") {
         throw part.error instanceof Error ? part.error : new Error(String(part.error));
       }
+    }
+    if (abortReason || abortController.signal.aborted) {
+      await finishCancelled();
+      return;
     }
     responseMessages = (await result.response).messages;
     closeThinkingWindow();
@@ -261,6 +380,7 @@ export async function processChatGeneration(
         }
         const finalAnswer = await streamFinalAnswer({
           model: llm.model,
+          abortSignal: abortController.signal,
           messages: [...llm.llmCallOptions.messages, ...responseMessages],
           maxOutputTokens: llm.llmCallOptions.maxOutputTokens,
           onTextDelta(text) {
@@ -296,6 +416,24 @@ export async function processChatGeneration(
       replyLength: reply.length,
     });
   } catch (error) {
+    // A watchdog abort surfaces as an AbortError (or an SDK error part) —
+    // that's a clean cancel, not a failure: persist the partial, no retry.
+    if (abortReason || abortController.signal.aborted) {
+      try {
+        await finishCancelled();
+      } catch (cancelError) {
+        logger.error("Failed to finalize cancelled chat generation", {
+          generationId,
+          sessionId,
+          error:
+            cancelError instanceof Error
+              ? cancelError.message
+              : String(cancelError),
+        });
+        await cancelChatGeneration(generationId).catch(() => {});
+      }
+      return;
+    }
     void Metrics.llmError();
     const detail = error instanceof Error ? error.message : String(error);
     logger.error("Background chat generation failed", { generationId, sessionId, error: detail });
@@ -308,6 +446,7 @@ export async function processChatGeneration(
     }
     throw error;
   } finally {
+    clearInterval(watchdog);
     await canvasMcpClient?.close().catch(() => {});
   }
 }

--- a/src/lib/chat/generation-store.ts
+++ b/src/lib/chat/generation-store.ts
@@ -4,6 +4,7 @@ import { generateUUID } from "@/lib/utils/uuid";
 
 const EVENT_TTL_SECONDS = 60 * 60;
 const EVENT_MAX_LENGTH = 4_000;
+const CANCEL_FLAG_TTL_SECONDS = 60 * 60;
 
 export interface ChatGenerationPayload {
   userId: string;
@@ -46,6 +47,10 @@ function normalizeGenerationRecord(
 
 function eventKey(generationId: string): string {
   return `chat-generation:${generationId}:events`;
+}
+
+function cancelKey(generationId: string): string {
+  return `chat-generation:${generationId}:cancel`;
 }
 
 export async function createChatGeneration(
@@ -132,6 +137,38 @@ export async function failChatGeneration(
     FROM app.chat_generations g
     WHERE g.id = ${generationId}::uuid AND s.id = g.session_id
   `;
+}
+
+/**
+ * Terminal cancel: the worker aborted (user stop or disconnect) or the
+ * generation was cancelled before it started. Any partial assistant message
+ * has already been persisted, so the session returns to plain 'idle'.
+ */
+export async function cancelChatGeneration(generationId: string): Promise<void> {
+  await sql`
+    UPDATE app.chat_generations
+    SET status = 'cancelled', completed_at = NOW(), updated_at = NOW()
+    WHERE id = ${generationId}::uuid AND status <> 'completed'
+  `;
+  await sql`
+    UPDATE app.chat_sessions s
+    SET generation_status = 'idle', updated_at = NOW()
+    FROM app.chat_generations g
+    WHERE g.id = ${generationId}::uuid AND s.id = g.session_id
+  `;
+}
+
+/** Ask an in-flight worker to abort. Observed by the generation watchdog. */
+export async function requestChatGenerationCancel(
+  generationId: string,
+): Promise<void> {
+  await redis.set(cancelKey(generationId), "1", "EX", CANCEL_FLAG_TTL_SECONDS);
+}
+
+export async function isChatGenerationCancelRequested(
+  generationId: string,
+): Promise<boolean> {
+  return (await redis.exists(cancelKey(generationId))) === 1;
 }
 
 export async function requeueChatGeneration(

--- a/src/lib/chat/hooks/use-chat-stream.ts
+++ b/src/lib/chat/hooks/use-chat-stream.ts
@@ -221,8 +221,18 @@ export function useChatStream(
   const [error, setError] = useState<string | null>(null);
   const thinkingStartRef = useRef<number | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  // durable background generation being consumed — lets Stop cancel the worker
+  const activeGenerationRef = useRef<string | null>(null);
 
   const cancel = useCallback(() => {
+    const generationId = activeGenerationRef.current;
+    if (generationId) {
+      // fire-and-forget: the worker watchdog aborts the LLM stream server-side
+      activeGenerationRef.current = null;
+      void fetch(`/api/chat/generations/${generationId}/cancel`, {
+        method: "POST",
+      }).catch(() => {});
+    }
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
     setLoading(false);
@@ -540,26 +550,33 @@ export function useChatStream(
     userText: string,
     signal: AbortSignal,
   ): Promise<void> {
+    activeGenerationRef.current = generationId;
     let afterId = "0-0";
     let attempts = 0;
-    while (!signal.aborted) {
-      try {
-        const response = await fetch(
-          `/api/chat/generations/${generationId}/stream?after=${encodeURIComponent(afterId)}`,
-          { headers: { Accept: "text/event-stream" }, signal },
-        );
-        if (!response.ok || !response.body) {
-          throw new Error(`Unable to resume response (${response.status})`);
+    try {
+      while (!signal.aborted) {
+        try {
+          const response = await fetch(
+            `/api/chat/generations/${generationId}/stream?after=${encodeURIComponent(afterId)}`,
+            { headers: { Accept: "text/event-stream" }, signal },
+          );
+          if (!response.ok || !response.body) {
+            throw new Error(`Unable to resume response (${response.status})`);
+          }
+          await consumeStream(response.body, assistantId, userText, (id) => {
+            afterId = id;
+          });
+          return;
+        } catch (error) {
+          if (signal.aborted) throw error;
+          attempts += 1;
+          if (attempts >= 4) throw error;
+          await new Promise<void>((resolve) => setTimeout(resolve, attempts * 500));
         }
-        await consumeStream(response.body, assistantId, userText, (id) => {
-          afterId = id;
-        });
-        return;
-      } catch (error) {
-        if (signal.aborted) throw error;
-        attempts += 1;
-        if (attempts >= 4) throw error;
-        await new Promise<void>((resolve) => setTimeout(resolve, attempts * 500));
+      }
+    } finally {
+      if (activeGenerationRef.current === generationId) {
+        activeGenerationRef.current = null;
       }
     }
   }

--- a/src/lib/chat/presence.ts
+++ b/src/lib/chat/presence.ts
@@ -1,0 +1,96 @@
+// Per-user, per-tab presence for chat generation cancellation.
+//
+// Every open app tab heartbeats its own field inside one Redis hash per user.
+// A tab-close beacon removes its field immediately; a crashed tab simply goes
+// stale. The chat worker treats "no fresh field" as the user being gone —
+// in-app navigation never touches this signal, so it can never cancel work.
+import { redis } from "@/lib/redis";
+
+/** Heartbeat cadence for visible tabs (hidden tabs are browser-throttled to ~60s). */
+export const PRESENCE_HEARTBEAT_MS = 10_000;
+
+/**
+ * A tab field older than this no longer counts as presence. Must comfortably
+ * exceed the ~60s timer throttling browsers apply to hidden tabs.
+ */
+export const PRESENCE_STALE_MS = 90_000;
+
+/**
+ * Continuous absence required before a disconnect aborts a generation.
+ * A refresh re-announces the same tab within ~2-5s, well inside this window.
+ */
+export const DISCONNECT_GRACE_MS = 15_000;
+
+/** Hash lifetime — long enough that an idle-but-open tab never loses its entry. */
+const PRESENCE_TTL_SECONDS = 15 * 60;
+
+const TAB_ID_RE = /^[a-zA-Z0-9-]{1,64}$/;
+
+function presenceKey(userId: string): string {
+  return `chat:presence:{${userId}}`;
+}
+
+export function isValidPresenceTabId(value: unknown): value is string {
+  return typeof value === "string" && TAB_ID_RE.test(value);
+}
+
+export async function recordChatPresence(
+  userId: string,
+  tabId: string,
+): Promise<void> {
+  const key = presenceKey(userId);
+  await redis.hset(key, tabId, Date.now());
+  await redis.expire(key, PRESENCE_TTL_SECONDS);
+}
+
+export async function removeChatPresence(
+  userId: string,
+  tabId: string,
+): Promise<void> {
+  await redis.hdel(presenceKey(userId), tabId);
+}
+
+/** True when any tab heartbeated within PRESENCE_STALE_MS. */
+export async function hasFreshChatPresence(
+  userId: string,
+  staleMs = PRESENCE_STALE_MS,
+): Promise<boolean> {
+  const entries = await redis.hgetall(presenceKey(userId));
+  const cutoff = Date.now() - staleMs;
+  return Object.values(entries ?? {}).some((value) => {
+    const ts = Number.parseInt(String(value), 10);
+    return Number.isFinite(ts) && ts >= cutoff;
+  });
+}
+
+export type AbortReason = "stopped" | "disconnected" | null;
+
+export interface AbortDecisionInput {
+  cancelRequested: boolean;
+  present: boolean;
+  /** user had presence at some point during this generation — guards pure API usage */
+  sawPresence: boolean;
+  /** ms timestamp when continuous absence began, or null while present */
+  firstAbsentAt: number | null;
+  now: number;
+  graceMs?: number;
+}
+
+/**
+ * Pure decision for the worker watchdog. An explicit cancel always wins;
+ * absence only aborts after it has lasted a full grace window, and only for
+ * users that were actually present during this generation.
+ */
+export function resolveAbortReason(input: AbortDecisionInput): AbortReason {
+  if (input.cancelRequested) return "stopped";
+  const graceMs = input.graceMs ?? DISCONNECT_GRACE_MS;
+  if (
+    !input.present &&
+    input.sawPresence &&
+    input.firstAbsentAt !== null &&
+    input.now - input.firstAbsentAt >= graceMs
+  ) {
+    return "disconnected";
+  }
+  return null;
+}

--- a/src/lib/chat/presence.ts
+++ b/src/lib/chat/presence.ts
@@ -24,6 +24,13 @@ export const DISCONNECT_GRACE_MS = 15_000;
 /** Hash lifetime — long enough that an idle-but-open tab never loses its entry. */
 const PRESENCE_TTL_SECONDS = 15 * 60;
 
+/**
+ * Dead tab fields (closes whose beacon was lost) accumulate inside a hash
+ * that a long-lived tab keeps refreshing. Pruning kicks in only past this
+ * field count so the common heartbeat stays at two Redis ops.
+ */
+const PRESENCE_PRUNE_THRESHOLD = 8;
+
 const TAB_ID_RE = /^[a-zA-Z0-9-]{1,64}$/;
 
 function presenceKey(userId: string): string {
@@ -41,6 +48,22 @@ export async function recordChatPresence(
   const key = presenceKey(userId);
   await redis.hset(key, tabId, Date.now());
   await redis.expire(key, PRESENCE_TTL_SECONDS);
+
+  try {
+    if ((await redis.hlen(key)) <= PRESENCE_PRUNE_THRESHOLD) return;
+    const entries = await redis.hgetall(key);
+    const cutoff = Date.now() - PRESENCE_STALE_MS;
+    const stale = Object.entries(entries ?? {})
+      .filter(([field, value]) => {
+        if (field === tabId) return false;
+        const ts = Number.parseInt(String(value), 10);
+        return !Number.isFinite(ts) || ts < cutoff;
+      })
+      .map(([field]) => field);
+    if (stale.length > 0) await redis.hdel(key, ...stale);
+  } catch {
+    // pruning is hygiene, not correctness — the key's TTL still bounds it
+  }
 }
 
 export async function removeChatPresence(

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -32,6 +32,8 @@ export interface MessageMetadata {
   partial?: boolean;
   error?: string;
   toolCallLimitHit?: boolean;
+  /** true when the generation was aborted (user stop or disconnect) */
+  cancelled?: boolean;
 }
 
 export interface Message {

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -282,7 +282,7 @@ export async function enqueueExtractRetryJob(
   delaySeconds: number,
 ): Promise<void> {
   if (getQueueProvider() === "cloudflare") {
-    await sendCloudflareQueueMessage(EXTRACT_RETRY_QUEUE, {
+    await sendCloudflareQueueMessage(CANVAS_IMPORT_QUEUE, {
       body: { type: "extract-retry", ...data },
       content_type: "json",
       delay_seconds: delaySeconds,
@@ -290,7 +290,7 @@ export async function enqueueExtractRetryJob(
     return;
   }
 
-  await getExtractRetryQueue().add(
+  await getCanvasImportQueue().add(
     "extract-retry",
     { type: "extract-retry", ...data },
     { ...DEFAULT_OPTS, delay: delaySeconds * 1000 },

--- a/src/lib/rateLimitConfig.ts
+++ b/src/lib/rateLimitConfig.ts
@@ -16,6 +16,9 @@ export interface RateLimitRule {
 export const RATE_LIMITS: Record<string, RateLimitRule> = {
   // tier 1 — expensive external API calls
   'chat':           { limit: 120, windowSeconds: 3600,  keyType: 'userId' },
+  // presence heartbeats fire every ~10s per open tab plus visibility events
+  'chat-presence':  { limit: 1200, windowSeconds: 3600, keyType: 'userId' },
+  'chat-cancel':    { limit: 120, windowSeconds: 3600,  keyType: 'userId' },
   'extract':        { limit: 10,  windowSeconds: 3600,  keyType: 'userId' },
   'canvas-connect': { limit: 10,  windowSeconds: 3600,  keyType: 'userId' },
 


### PR DESCRIPTION
## Summary

- add provider-neutral weighted fair Canvas import scheduling with 1:3:5 free/semester/academic-year service shares and per-user round robin
- move delayed extraction retries into the shared import queue while retaining the legacy retry consumer for in-flight messages
- cancel queued or running chat generations from Stop, preserving partial responses
- track per-tab presence so genuinely disconnected users stop consuming generation capacity after a grace period
- keep high-frequency presence authentication and Redis heartbeats lightweight

## Database

- migration 047 adds local import service-class entitlement state and scheduler tables/dispatch metadata

## Verification

- repository pre-commit gate passed on the import change: lint, i18n audit, typecheck, full Vitest suite, and Dockerfile.marker validation
- promotion PR checks must pass before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable “Stop generating” support for active and background chat responses.
  * Chat generation now recognizes tab disconnects and can preserve partial responses while cancelling gracefully.
  * Improved fairness for Canvas imports, balancing processing across service levels and preventing one user from monopolizing capacity.

* **Bug Fixes**
  * Client-disconnected AI streams now stop promptly.
  * Delayed extraction retries rejoin the shared Canvas import queue for more consistent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->