### PR TITLE
Fix new-note persistence IDs

### DIFF
--- a/src/__tests__/lib/schemas.test.ts
+++ b/src/__tests__/lib/schemas.test.ts
@@ -44,6 +44,17 @@ describe("noteCreateSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("preserves a valid optimistic note id", () => {
+    const id = "550e8400-e29b-41d4-a716-446655440000";
+    const result = noteCreateSchema.safeParse({ id, title: "Hello" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.id).toBe(id);
+  });
+
+  it("rejects an invalid optimistic note id", () => {
+    expect(noteCreateSchema.safeParse({ id: "not-a-uuid" }).success).toBe(false);
+  });
+
   it("rejects title exceeding 500 characters", () => {
     expect(noteCreateSchema.safeParse({ title: "a".repeat(501) }).success).toBe(
       false,

--- a/src/app/api/notes/route.js
+++ b/src/app/api/notes/route.js
@@ -87,8 +87,9 @@ export const POST = withErrorHandler(async (request) => {
     throw new ApiError(400, `Content must be ${MAX_CONTENT_LENGTH} bytes or fewer`);
   }
 
-  // Generate UUID v7 for note
-  const noteId = generateUUID();
+  // The notes UI creates an optimistic UUID before POSTing so its tree item and
+  // route point at the same persisted note. API-only callers may omit it.
+  const noteId = body.id || generateUUID();
 
   // Create new note in PostgreSQL
   const isFolder = body.isFolder === true || body.is_folder === true;

--- a/src/lib/validations/schemas.ts
+++ b/src/lib/validations/schemas.ts
@@ -6,6 +6,7 @@ import { NextResponse } from "next/server";
 export const uuidParam = z.string().uuid();
 
 export const noteCreateSchema = z.object({
+  id: z.string().uuid().optional(),
   title: z.string().max(500).optional(),
   content: z.string().optional(),
   isFolder: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- preserve the optimistic UUID generated by the notes UI through request validation
- persist that same UUID in the notes API so the new tree item and route resolve immediately
- reject malformed client note IDs while retaining server-generated IDs for API callers that omit one

## Production finding

A real test-account smoke test found the UI routed to its optimistic ID while the API silently generated a different ID, causing 404s and duplicate Untitled entries.

## Verification

- full pre-commit gate passed
- 132 test files / 878 tests passed
- typecheck, lint, i18n audit, and Dockerfile validation passed