### PR TITLE
Default Marker OCR to disabled

### DIFF
--- a/src/__tests__/lib/extraction-core.test.ts
+++ b/src/__tests__/lib/extraction-core.test.ts
@@ -25,18 +25,34 @@ describe("Marker OCR environment toggle", () => {
     vi.clearAllMocks();
   });
 
-  it("uses configured Marker OCR by default", async () => {
+  it("bypasses configured Marker OCR by default", async () => {
     const result = await extractContentFromBuffer({
       buffer: Buffer.from("document"),
       filename: "lecture.docx",
       mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     });
 
-    expect(extractWithMarker).toHaveBeenCalledOnce();
-    expect(result.source).toBe("marker");
+    expect(extractWithMarker).not.toHaveBeenCalled();
+    expect(result.source).toBe("skipped");
   });
 
-  it.each(["false", "0", "off", " FALSE "])(
+  it.each(["true", "1", "on", " TRUE "])(
+    "uses Marker OCR only when MARKER_OCR_ENABLED=%s",
+    async (value) => {
+      process.env.MARKER_OCR_ENABLED = value;
+
+      const result = await extractContentFromBuffer({
+        buffer: Buffer.from("document"),
+        filename: "lecture.docx",
+        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      });
+
+      expect(extractWithMarker).toHaveBeenCalledOnce();
+      expect(result.source).toBe("marker");
+    },
+  );
+
+  it.each(["false", "0", "off", " FALSE ", "unexpected"])(
     "bypasses Marker OCR when MARKER_OCR_ENABLED=%s",
     async (value) => {
       process.env.MARKER_OCR_ENABLED = value;

--- a/src/lib/ingestion/extraction-core.ts
+++ b/src/lib/ingestion/extraction-core.ts
@@ -28,7 +28,7 @@ function isTextLikeFile(filename: string, mimeType?: string): boolean {
 
 function markerOcrEnabled(): boolean {
   const value = process.env.MARKER_OCR_ENABLED?.trim().toLowerCase();
-  return !["0", "false", "off"].includes(value ?? "");
+  return ["1", "true", "on"].includes(value ?? "");
 }
 
 async function extractPdfTextLayer(


### PR DESCRIPTION
## Summary
- make Marker OCR opt-in instead of opt-out
- require `MARKER_OCR_ENABLED=true`, `1`, or `on` before calling Marker
- keep CPU `pdf-parse` as the default PDF path even if deployment env propagation is incomplete
- cover default, enabled, disabled, whitespace, and unexpected values

## Verification
- full precommit suite: lint, i18n audit, typecheck, 908 tests
- Dockerfile.marker validation
- live production PDF parsed through the corrected binary path: 53,914 characters / 129 chunks / source `pdf-parse`