### PR TITLE
Fix CPU-only PDF extraction in deploys

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,6 +152,7 @@ pipeline {
                         -e MIGRATION_DATABASE_URL= \
                         -e DEPLOY_ENV="$DEPLOY_ENV" \
                         -e QUEUE_PREFIX="$QUEUE_PREFIX" \
+                        -e MARKER_OCR_ENABLED=false \
                         -e QDRANT_URL=http://oghma-qdrant:6333 \
                         -e QDRANT_COLLECTION=oghma_${DEPLOY_ENV}_chunks \
                         "$WORKER_IMAGE" \
@@ -198,6 +199,7 @@ pipeline {
                           -e MIGRATION_DATABASE_URL= \
                           -e DEPLOY_ENV="\$DEPLOY_ENV" \
                           -e QUEUE_PREFIX="\$QUEUE_PREFIX" \
+                          -e MARKER_OCR_ENABLED=false \
                           -e QDRANT_URL=http://oghma-qdrant:6333 \
                           -e QDRANT_COLLECTION=oghma_\${DEPLOY_ENV}_chunks \
                           --memory "\$APP_MEM" \
@@ -235,6 +237,7 @@ pipeline {
                           -e MIGRATION_DATABASE_URL= \
                           -e DEPLOY_ENV="\$DEPLOY_ENV" \
                           -e QUEUE_PREFIX="\$QUEUE_PREFIX" \
+                          -e MARKER_OCR_ENABLED=false \
                           -e QDRANT_URL=http://oghma-qdrant:6333 \
                           -e QDRANT_COLLECTION=oghma_\${DEPLOY_ENV}_chunks \
                           --memory "\$APP_MEM" \
@@ -304,6 +307,7 @@ pipeline {
                           -e MIGRATION_DATABASE_URL= \
                           -e DEPLOY_ENV="\$DEPLOY_ENV" \
                           -e QUEUE_PREFIX="\$QUEUE_PREFIX" \
+                          -e MARKER_OCR_ENABLED=false \
                           -e QDRANT_URL=http://oghma-qdrant:6333 \
                           -e QDRANT_COLLECTION=oghma_\${DEPLOY_ENV}_chunks \
                           --memory "\$WORKER_MEM" \
@@ -338,6 +342,7 @@ pipeline {
                           -e MIGRATION_DATABASE_URL= \
                           -e DEPLOY_ENV="\$DEPLOY_ENV" \
                           -e QUEUE_PREFIX="\$QUEUE_PREFIX" \
+                          -e MARKER_OCR_ENABLED=false \
                           -e QDRANT_URL=http://oghma-qdrant:6333 \
                           -e QDRANT_COLLECTION=oghma_\${DEPLOY_ENV}_chunks \
                           --memory "\$WORKER_MEM" \

--- a/src/__tests__/lib/canvas-import-extraction.test.ts
+++ b/src/__tests__/lib/canvas-import-extraction.test.ts
@@ -56,9 +56,55 @@ import sql from "@/database/pgsql.js";
 import { getStorageProvider } from "@/lib/storage/init";
 import { processRagPipeline } from "@/lib/canvas/import-embedding.js";
 import {
+  processDirectExtraction,
   processExtractionRetry,
   processMarkerComplete,
 } from "@/lib/canvas/import-extraction.js";
+
+describe("processDirectExtraction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes the original binary object buffer to PDF extraction", async () => {
+    const pdfBuffer = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0xff, 0x00]);
+    const getObjectAndMeta = vi.fn().mockResolvedValue({ buffer: pdfBuffer });
+
+    vi.mocked(sql)
+      .mockResolvedValueOnce([{ status: "pending" }] as never)
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([{ parent_id: null }] as never)
+      .mockResolvedValueOnce([] as never);
+    vi.mocked(getStorageProvider).mockReturnValue({ getObjectAndMeta } as never);
+    vi.mocked(processRagPipeline).mockResolvedValue({
+      noteId: "note-123",
+      chunksStored: 2,
+    } as never);
+
+    await processDirectExtraction({
+      noteId: "note-123",
+      userId: "user-123",
+      s3Key: "notes/note-123/lecture.pdf",
+      filename: "lecture.pdf",
+      mimeType: "application/pdf",
+    });
+
+    expect(getObjectAndMeta).toHaveBeenCalledWith(
+      "notes/note-123/lecture.pdf",
+    );
+    expect(processRagPipeline).toHaveBeenCalledWith(
+      "note-123",
+      "user-123",
+      null,
+      pdfBuffer,
+      expect.objectContaining({
+        filename: "lecture.pdf",
+        mimeType: "application/pdf",
+      }),
+      expect.any(Function),
+    );
+  });
+});
 
 describe("processMarkerComplete", () => {
   beforeEach(() => {

--- a/src/lib/canvas/import-extraction.js
+++ b/src/lib/canvas/import-extraction.js
@@ -717,7 +717,8 @@ export async function processDirectExtraction(msg) {
   `;
 
   const storage = getStorageProvider();
-  const buffer = await storage.getObject(s3Key);
+  const objectData = await storage.getObjectAndMeta(s3Key);
+  const buffer = objectData?.buffer;
   if (!buffer) {
     await sql`
       UPDATE app.ingestion_jobs


### PR DESCRIPTION
## Summary
- explicitly disable Marker OCR in app, worker, and retry-drain containers
- preserve uploaded PDF bytes by using the binary storage result in direct extraction
- guarantee imports use the built-in CPU PDF parser even if a Marker URL later appears in an env file
- add a regression test proving the original binary buffer reaches the extraction pipeline

## Live finding
Production direct uploads reached the CPU fallback but produced zero chunks because `getObject()` decoded binary PDF bytes as text. The worker now reads `getObjectAndMeta().buffer`, matching the already-correct retry path.

## Verification
- full precommit suite: lint, i18n audit, typecheck, 899 tests
- Dockerfile.marker validation
- Jenkinsfile hard override on all five relevant container launches