### PR TITLE
Fix PDF uploads and make indexing CPU-first

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,7 @@ VAULT_JOBS_ENABLED=true
 # Document extraction
 MARKER_API_URL=
 # Set false to bypass Marker/GPU OCR and use local text-layer extraction only.
-MARKER_OCR_ENABLED=true
+MARKER_OCR_ENABLED=false
 # Optional shared secret for protected Marker servers.
 MARKER_API_TOKEN=
 # Historical/emergency/benchmark only. Do not use Datalab/managed document APIs as the steady-state launch import path.

--- a/.env.production.template
+++ b/.env.production.template
@@ -77,7 +77,7 @@ VAULT_JOBS_ENABLED=true
 # Document extraction
 MARKER_API_URL=
 # Set false to bypass Marker/GPU OCR and use local text-layer extraction only.
-MARKER_OCR_ENABLED=true
+MARKER_OCR_ENABLED=false
 # Optional shared secret for protected Marker servers.
 MARKER_API_TOKEN=
 # Historical/emergency/benchmark only. Do not use Datalab/managed document APIs as the steady-state launch import path.

--- a/src/__tests__/lib/canvas-import-extraction.test.ts
+++ b/src/__tests__/lib/canvas-import-extraction.test.ts
@@ -103,6 +103,12 @@ describe("processDirectExtraction", () => {
       }),
       expect.any(Function),
     );
+
+    const completionQuery = vi
+      .mocked(sql)
+      .mock.calls.map((call: any[]) => call[0]?.join(""))
+      .find((query: string | undefined) => query?.includes("SET status = 'done'"));
+    expect(completionQuery).toContain("chunks_stored");
   });
 });
 

--- a/src/__tests__/lib/detect-mime.test.ts
+++ b/src/__tests__/lib/detect-mime.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { detectMimeType } from "@/lib/uploads/detect-mime";
+
+describe("detectMimeType", () => {
+  it("detects an extensionless PDF from its bytes without a browser MIME type", () => {
+    const pdf = Buffer.from("%PDF-1.7\n");
+    expect(
+      detectMimeType(
+        pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength),
+        "",
+      ),
+    ).toBe("application/pdf");
+  });
+
+  it("accepts a declared MIME type when the signature matches", () => {
+    const pdf = Buffer.from("%PDF-1.7\n");
+    expect(
+      detectMimeType(
+        pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength),
+        "application/pdf",
+      ),
+    ).toBe("application/pdf");
+  });
+
+  it("replaces a generic browser MIME type with the detected PDF type", () => {
+    const pdf = Buffer.from("%PDF-1.7\n");
+    expect(
+      detectMimeType(
+        pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength),
+        "application/octet-stream",
+      ),
+    ).toBe("application/pdf");
+  });
+
+  it("rejects a declared MIME type that conflicts with the bytes", () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+    expect(
+      detectMimeType(
+        png.buffer.slice(png.byteOffset, png.byteOffset + png.byteLength),
+        "application/pdf",
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/__tests__/lib/extraction-core.test.ts
+++ b/src/__tests__/lib/extraction-core.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const extractWithMarker = vi.hoisted(() => vi.fn());
+const getPdfText = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/ocr", () => ({ extractWithMarker }));
+vi.mock("pdf-parse", () => ({
+  PDFParse: class {
+    getText = getPdfText;
+  },
+}));
 
 import { extractContentFromBuffer } from "@/lib/ingestion/extraction-core";
 
@@ -17,6 +23,7 @@ describe("Marker OCR environment toggle", () => {
       metadata: null,
       pageRange: null,
     });
+    getPdfText.mockResolvedValue({ text: "CPU text layer" });
   });
 
   afterEach(() => {
@@ -51,6 +58,20 @@ describe("Marker OCR environment toggle", () => {
       expect(result.source).toBe("marker");
     },
   );
+
+  it("uses CPU PDF parsing before Marker even when Marker is enabled", async () => {
+    process.env.MARKER_OCR_ENABLED = "true";
+
+    const result = await extractContentFromBuffer({
+      buffer: Buffer.from("%PDF-1.7"),
+      filename: "lecture",
+      mimeType: "application/pdf",
+    });
+
+    expect(result.source).toBe("pdf-parse");
+    expect(result.rawText).toBe("CPU text layer");
+    expect(extractWithMarker).not.toHaveBeenCalled();
+  });
 
   it.each(["false", "0", "off", " FALSE ", "unexpected"])(
     "bypasses Marker OCR when MARKER_OCR_ENABLED=%s",

--- a/src/__tests__/lib/file-spec.test.ts
+++ b/src/__tests__/lib/file-spec.test.ts
@@ -36,6 +36,10 @@ describe('inferFileType', () => {
     it('handles titles with multiple dots', () => {
         expect(inferFileType('my.lecture.notes.pdf')).toBe('pdf');
     });
+
+    it('uses persisted MIME type when the title has no extension', () => {
+        expect(inferFileType('Lecture slides', 'application/pdf')).toBe('pdf');
+    });
 });
 
 describe('buildFileSpec', () => {
@@ -50,6 +54,12 @@ describe('buildFileSpec', () => {
         const spec = buildFileSpec({ id: '2', title: 'doc.pdf', content: 'fallback', s3Key: 'uploads/doc.pdf' });
         expect(spec.fileType).toBe('pdf');
         expect(spec.sourcePath).toBe('uploads/doc.pdf');
+    });
+
+    it('builds an extensionless PDF spec from attachment metadata', () => {
+        const spec = buildFileSpec({ id: '2', title: 'Lecture slides', s3Key: 'uploads/slides', mimeType: 'application/pdf' });
+        expect(spec.fileType).toBe('pdf');
+        expect(spec.sourcePath).toBe('uploads/slides');
     });
 
     it('falls back to content for media when s3Key is missing', () => {

--- a/src/__tests__/lib/map-note.test.js
+++ b/src/__tests__/lib/map-note.test.js
@@ -7,6 +7,7 @@ const FULL_ROW = {
     content: '# Hello',
     is_folder: false,
     s3_key: 'uploads/file.pdf',
+    mime_type: 'application/pdf',
     deleted: 0,
     shared: 0,
     pinned: 1,
@@ -22,6 +23,7 @@ describe('mapNoteFromDB', () => {
         expect(result.content).toBe('# Hello');
         expect(result.isFolder).toBe(false);
         expect(result.s3Key).toBe('uploads/file.pdf');
+        expect(result.mimeType).toBe('application/pdf');
         expect(result.deleted).toBe(0);
         expect(result.shared).toBe(0);
         expect(result.pinned).toBe(1);

--- a/src/app/api/notes/[id]/route.ts
+++ b/src/app/api/notes/[id]/route.ts
@@ -28,6 +28,7 @@ interface NoteSummaryRow {
   content: string;
   is_folder: boolean;
   s3_key: string | null;
+  mime_type: string | null;
   shared: number;
   pinned: number;
   created_at: string;
@@ -73,11 +74,15 @@ export const GET = withErrorHandler(async (request: NextRequest, { params }: Not
   }
 
   const rows = (await sql`
-     SELECT note_id, title, content, is_folder, s3_key, shared, pinned, created_at, updated_at
-     FROM app.notes
-     WHERE note_id = ${noteId}::uuid
-       AND user_id = ${user.user_id}::uuid
-       AND deleted_at IS NULL
+     SELECT n.note_id, n.title, n.content, n.is_folder, n.s3_key, n.shared, n.pinned,
+            n.created_at, n.updated_at,
+            (SELECT a.mime_type FROM app.attachments a
+             WHERE a.note_id = n.note_id AND a.user_id = n.user_id AND a.s3_key = n.s3_key
+             LIMIT 1) AS mime_type
+     FROM app.notes n
+     WHERE n.note_id = ${noteId}::uuid
+       AND n.user_id = ${user.user_id}::uuid
+       AND n.deleted_at IS NULL
    `) as NoteSummaryRow[];
 
   const dbNote = rows[0];

--- a/src/app/api/notes/route.js
+++ b/src/app/api/notes/route.js
@@ -46,10 +46,14 @@ export const GET = withErrorHandler(async (request) => {
   // content is excluded from the list query — fetch individual notes for full content
   const sqlLimit = limit ?? 200;
   const notes = await sql`
-    SELECT note_id, title, is_folder, s3_key, shared, pinned, created_at, updated_at
-    FROM app.notes
-    WHERE user_id = ${user.user_id}::uuid AND deleted_at IS NULL
-    ORDER BY created_at DESC
+    SELECT n.note_id, n.title, n.is_folder, n.s3_key, n.shared, n.pinned,
+           n.created_at, n.updated_at,
+           (SELECT a.mime_type FROM app.attachments a
+            WHERE a.note_id = n.note_id AND a.user_id = n.user_id AND a.s3_key = n.s3_key
+            LIMIT 1) AS mime_type
+    FROM app.notes n
+    WHERE n.user_id = ${user.user_id}::uuid AND n.deleted_at IS NULL
+    ORDER BY n.created_at DESC
     LIMIT ${sqlLimit} OFFSET ${skip}
   `;
 

--- a/src/app/api/tree/children/route.ts
+++ b/src/app/api/tree/children/route.ts
@@ -41,6 +41,9 @@ export const GET = withErrorHandler(async (request) => {
             n.is_folder as "isFolder",
             ti.is_expanded as "isExpanded",
             n.s3_key as "s3Key",
+            (SELECT a.mime_type FROM app.attachments a
+             WHERE a.note_id = n.note_id AND a.user_id = n.user_id AND a.s3_key = n.s3_key
+             LIMIT 1) as "mimeType",
             n.pinned
           FROM app.tree_items ti
           JOIN app.notes n ON ti.note_id = n.note_id
@@ -56,6 +59,9 @@ export const GET = withErrorHandler(async (request) => {
             n.is_folder as "isFolder",
             ti.is_expanded as "isExpanded",
             n.s3_key as "s3Key",
+            (SELECT a.mime_type FROM app.attachments a
+             WHERE a.note_id = n.note_id AND a.user_id = n.user_id AND a.s3_key = n.s3_key
+             LIMIT 1) as "mimeType",
             n.pinned
           FROM app.tree_items ti
           JOIN app.notes n ON ti.note_id = n.note_id
@@ -67,12 +73,13 @@ export const GET = withErrorHandler(async (request) => {
 
     const body = {
       parentId: parentId || 'root',
-      items: rows.map((row: { id: string; title: string; isFolder: boolean; isExpanded: boolean; s3Key: string | null; pinned: number }) => ({
+      items: rows.map((row: { id: string; title: string; isFolder: boolean; isExpanded: boolean; s3Key: string | null; mimeType: string | null; pinned: number }) => ({
         id: row.id,
         title: row.title,
         isFolder: row.isFolder,
         isExpanded: row.isExpanded,
         s3Key: row.s3Key || null,
+        mimeType: row.mimeType || null,
         pinned: row.pinned ?? 0,
       })),
     };

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -11,6 +11,7 @@ import { xraySubsegment } from "@/lib/xray";
 import logger from "@/lib/logger";
 import { config } from "@/lib/config";
 import { enqueueCanvasJob } from "@/lib/queue";
+import { detectMimeType } from "@/lib/uploads/detect-mime";
 
 function sanitizeFileName(raw: string): string {
   return raw
@@ -18,39 +19,6 @@ function sanitizeFileName(raw: string): string {
     .replace(/[^a-zA-Z0-9._-]/g, "_")
     .replace(/\.{2,}/g, ".")
     .substring(0, 255);
-}
-
-const MAGIC_NUMBERS: [string, Set<string>][] = [
-  ["25504446", new Set(["application/pdf"])],
-  ["89504e47", new Set(["image/png"])],
-  ["ffd8ff", new Set(["image/jpeg"])],
-  ["47494638", new Set(["image/gif"])],
-  ["52494646", new Set(["image/webp", "audio/wav"])],
-  [
-    "504b0304",
-    new Set([
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    ]),
-  ],
-  ["d0cf11e0", new Set(["application/msword"])],
-  ["494433", new Set(["audio/mpeg"])],
-  ["fff1", new Set(["audio/mpeg"])],
-  ["fffb", new Set(["audio/mpeg"])],
-  ["00000020", new Set(["video/mp4"])],
-  ["0000001c", new Set(["video/mp4"])],
-];
-
-function validateMagicNumber(buffer: ArrayBuffer, mimeType: string): boolean {
-  if (mimeType.startsWith("text/")) return true;
-  const header = Buffer.from(buffer).subarray(0, 12).toString("hex");
-  for (const [magic, allowedTypes] of MAGIC_NUMBERS) {
-    if (header.startsWith(magic)) {
-      return allowedTypes.has(mimeType);
-    }
-  }
-  return false;
 }
 
 const ALLOWED_MIME_TYPES = new Set([
@@ -90,13 +58,18 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     );
   }
 
-  if (file.type && !ALLOWED_MIME_TYPES.has(file.type)) {
+  if (file.type && file.type !== "application/octet-stream" && !ALLOWED_MIME_TYPES.has(file.type)) {
     return tracedError(`File type '${file.type}' is not allowed`, 400);
   }
 
   const rawBuffer = await file.arrayBuffer();
-  if (file.type && !validateMagicNumber(rawBuffer, file.type)) {
+  const detectedMimeType = detectMimeType(rawBuffer, file.type);
+  if (file.type && !detectedMimeType) {
     return tracedError("File content does not match declared type", 400);
+  }
+  const mimeType = detectedMimeType || file.type;
+  if (!mimeType || !ALLOWED_MIME_TYPES.has(mimeType)) {
+    return tracedError("Could not determine an allowed file type", 400);
   }
 
   let createdNewNote = false;
@@ -130,7 +103,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
   try {
     await xraySubsegment("s3-put", () =>
       storage.putObject(storagePath, Buffer.from(rawBuffer), {
-        contentType: file.type || "application/octet-stream",
+        contentType: mimeType,
       }),
     );
   } catch (s3Error) {
@@ -150,7 +123,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     await sql`
       INSERT INTO app.attachments (id, note_id, user_id, filename, s3_key, mime_type, file_size)
       VALUES (${attachmentId}::uuid, ${noteId}::uuid, ${session.user_id}::uuid,
-              ${fileName}, ${storagePath}, ${file.type || "application/octet-stream"}, ${file.size})
+              ${fileName}, ${storagePath}, ${mimeType}, ${file.size})
     `;
   } catch (dbError) {
     logger.warn(
@@ -193,12 +166,13 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     "text/x-markdown",
   ]);
 
-  if (extractableTypes.has(file.type)) {
+  let ingestionStatus = "not-applicable";
+  if (extractableTypes.has(mimeType)) {
     try {
       // insert job record so frontend can poll /api/ingestion-status
       await sql`
         INSERT INTO app.ingestion_jobs (note_id, user_id, s3_key, mime_type, status)
-        VALUES (${noteId}::uuid, ${session.user_id}::uuid, ${storagePath}, ${file.type || "application/pdf"}, 'pending')
+        VALUES (${noteId}::uuid, ${session.user_id}::uuid, ${storagePath}, ${mimeType}, 'pending')
         ON CONFLICT DO NOTHING
       `;
 
@@ -206,12 +180,14 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
         noteId,
         userId: session.user_id,
         s3Key: storagePath,
-        mimeType: file.type || "application/pdf",
+        mimeType,
         filename: fileName,
       });
 
-      logger.info("extraction job queued", { noteId, mimeType: file.type });
+      ingestionStatus = "pending";
+      logger.info("extraction job queued", { noteId, mimeType });
     } catch (extractErr) {
+      ingestionStatus = "failed-to-queue";
       logger.warn("failed to queue extraction job", {
         error: extractErr,
         noteId,
@@ -226,7 +202,8 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     path: storagePath,
     url: signedUrl,
     size: file.size,
-    type: file.type,
+    type: mimeType,
+    ingestionStatus,
     attachmentId,
     createdNewNote,
   });

--- a/src/lib/canvas/import-embedding.js
+++ b/src/lib/canvas/import-embedding.js
@@ -142,24 +142,8 @@ export async function processRagPipeline(
       );
     } else {
       console.log(
-        `pdf-parse fallback: extracted ${chunks.length} chunks for note ${noteId}`,
+        `pdf-parse: extracted ${chunks.length} chunks for note ${noteId}`,
       );
-      // only retry to Marker if MARKER_API_URL is set; otherwise the retry
-      // would just hit pdf-parse again on each attempt (wasted budget)
-      if (attempt < MAX_EXTRACTION_RETRIES && process.env.MARKER_API_URL && source !== "skipped") {
-        await queueExtractionRetry({
-          noteId,
-          userId,
-          s3Key,
-          filename,
-          mimeType,
-          parentFolderId,
-          attempt,
-        });
-        console.log(
-          `Queued Marker enrichment retry for note ${noteId} after pdf-parse fallback`,
-        );
-      }
     }
 
     if (isText) {

--- a/src/lib/ingestion/extraction-core.ts
+++ b/src/lib/ingestion/extraction-core.ts
@@ -56,8 +56,16 @@ export async function extractContentFromBuffer({
     return { rawText, chunks: chunkText(rawText), source: "text" };
   }
 
-  // Try Marker when configured and enabled; fall through to pdf-parse on
-  // failure or when operators explicitly bypass the OCR layer.
+  // Use the PDF text layer first. This is CPU-only and lets searchable PDFs
+  // become RAG-ready without waiting for the optional OCR service.
+  if (mimeType === "application/pdf") {
+    const textLayer = await extractPdfTextLayer(buffer);
+    if (textLayer) {
+      return { rawText: textLayer.rawText, chunks: textLayer.chunks, source: "pdf-parse" };
+    }
+  }
+
+  // Marker is an explicit fallback for scanned/image-only documents.
   if (process.env.MARKER_API_URL && markerOcrEnabled()) {
     try {
       const marker = await extractWithMarker(buffer, filename, { fastPath: true });
@@ -70,14 +78,7 @@ export async function extractContentFromBuffer({
         pageRange: marker.pageRange,
       };
     } catch {
-      // fall through to pdf-parse / skipped
-    }
-  }
-
-  if (mimeType === "application/pdf") {
-    const fallback = await extractPdfTextLayer(buffer);
-    if (fallback) {
-      return { rawText: fallback.rawText, chunks: fallback.chunks, source: "pdf-parse" };
+      // fall through to skipped
     }
   }
   return { rawText: "", chunks: [], source: "skipped" };

--- a/src/lib/notes/api/tree.ts
+++ b/src/lib/notes/api/tree.ts
@@ -12,6 +12,7 @@ interface TreeItem {
   isFolder: boolean;
   isExpanded: boolean;
   s3Key: string | null;
+  mimeType: string | null;
   pinned: number;
 }
 

--- a/src/lib/notes/state/tree-utils.ts
+++ b/src/lib/notes/state/tree-utils.ts
@@ -108,6 +108,7 @@ export interface ApiTreeItem {
   isFolder?: boolean;
   isExpanded?: boolean;
   s3Key?: string;
+  mimeType?: string;
   pinned?: NOTE_PINNED;
 }
 
@@ -126,6 +127,7 @@ export function buildTreeItemFromApi(item: ApiTreeItem): TreeItemModel {
       title: item.title ?? "Untitled",
       isFolder: item.isFolder ?? false,
       s3Key: item.s3Key ?? undefined,
+      mimeType: item.mimeType ?? undefined,
       deleted: NOTE_DELETED.NORMAL,
       shared: NOTE_SHARED.PRIVATE,
       pinned: item.pinned ?? NOTE_PINNED.UNPINNED,

--- a/src/lib/notes/types/note.ts
+++ b/src/lib/notes/types/note.ts
@@ -16,6 +16,7 @@ export interface NoteModel {
   updatedAt?: string; // ISO 8601 timestamp
   isFolder?: boolean; // true if this note is a folder/directory
   s3Key?: string; // S3 storage path for attached files/PDFs
+  mimeType?: string; // Persisted attachment MIME type; independent of editable title
   deleted: NOTE_DELETED;
   shared: NOTE_SHARED;
   pinned: NOTE_PINNED;

--- a/src/lib/notes/utils/file-spec.ts
+++ b/src/lib/notes/utils/file-spec.ts
@@ -5,6 +5,7 @@ interface FileSource {
   title?: string | null;
   content?: string | null;
   s3Key?: string | null;
+  mimeType?: string | null;
 }
 
 const PDF_EXTENSIONS = new Set(['pdf']);
@@ -19,7 +20,12 @@ function getExtension(title?: string | null) {
   return parts.length > 1 ? parts.at(-1) || '' : '';
 }
 
-export function inferFileType(title?: string | null): FileType {
+export function inferFileType(title?: string | null, mimeType?: string | null): FileType {
+  const normalizedMimeType = mimeType?.trim().toLowerCase();
+  if (normalizedMimeType === 'application/pdf') return 'pdf';
+  if (normalizedMimeType?.startsWith('image/')) return 'image';
+  if (normalizedMimeType?.startsWith('video/')) return 'video';
+
   const extension = getExtension(title);
 
   if (PDF_EXTENSIONS.has(extension)) return 'pdf';
@@ -30,7 +36,7 @@ export function inferFileType(title?: string | null): FileType {
 }
 
 export function buildFileSpec(source: FileSource): FileSpec {
-  const fileType = inferFileType(source.title);
+  const fileType = inferFileType(source.title, source.mimeType);
   // for PDFs/media, prefer s3Key over content (Canvas imports store path in s3Key, not content)
   const sourcePath = fileType !== 'note'
     ? (source.s3Key || source.content || undefined)

--- a/src/lib/notes/utils/map-note.js
+++ b/src/lib/notes/utils/map-note.js
@@ -12,6 +12,7 @@ export function mapNoteFromDB(dbRow) {
     content: dbRow.content,
     isFolder: dbRow.is_folder,
     s3Key: dbRow.s3_key,
+    mimeType: dbRow.mime_type,
     deleted: 0,
     shared: dbRow.shared,
     pinned: dbRow.pinned,

--- a/src/lib/uploads/detect-mime.ts
+++ b/src/lib/uploads/detect-mime.ts
@@ -1,0 +1,42 @@
+const MAGIC_MIME_TYPES: Array<[string, readonly string[]]> = [
+  ["25504446", ["application/pdf"]],
+  ["89504e47", ["image/png"]],
+  ["ffd8ff", ["image/jpeg"]],
+  ["47494638", ["image/gif"]],
+  ["52494646", ["image/webp", "audio/wav"]],
+  [
+    "504b0304",
+    [
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ],
+  ],
+  ["d0cf11e0", ["application/msword"]],
+  ["494433", ["audio/mpeg"]],
+  ["fff1", ["audio/mpeg"]],
+  ["fffb", ["audio/mpeg"]],
+  ["00000020", ["video/mp4"]],
+  ["0000001c", ["video/mp4"]],
+];
+
+export function detectMimeType(
+  buffer: ArrayBuffer,
+  declaredMimeType: string,
+): string | null {
+  const rawDeclared = declaredMimeType.trim().toLowerCase();
+  const declared =
+    rawDeclared === "application/octet-stream" ? "" : rawDeclared;
+  if (declared.startsWith("text/")) return declared;
+
+  const header = Buffer.from(buffer).subarray(0, 12).toString("hex");
+  const match = MAGIC_MIME_TYPES.find(([magic]) => header.startsWith(magic));
+  if (!match) return null;
+
+  const possibleTypes = match[1];
+  if (declared) return possibleTypes.includes(declared) ? declared : null;
+
+  // Ambiguous signatures (for example ZIP-based Office files) still require a
+  // declared type. Unambiguous signatures safely classify unnamed files.
+  return possibleTypes.length === 1 ? possibleTypes[0] : null;
+}


### PR DESCRIPTION
## What changed

- detect uploaded PDFs from file signatures when filenames or browser MIME metadata are missing
- persist and expose attachment MIME metadata so renaming a PDF does not turn it into a Markdown note
- parse PDF text layers on CPU before optional Marker OCR
- stop successful CPU parsing from queueing redundant Marker enrichment retries
- report upload ingestion queue state and default Marker OCR to disabled

## Why

PDF rendering was tied to the editable note title, and extensionless uploads could miss extraction entirely. The extraction pipeline could also wait on Marker or launch duplicate enrichment retries after successful CPU parsing.

## Impact

PDFs become viewable and RAG-indexable independently of their filename. Searchable PDFs are extracted and embedded immediately through the CPU text-layer path; Marker remains an explicit fallback for image-only documents.

## Validation

- full pre-commit suite: 134 test files, 911 tests passed
- TypeScript typecheck passed
- ESLint and i18n audit passed
- Dockerfile.marker validation passed
- production test upload verified with 129 PostgreSQL chunks and 129 Qdrant vectors