### PR TITLE
Promote resizable sidebars and UI refinements to production

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,10 +9,13 @@ echo "🔍 Running precommit checks..."
 echo "✓ Linting TypeScript/JavaScript..."
 npm run lint:all
 
-# 2. Validate Dockerfile.marker syntax (if it exists and Docker is available)
+# 2. Validate Dockerfile.marker syntax (if it exists and Docker is available).
+# Non-fatal: the docker CLI existing does not mean the daemon is running or
+# that this docker version supports the validate flags — never block commits
+# on machines without a usable Docker.
 if [ -f Dockerfile.marker ] && command -v docker >/dev/null 2>&1; then
   echo "✓ Validating Dockerfile.marker..."
-  npm run docker:marker:validate
+  npm run docker:marker:validate || echo "⚠ Docker validation skipped (daemon unavailable or incompatible docker version)"
 fi
 
 # 3. Validate tracked shell scripts when ShellCheck is installed

--- a/database/migrations/048_prevent_tree_self_parent.sql
+++ b/database/migrations/048_prevent_tree_self_parent.sql
@@ -1,0 +1,12 @@
+-- Repair tree rows that point at themselves, then prevent recurrence.
+UPDATE app.tree_items
+SET parent_id = NULL,
+    updated_at = NOW()
+WHERE parent_id = note_id;
+
+ALTER TABLE app.tree_items
+  DROP CONSTRAINT IF EXISTS tree_items_no_self_parent;
+
+ALTER TABLE app.tree_items
+  ADD CONSTRAINT tree_items_no_self_parent
+  CHECK (parent_id IS NULL OR parent_id <> note_id);

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -65,6 +65,19 @@ Indexing stores chunk text and ownership in PostgreSQL, computes embeddings thro
 
 Chat supports streaming and non-streaming responses. Streaming prompts are durable BullMQ jobs: the worker writes ordered SSE events to an expiring Redis Stream while PostgreSQL owns generation state and the final assistant message. A browser reconnect supplies the last Redis event ID, replays missed events, and then continues live delivery. Sessions and messages are relational data. Assistant messages retain canonical plain `content` and optional structured `parts` for durable tool and error UI.
 
+Generations are cancellable. Every open browser tab heartbeats a per-user,
+per-tab presence hash in Redis through [`src/lib/chat/presence.ts`](../../src/lib/chat/presence.ts)
+and removes its own field with a `pagehide` beacon. A worker watchdog aborts
+the LLM stream when the user explicitly stops (Redis cancel flag set by
+`/api/chat/generations/[id]/cancel`) or when presence has been absent for a
+full grace window — a real disconnect. In-app navigation and other open tabs
+keep presence alive, so only closing the last tab (or a crash, via staleness)
+cancels; users that never had browser presence, such as API clients, are only
+ever cancelled explicitly. On abort the worker persists any partial answer as
+an interrupted assistant message, marks the generation `cancelled`, and does
+not retry. The inline SSE path aborts the same way when its client connection
+drops.
+
 The chat also has an always-available, read-only `getAppGuide` tool backed by
 [`src/lib/chat/app-guide.ts`](../../src/lib/chat/app-guide.ts). It answers product
 workflow, navigation, capability, and troubleshooting questions without using

--- a/src/__tests__/components/chat/conversation-history.test.ts
+++ b/src/__tests__/components/chat/conversation-history.test.ts
@@ -42,16 +42,19 @@ describe("ConversationHistory", () => {
 
     const toggle = screen.getByRole("button", { name: /Pinned/ });
     const pinnedPanel = document.getElementById("pinned-conversations");
+    const pinnedSection = toggle.closest("section");
 
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
-    expect(pinnedPanel?.hidden).toBe(false);
-    expect(pinnedPanel?.closest("section")?.className).toContain("max-h-[35%]");
+    expect(pinnedPanel).toBeTruthy();
+    expect(pinnedSection?.className).toContain("max-h-[35%]");
     expect(screen.getByText("Recent conversation")).toBeTruthy();
 
     fireEvent.click(toggle);
 
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    expect(pinnedPanel?.hidden).toBe(true);
+    expect(document.getElementById("pinned-conversations")).toBeNull();
+    expect(screen.queryByText("Pinned conversation")).toBeNull();
+    expect(pinnedSection?.className).not.toContain("max-h-[35%]");
     expect(screen.getByText("Recent conversation")).toBeTruthy();
   });
 });

--- a/src/__tests__/components/chat/conversation-history.test.ts
+++ b/src/__tests__/components/chat/conversation-history.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ConversationHistory } from "@/app/chat/chat-page-client";
+
+const conversations = [
+  {
+    id: "pinned-1",
+    title: "Pinned conversation",
+    messageCount: 2,
+    createdAt: Date.now(),
+    pinned: true,
+  },
+  {
+    id: "recent-1",
+    title: "Recent conversation",
+    messageCount: 1,
+    createdAt: Date.now(),
+    pinned: false,
+  },
+];
+
+describe("ConversationHistory", () => {
+  it("collapses pinned conversations and preserves access to recents", () => {
+    render(
+      React.createElement(ConversationHistory, {
+        conversations,
+        activeId: null,
+        loaded: true,
+        t: (key) => key,
+        onNewConversation: vi.fn(),
+        onSelectConversation: vi.fn(),
+        onDeleteConversation: vi.fn(),
+        onRenameConversation: vi.fn().mockResolvedValue(true),
+        onTogglePinned: vi.fn().mockResolvedValue(true),
+        onDismiss: vi.fn(),
+        showHeader: false,
+      }),
+    );
+
+    const toggle = screen.getByRole("button", { name: /Pinned/ });
+    const pinnedPanel = document.getElementById("pinned-conversations");
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(pinnedPanel?.hidden).toBe(false);
+    expect(pinnedPanel?.closest("section")?.className).toContain("max-h-[35%]");
+    expect(screen.getByText("Recent conversation")).toBeTruthy();
+
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(pinnedPanel?.hidden).toBe(true);
+    expect(screen.getByText("Recent conversation")).toBeTruthy();
+  });
+});

--- a/src/__tests__/components/notes-workspace.test.ts
+++ b/src/__tests__/components/notes-workspace.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -17,13 +17,24 @@ const layoutState = {
   rightPanelWidth: 280,
   rightPanelOpen: false,
   rightPanelTab: "meta" as const,
+  splitPosition: 50,
   paneA: { fileId: "", fileType: "note" },
   paneB: null,
   activePane: "A",
   setPaneA: mocks.setPaneA,
   setActivePane: vi.fn(),
   setRightPanelOpen: vi.fn(),
+  setSizes: vi.fn(),
 };
+
+vi.mock("react-resizable-panels", () => ({
+  Group: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("div", null, children),
+  Panel: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("div", null, children),
+  Separator: ({ "aria-label": ariaLabel }: { "aria-label"?: string }) =>
+    React.createElement("div", { role: "separator", "aria-label": ariaLabel }),
+}));
 
 vi.mock("next/navigation", () => ({
   usePathname: () => mocks.pathname,
@@ -62,7 +73,9 @@ vi.mock("@/lib/notes/hooks/use-note-tree-initialization", () => ({
   default: () => true,
 }));
 
-vi.mock("@/components/navigation/primary-navigation", () => ({ default: () => null }));
+vi.mock("@/components/navigation/primary-navigation", () => ({
+  default: () => null,
+}));
 vi.mock("@/components/navigation/mobile-app-header", () => ({
   default: () => null,
 }));
@@ -72,7 +85,9 @@ vi.mock("@/components/navigation/mobile-drawer", () => ({
 vi.mock("@/components/notes/note-tree-panel", () => ({
   default: () => null,
 }));
-vi.mock("@/components/editor/split-editor-pane", () => ({ default: () => null }));
+vi.mock("@/components/editor/split-editor-pane", () => ({
+  default: () => null,
+}));
 vi.mock("@/components/notes/note-inspector-panel", () => ({
   default: () => null,
 }));
@@ -114,5 +129,19 @@ describe("NotesWorkspace note route synchronization", () => {
       "/api/notes/550e8400-e29b-41d4-a716-446655440000",
       { signal: expect.any(AbortSignal) },
     );
+  });
+
+  it("renders resize handles for both desktop side panels", () => {
+    layoutState.paneA.fileId = "550e8400-e29b-41d4-a716-446655440000";
+    layoutState.rightPanelOpen = true;
+
+    render(React.createElement(NotesWorkspace));
+
+    expect(
+      screen.getByRole("separator", { name: "Resize notes panel" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("separator", { name: "Resize details panel" }),
+    ).toBeTruthy();
   });
 });

--- a/src/__tests__/components/notes/sidebar-selection-utils.test.ts
+++ b/src/__tests__/components/notes/sidebar-selection-utils.test.ts
@@ -7,6 +7,10 @@ import {
   treeItemContainsId,
   toggleSelectedId,
 } from "@/components/notes/sidebar/selection-utils";
+import {
+  getCycleSafeChildren,
+  wouldCreateTreeCycle,
+} from "@/lib/notes/state/tree-cycle";
 
 describe("sidebar selection utilities", () => {
   it("excludes selected descendants when an ancestor is selected", () => {
@@ -70,5 +74,24 @@ describe("sidebar selection utilities", () => {
 
     expect(treeItemContainsId(tree, "folder", "child")).toBe(true);
     expect(treeItemContainsId(tree, "folder", "after")).toBe(false);
+  });
+
+  it("tolerates a self-parent cycle when collecting visible items", () => {
+    let tree = TreeActions.addItem(DEFAULT_TREE, "folder");
+    tree = TreeActions.mutateItem(tree, "folder", { children: ["folder"] });
+
+    expect(getVisibleTreeItemIds(tree, new Set(["folder"]))).toEqual([
+      "folder",
+    ]);
+    expect(getCycleSafeChildren(tree).folder).toEqual([]);
+  });
+
+  it("rejects moving a folder into itself or a descendant", () => {
+    let tree = TreeActions.addItem(DEFAULT_TREE, "folder");
+    tree = TreeActions.addItem(tree, "child", "folder");
+
+    expect(wouldCreateTreeCycle(tree, "folder", "folder")).toBe(true);
+    expect(wouldCreateTreeCycle(tree, "folder", "child")).toBe(true);
+    expect(wouldCreateTreeCycle(tree, "child", ROOT_ID)).toBe(false);
   });
 });

--- a/src/__tests__/lib/notes/layout-pane-coordination.test.ts
+++ b/src/__tests__/lib/notes/layout-pane-coordination.test.ts
@@ -74,4 +74,13 @@ describe("layout pane coordination", () => {
       selectedNode: null,
     });
   });
+
+  it("allows both side panels to grow to 600 pixels", () => {
+    useLayoutStore.getState().setSizes(700, 700, 50);
+
+    expect(useLayoutStore.getState()).toMatchObject({
+      treeWidth: 600,
+      rightPanelWidth: 600,
+    });
+  });
 });

--- a/src/app/api/tree/route.ts
+++ b/src/app/api/tree/route.ts
@@ -3,6 +3,7 @@ import { withErrorHandler, requireAuth, requireValidId, ApiError } from '@/lib/a
 import { getTreeFromPG } from '@/lib/notes/storage/pg-tree.js';
 import { ROOT_ID } from '@/lib/notes/types/tree';
 import { cacheInvalidate, cacheKeys } from '@/lib/cache';
+import { wouldCreateTreeCycle } from '@/lib/notes/state/tree-cycle';
 
 interface TreeMutateAction {
     action: 'move' | 'mutate';
@@ -61,6 +62,9 @@ export const POST = withErrorHandler(async (request) => {
               // Determine new parent ID (null if moving to root)
               const newParentId = destination.parentId === ROOT_ID ? null : destination.parentId;
               if (newParentId) requireValidId(newParentId, "parent ID");
+              if (newParentId && wouldCreateTreeCycle(tree, noteId, newParentId)) {
+                throw new ApiError(400, 'Cannot move an item inside itself');
+              }
 
               // Move the note in the tree (position stored separately if needed)
               await moveNoteInTree(user.user_id, noteId, newParentId);

--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Suspense } from "react";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 
 const ERROR_MESSAGES: Record<string, string> = {
   OAuthSignin: "Could not start the sign-in flow. Please try again.",
@@ -30,19 +31,10 @@ function AuthErrorContent() {
         <div className="glass-card px-6 py-12 rounded-radius-xl sm:px-12">
           <div className="text-center">
             <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-500/10">
-              <svg
+              <ExclamationTriangleIcon
                 className="h-6 w-6 text-red-400"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth="1.5"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
-                />
-              </svg>
+                aria-hidden="true"
+              />
             </div>
             <h2 className="text-xl font-semibold text-text mb-2">
               Sign-in failed

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   CheckIcon,
   ChevronLeftIcon,
@@ -62,6 +62,7 @@ export default function CalendarPage() {
   const splitPosition = useLayoutStore((state) => state.splitPosition);
   const setActiveNav = useLayoutStore((state) => state.setActiveNav);
   const setSizes = useLayoutStore((state) => state.setSizes);
+  const taskPanelWidthRef = useRef(rightPanelWidth);
 
   useEffect(() => {
     setActiveNav("calendar");
@@ -146,6 +147,9 @@ export default function CalendarPage() {
           key={hasTaskSidebar ? "with-tasks" : "without-tasks"}
           orientation="horizontal"
           className="min-w-0 flex-1"
+          onLayoutChanged={() => {
+            setSizes(treeWidth, taskPanelWidthRef.current, splitPosition);
+          }}
         >
           <Panel id="calendar" minSize="480px" className="flex min-w-0">
             <main
@@ -320,10 +324,8 @@ export default function CalendarPage() {
               minSize="250px"
               maxSize="600px"
               groupResizeBehavior="preserve-pixel-size"
-              onResize={({ inPixels }, _id, previousSize) => {
-                if (previousSize) {
-                  setSizes(treeWidth, inPixels, splitPosition);
-                }
+              onResize={({ inPixels }) => {
+                taskPanelWidthRef.current = inPixels;
               }}
               className="flex min-w-0"
             >

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -9,6 +9,11 @@ import {
   ClipboardDocumentListIcon,
 } from "@heroicons/react/20/solid";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
+import {
+  Group as PanelGroup,
+  Panel,
+  Separator as PanelResizeHandle,
+} from "react-resizable-panels";
 import useCalendarStore from "@/lib/notes/state/calendar.zustand";
 import useLayoutStore from "@/lib/notes/state/layout.zustand";
 import useMediaQuery from "@/lib/hooks/use-media-query";
@@ -49,8 +54,14 @@ export default function CalendarPage() {
     fetchTimeBlocks,
     fetchReviewDates,
   } = useCalendarStore();
-  const fetchAssignments = useAssignmentStore((state) => state.fetchAssignments);
-  const { setActiveNav } = useLayoutStore();
+  const fetchAssignments = useAssignmentStore(
+    (state) => state.fetchAssignments,
+  );
+  const treeWidth = useLayoutStore((state) => state.treeWidth);
+  const rightPanelWidth = useLayoutStore((state) => state.rightPanelWidth);
+  const splitPosition = useLayoutStore((state) => state.splitPosition);
+  const setActiveNav = useLayoutStore((state) => state.setActiveNav);
+  const setSizes = useLayoutStore((state) => state.setSizes);
 
   useEffect(() => {
     setActiveNav("calendar");
@@ -68,8 +79,12 @@ export default function CalendarPage() {
       startDateKey = addDaysToDateKey(selectedDate, -7);
       endDateKey = addDaysToDateKey(selectedDate, 7);
     } else if (view === "month") {
-      startDateKey = formatDateKey(new Date(anchor.getFullYear(), anchor.getMonth(), -6));
-      endDateKey = formatDateKey(new Date(anchor.getFullYear(), anchor.getMonth() + 1, 7));
+      startDateKey = formatDateKey(
+        new Date(anchor.getFullYear(), anchor.getMonth(), -6),
+      );
+      endDateKey = formatDateKey(
+        new Date(anchor.getFullYear(), anchor.getMonth() + 1, 7),
+      );
     } else {
       const monday = new Date(anchor);
       monday.setDate(anchor.getDate() - ((anchor.getDay() + 6) % 7));
@@ -79,7 +94,14 @@ export default function CalendarPage() {
     const range = localDateKeyRangeToIso(startDateKey, endDateKey);
     void fetchTimeBlocks(range.start, range.end);
     void fetchReviewDates(startDateKey, endDateKey);
-  }, [currentDate, fetchReviewDates, fetchTimeBlocks, isDesktop, selectedDate, view]);
+  }, [
+    currentDate,
+    fetchReviewDates,
+    fetchTimeBlocks,
+    isDesktop,
+    selectedDate,
+    view,
+  ]);
 
   useEffect(() => {
     const refresh = () => {
@@ -90,7 +112,8 @@ export default function CalendarPage() {
       void fetchTimeBlocks(range.start, range.end);
     };
     window.addEventListener("oghma:time-block-changed", refresh);
-    return () => window.removeEventListener("oghma:time-block-changed", refresh);
+    return () =>
+      window.removeEventListener("oghma:time-block-changed", refresh);
   }, [fetchTimeBlocks, selectedDate]);
 
   const current = new Date(currentDate);
@@ -119,19 +142,99 @@ export default function CalendarPage() {
           </div>
         )}
 
-        <div className="flex min-w-0 flex-1">
-          <main className="flex min-w-0 flex-1 flex-col" aria-label={t("Calendar")}>
-            <header className="glass-panel relative z-50 hidden h-12 shrink-0 items-center justify-between gap-2 border-b border-border-subtle px-4 md:flex">
-              <h1 className="min-w-0 flex-1 truncate text-sm font-semibold text-text-secondary md:text-base">
-                <time>{weekLabel}</time>
-              </h1>
+        <PanelGroup
+          key={hasTaskSidebar ? "with-tasks" : "without-tasks"}
+          orientation="horizontal"
+          className="min-w-0 flex-1"
+        >
+          <Panel id="calendar" minSize="480px" className="flex min-w-0">
+            <main
+              className="flex h-full w-full min-w-0 flex-1 flex-col"
+              aria-label={t("Calendar")}
+            >
+              <header className="glass-panel relative z-50 hidden h-12 shrink-0 items-center justify-between gap-2 border-b border-border-subtle px-4 md:flex">
+                <h1 className="min-w-0 flex-1 truncate text-sm font-semibold text-text-secondary md:text-base">
+                  <time>{weekLabel}</time>
+                </h1>
 
-              <div className="flex shrink-0 items-center gap-2">
-                <div className="relative flex h-8 items-center overflow-hidden rounded-radius-md glass-card">
+                <div className="flex shrink-0 items-center gap-2">
+                  <div className="relative flex h-8 items-center overflow-hidden rounded-radius-md glass-card">
+                    <button
+                      type="button"
+                      onClick={navigateBack}
+                      className="flex h-8 w-8 items-center justify-center text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-400/50"
+                      aria-label={t("Previous period")}
+                    >
+                      <ChevronLeftIcon className="h-4 w-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={goToToday}
+                      className="hidden h-8 px-3 text-xs font-medium text-text-secondary hover:bg-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-400/50 md:block"
+                    >
+                      {t("Today")}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={navigateForward}
+                      className="flex h-8 w-8 items-center justify-center text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-400/50"
+                      aria-label={t("Next period")}
+                    >
+                      <ChevronRightIcon className="h-4 w-4" />
+                    </button>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={() => setTasksOpen(true)}
+                    className="flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-radius-md px-2 text-xs font-medium text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/50 lg:hidden"
+                    aria-label={t("Tasks")}
+                  >
+                    <ClipboardDocumentListIcon className="h-4 w-4" />
+                    <span className="hidden sm:inline">{t("Tasks")}</span>
+                  </button>
+
+                  <Menu as="div" className="relative z-[60]">
+                    <MenuButton className="flex h-8 min-w-24 items-center justify-between gap-2 rounded-radius-md px-3 text-xs font-medium text-text-secondary glass-card-interactive outline-none focus:outline-none data-[focus]:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/50">
+                      <span>{view === "month" ? t("Month") : t("Week")}</span>
+                      <ChevronDownIcon className="h-4 w-4 text-text-tertiary" />
+                    </MenuButton>
+                    <MenuItems className="absolute right-0 z-[90] mt-1 w-40 overflow-hidden rounded-radius-md border border-border bg-app-page py-1 shadow-2xl ring-1 ring-black/20 focus:outline-none">
+                      <MenuItem>
+                        <button
+                          type="button"
+                          onClick={() => setView("month")}
+                          className="flex h-9 w-full items-center justify-between gap-2 bg-app-page px-3 text-left text-xs text-text-secondary hover:bg-subtle focus:outline-none data-[focus]:bg-subtle"
+                        >
+                          {t("Month view")}
+                          {view === "month" && (
+                            <CheckIcon className="h-4 w-4 shrink-0 text-primary-400" />
+                          )}
+                        </button>
+                      </MenuItem>
+                      <MenuItem>
+                        <button
+                          type="button"
+                          onClick={() => setView("week")}
+                          className="flex h-9 w-full items-center justify-between gap-2 bg-app-page px-3 text-left text-xs text-text-secondary hover:bg-subtle focus:outline-none data-[focus]:bg-subtle"
+                        >
+                          {t("Week view")}
+                          {view === "week" && (
+                            <CheckIcon className="h-4 w-4 shrink-0 text-primary-400" />
+                          )}
+                        </button>
+                      </MenuItem>
+                    </MenuItems>
+                  </Menu>
+                </div>
+              </header>
+
+              {isDesktop === false && (
+                <div className="flex shrink-0 items-center gap-1 border-b border-border-subtle px-2 py-1.5">
                   <button
                     type="button"
                     onClick={navigateBack}
-                    className="flex h-8 w-8 items-center justify-center text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-400/50"
+                    className="flex h-11 w-11 items-center justify-center rounded-md glass-card"
                     aria-label={t("Previous period")}
                   >
                     <ChevronLeftIcon className="h-4 w-4" />
@@ -139,113 +242,104 @@ export default function CalendarPage() {
                   <button
                     type="button"
                     onClick={goToToday}
-                    className="hidden h-8 px-3 text-xs font-medium text-text-secondary hover:bg-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-400/50 md:block"
+                    className="h-11 rounded-md px-3 text-xs font-medium glass-card"
                   >
                     {t("Today")}
                   </button>
                   <button
                     type="button"
                     onClick={navigateForward}
-                    className="flex h-8 w-8 items-center justify-center text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-400/50"
+                    className="flex h-11 w-11 items-center justify-center rounded-md glass-card"
                     aria-label={t("Next period")}
                   >
                     <ChevronRightIcon className="h-4 w-4" />
                   </button>
+                  <div className="flex-1" />
+                  <button
+                    type="button"
+                    onClick={() => setTasksOpen(true)}
+                    className="h-11 rounded-md px-3 text-xs font-medium glass-card"
+                  >
+                    {t("Tasks")}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setStudyBlockStart(undefined);
+                      setStudyBlockEnd(undefined);
+                      setStudyBlockOpen(true);
+                    }}
+                    className="h-11 rounded-md bg-primary-600 px-3 text-xs font-medium text-text-on-primary"
+                  >
+                    {t("Add study block")}
+                  </button>
                 </div>
-
-                <button
-                  type="button"
-                  onClick={() => setTasksOpen(true)}
-                  className="flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-radius-md px-2 text-xs font-medium text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/50 lg:hidden"
-                  aria-label={t("Tasks")}
-                >
-                  <ClipboardDocumentListIcon className="h-4 w-4" />
-                  <span className="hidden sm:inline">{t("Tasks")}</span>
-                </button>
-
-                <Menu as="div" className="relative z-[60]">
-                  <MenuButton className="flex h-8 min-w-24 items-center justify-between gap-2 rounded-radius-md px-3 text-xs font-medium text-text-secondary glass-card-interactive outline-none focus:outline-none data-[focus]:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/50">
-                    <span>{view === "month" ? t("Month") : t("Week")}</span>
-                    <ChevronDownIcon className="h-4 w-4 text-text-tertiary" />
-                  </MenuButton>
-                  <MenuItems className="absolute right-0 z-[90] mt-1 w-40 overflow-hidden rounded-radius-md border border-border bg-app-page py-1 shadow-2xl ring-1 ring-black/20 focus:outline-none">
-                    <MenuItem>
-                      <button
-                        type="button"
-                        onClick={() => setView("month")}
-                        className="flex h-9 w-full items-center justify-between gap-2 bg-app-page px-3 text-left text-xs text-text-secondary hover:bg-subtle focus:outline-none data-[focus]:bg-subtle"
-                      >
-                        {t("Month view")}
-                        {view === "month" && (
-                          <CheckIcon className="h-4 w-4 shrink-0 text-primary-400" />
-                        )}
-                      </button>
-                    </MenuItem>
-                    <MenuItem>
-                      <button
-                        type="button"
-                        onClick={() => setView("week")}
-                        className="flex h-9 w-full items-center justify-between gap-2 bg-app-page px-3 text-left text-xs text-text-secondary hover:bg-subtle focus:outline-none data-[focus]:bg-subtle"
-                      >
-                        {t("Week view")}
-                        {view === "week" && (
-                          <CheckIcon className="h-4 w-4 shrink-0 text-primary-400" />
-                        )}
-                      </button>
-                    </MenuItem>
-                  </MenuItems>
-                </Menu>
-              </div>
-            </header>
-
-            {isDesktop === false && (
-              <div className="flex shrink-0 items-center gap-1 border-b border-border-subtle px-2 py-1.5">
-                <button type="button" onClick={navigateBack} className="flex h-11 w-11 items-center justify-center rounded-md glass-card" aria-label={t("Previous period")}><ChevronLeftIcon className="h-4 w-4" /></button>
-                <button type="button" onClick={goToToday} className="h-11 rounded-md px-3 text-xs font-medium glass-card">{t("Today")}</button>
-                <button type="button" onClick={navigateForward} className="flex h-11 w-11 items-center justify-center rounded-md glass-card" aria-label={t("Next period")}><ChevronRightIcon className="h-4 w-4" /></button>
-                <div className="flex-1" />
-                <button type="button" onClick={() => setTasksOpen(true)} className="h-11 rounded-md px-3 text-xs font-medium glass-card">{t("Tasks")}</button>
-                <button type="button" onClick={() => { setStudyBlockStart(undefined); setStudyBlockEnd(undefined); setStudyBlockOpen(true); }} className="h-11 rounded-md bg-primary-600 px-3 text-xs font-medium text-text-on-primary">{t("Add study block")}</button>
-              </div>
-            )}
-
-            <div className="min-h-0 flex-1 overflow-hidden">
-              {isDesktop === false ? (
-                <MobileDayAgenda
-                  onAddStudyBlock={() => setStudyBlockOpen(true)}
-                  onRetry={() => {
-                    void fetchAssignments();
-                    const range = localDateKeyRangeToIso(selectedDate, selectedDate);
-                    void fetchTimeBlocks(range.start, range.end);
-                    void fetchReviewDates(selectedDate, selectedDate);
-                  }}
-                />
-              ) : view === "month" ? (
-                <MonthView onSelectDate={() => setDayDetailsOpen(true)} />
-              ) : (
-                <WeekView
-                  onSelectDate={() => setDayDetailsOpen(true)}
-                  onAddStudyBlock={(_date, start, end) => {
-                    setStudyBlockStart(start);
-                    setStudyBlockEnd(end);
-                    setStudyBlockOpen(true);
-                  }}
-                />
               )}
-            </div>
-          </main>
+
+              <div className="min-h-0 flex-1 overflow-hidden">
+                {isDesktop === false ? (
+                  <MobileDayAgenda
+                    onAddStudyBlock={() => setStudyBlockOpen(true)}
+                    onRetry={() => {
+                      void fetchAssignments();
+                      const range = localDateKeyRangeToIso(
+                        selectedDate,
+                        selectedDate,
+                      );
+                      void fetchTimeBlocks(range.start, range.end);
+                      void fetchReviewDates(selectedDate, selectedDate);
+                    }}
+                  />
+                ) : view === "month" ? (
+                  <MonthView onSelectDate={() => setDayDetailsOpen(true)} />
+                ) : (
+                  <WeekView
+                    onSelectDate={() => setDayDetailsOpen(true)}
+                    onAddStudyBlock={(_date, start, end) => {
+                      setStudyBlockStart(start);
+                      setStudyBlockEnd(end);
+                      setStudyBlockOpen(true);
+                    }}
+                  />
+                )}
+              </div>
+            </main>
+          </Panel>
 
           {hasTaskSidebar === true && (
-            <aside className="flex w-[280px] shrink-0 flex-col border-l border-border-subtle glass-panel">
-              <div className="flex h-12 shrink-0 items-center border-b border-border-subtle px-3">
-                <h2 className="text-sm font-semibold text-text-secondary">{t("Tasks")}</h2>
-              </div>
-              <div className="flex min-h-0 flex-1 flex-col">
-                <AssignmentTracker surface="compact" />
-              </div>
-            </aside>
+            <PanelResizeHandle
+              aria-label={t("Resize tasks panel")}
+              className="w-px cursor-col-resize bg-border-subtle transition-colors hover:bg-primary-500/40 active:bg-primary-500/60"
+            />
           )}
-        </div>
+
+          {hasTaskSidebar === true && (
+            <Panel
+              id="calendar-tasks"
+              defaultSize={`${rightPanelWidth}px`}
+              minSize="250px"
+              maxSize="600px"
+              groupResizeBehavior="preserve-pixel-size"
+              onResize={({ inPixels }, _id, previousSize) => {
+                if (previousSize) {
+                  setSizes(treeWidth, inPixels, splitPosition);
+                }
+              }}
+              className="flex min-w-0"
+            >
+              <aside className="glass-panel flex h-full w-full flex-col">
+                <div className="flex h-12 shrink-0 items-center border-b border-border-subtle px-3">
+                  <h2 className="text-sm font-semibold text-text-secondary">
+                    {t("Tasks")}
+                  </h2>
+                </div>
+                <div className="flex min-h-0 flex-1 flex-col">
+                  <AssignmentTracker surface="compact" />
+                </div>
+              </aside>
+            </Panel>
+          )}
+        </PanelGroup>
       </div>
 
       {hasTaskSidebar === false && (

--- a/src/app/chat/chat-page-client.tsx
+++ b/src/app/chat/chat-page-client.tsx
@@ -193,8 +193,12 @@ export function ConversationHistory({
             className={`flex min-h-0 flex-col ${
               isPinned
                 ? hasBothSections
-                  ? "max-h-[35%] shrink-0 border-b border-border-subtle/70 pb-2"
-                  : "flex-1"
+                  ? pinnedOpen
+                    ? "max-h-[35%] shrink-0 border-b border-border-subtle/70 pb-2"
+                    : "shrink-0 border-b border-border-subtle/70 pb-1"
+                  : pinnedOpen
+                    ? "flex-1"
+                    : "shrink-0"
                 : "flex-1 pt-1"
             }`}
           >
@@ -224,9 +228,9 @@ export function ConversationHistory({
                 </h3>
               )
             )}
+            {sectionOpen && (
             <div
               id={isPinned ? "pinned-conversations" : undefined}
-              hidden={!sectionOpen}
               className="obsidian-scrollbar min-h-0 flex-1 space-y-0.5 overflow-y-auto px-1.5"
             >
             {section.items.map((conv) => (
@@ -305,6 +309,7 @@ export function ConversationHistory({
           </div>
             ))}
             </div>
+            )}
           </section>
           );
         })}

--- a/src/app/chat/chat-page-client.tsx
+++ b/src/app/chat/chat-page-client.tsx
@@ -95,7 +95,7 @@ interface ConversationHistoryProps {
   showHeader?: boolean;
 }
 
-function ConversationHistory({
+export function ConversationHistory({
   conversations,
   activeId,
   loaded,
@@ -110,6 +110,7 @@ function ConversationHistory({
 }: ConversationHistoryProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editTitle, setEditTitle] = useState("");
+  const [pinnedOpen, setPinnedOpen] = useState(true);
   const cancelRenameRef = useRef(false);
   const pinnedConversations = conversations.filter((conversation) => conversation.pinned);
   const recentConversations = conversations.filter((conversation) => !conversation.pinned);
@@ -174,19 +175,60 @@ function ConversationHistory({
         </button>
       </div>
 
-      <nav className="obsidian-scrollbar flex-1 overflow-y-auto px-1.5 pb-3 pt-1">
+      <nav className="flex min-h-0 flex-1 flex-col overflow-hidden pb-3 pt-1">
         {[
           { label: "Pinned", items: pinnedConversations },
           { label: "Recent", items: recentConversations },
-        ].map((section) => section.items.length > 0 && (
-          <section key={section.label} className={section.label === "Pinned" ? "mb-2.5" : ""}>
-            {section.label === "Pinned" && (
-              <h3 className="flex h-6 items-center gap-0.5 px-2 text-[10px] font-semibold text-text-tertiary/80">
-                {t("Pinned")}
-                <ChevronDownIcon className="h-2.5 w-2.5" aria-hidden="true" />
+        ].map((section) => {
+          if (section.items.length === 0) return null;
+
+          const isPinned = section.label === "Pinned";
+          const hasBothSections =
+            pinnedConversations.length > 0 && recentConversations.length > 0;
+          const sectionOpen = !isPinned || pinnedOpen;
+
+          return (
+          <section
+            key={section.label}
+            className={`flex min-h-0 flex-col ${
+              isPinned
+                ? hasBothSections
+                  ? "max-h-[35%] shrink-0 border-b border-border-subtle/70 pb-2"
+                  : "flex-1"
+                : "flex-1 pt-1"
+            }`}
+          >
+            {isPinned ? (
+              <h3 className="shrink-0 px-1.5">
+                <button
+                  type="button"
+                  onClick={() => setPinnedOpen((open) => !open)}
+                  className="flex h-7 w-full items-center rounded-radius-sm px-2 text-[10px] font-semibold text-text-tertiary/80 transition-colors hover:bg-subtle/70 hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-primary-400/40"
+                  aria-expanded={pinnedOpen}
+                  aria-controls="pinned-conversations"
+                >
+                  <span className="flex-1 text-left">{t("Pinned")}</span>
+                  <span className="mr-1 tabular-nums text-text-tertiary/60">
+                    {pinnedConversations.length}
+                  </span>
+                  <ChevronDownIcon
+                    className={`h-3 w-3 transition-transform ${pinnedOpen ? "rotate-180" : ""}`}
+                    aria-hidden="true"
+                  />
+                </button>
               </h3>
+            ) : (
+              hasBothSections && (
+                <h3 className="flex h-7 shrink-0 items-center px-3.5 text-[10px] font-semibold text-text-tertiary/80">
+                  {t("Recent")}
+                </h3>
+              )
             )}
-            <div className="space-y-0.5">
+            <div
+              id={isPinned ? "pinned-conversations" : undefined}
+              hidden={!sectionOpen}
+              className="obsidian-scrollbar min-h-0 flex-1 space-y-0.5 overflow-y-auto px-1.5"
+            >
             {section.items.map((conv) => (
           <div
             key={conv.id}
@@ -264,7 +306,8 @@ function ConversationHistory({
             ))}
             </div>
           </section>
-        ))}
+          );
+        })}
         {loaded && conversations.length === 0 && (
           <p className="py-4 text-center text-xs text-text-tertiary">
             {t("chat.no_conversations")}

--- a/src/app/chat/chat-page-client.tsx
+++ b/src/app/chat/chat-page-client.tsx
@@ -44,8 +44,19 @@ interface ContextItem {
 
 function PushPinIcon({ className = "" }: { className?: string }) {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className} aria-hidden="true">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m8 3 1.5 2v5L7 13v1h10v-1l-2.5-3V5L16 3H8Zm4 11v7" />
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m8 3 1.5 2v5L7 13v1h10v-1l-2.5-3V5L16 3H8Zm4 11v7"
+      />
     </svg>
   );
 }

--- a/src/app/chat/chat-page-client.tsx
+++ b/src/app/chat/chat-page-client.tsx
@@ -231,7 +231,7 @@ function ConversationHistory({
               <Link
                 href={`/chat/${conv.id}`}
                 onClick={() => onSelectConversation(conv.id)}
-                className="flex min-h-11 w-full items-center gap-1.5 px-2.5 pr-28 text-left focus-visible:outline-none md:min-h-8 md:pr-20"
+                className="flex min-h-11 w-full items-center gap-1.5 px-2.5 pr-32 text-left focus-visible:outline-none md:min-h-8 md:pr-28"
                 aria-current={conv.id === activeId ? "page" : undefined}
               >
                 {conv.pinned && <PushPinIcon className="h-3 w-3 shrink-0 text-primary-400" />}

--- a/src/app/chat/chat-page-client.tsx
+++ b/src/app/chat/chat-page-client.tsx
@@ -231,7 +231,7 @@ function ConversationHistory({
               <Link
                 href={`/chat/${conv.id}`}
                 onClick={() => onSelectConversation(conv.id)}
-                className="flex min-h-11 w-full items-center gap-1.5 px-2.5 pr-32 text-left focus-visible:outline-none md:min-h-8 md:pr-28"
+                className="flex min-h-11 w-full items-center gap-1.5 px-2.5 pr-32 text-left transition-[padding] duration-150 focus-visible:outline-none md:min-h-8 md:pr-16 md:group-hover:pr-28 md:group-focus-within:pr-28"
                 aria-current={conv.id === activeId ? "page" : undefined}
               >
                 {conv.pinned && <PushPinIcon className="h-3 w-3 shrink-0 text-primary-400" />}

--- a/src/app/chat/chat-page-client.tsx
+++ b/src/app/chat/chat-page-client.tsx
@@ -10,7 +10,6 @@ import {
   TrashIcon,
   ChatBubbleLeftRightIcon,
   PencilSquareIcon,
-  Cog6ToothIcon,
   ChevronDownIcon,
 } from "@heroicons/react/24/outline";
 import ChatInterface from "@/components/chat/chat-interface";
@@ -273,17 +272,6 @@ function ConversationHistory({
         )}
       </nav>
 
-      <div className="flex shrink-0 items-center border-t border-border-subtle px-2 py-2">
-        <Link
-          href="/settings"
-          onClick={onDismiss}
-          className="flex h-10 w-10 items-center justify-center rounded-radius-md text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary md:h-8 md:w-8"
-          title={t("chat.configure_ai")}
-          aria-label={t("chat.configure_ai")}
-        >
-          <Cog6ToothIcon className="h-4 w-4" />
-        </Link>
-      </div>
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1104,6 +1104,11 @@ html.light .glass-card-active {
   margin: 0.2rem;
 }
 
+.oghma-milkdown-editor .milkdown-top-bar .top-bar-item svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
 .oghma-milkdown-editor .milkdown-top-bar .top-bar-divider {
   height: 1.4rem;
   margin: 0.35rem;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -571,6 +571,15 @@ select option:disabled {
   letter-spacing: -0.012em;
 }
 
+.md-rendered[data-markdown-variant="note"] h1,
+.md-rendered[data-markdown-variant="note"] h2,
+.md-rendered[data-markdown-variant="note"] h3,
+.md-rendered[data-markdown-variant="note"] h4,
+.md-rendered[data-markdown-variant="note"] h5,
+.md-rendered[data-markdown-variant="note"] h6 {
+  font-family: var(--font-sans);
+}
+
 .markdown-preview a,
 .md-rendered a {
   color: var(--md-link);
@@ -755,11 +764,10 @@ select option:disabled {
 
 /* drag-between line indicator */
 .rct-tree-drag-between-line {
-  height: 3px !important;
-  background: rgb(96, 165, 250) !important;
-  border-radius: 999px;
-  box-shadow: 0 0 0 1px rgb(15 23 42 / 0.85), 0 0 8px rgb(96 165 250 / 0.65);
-  opacity: 1;
+  height: 2px !important;
+  background: rgb(59, 130, 246) !important;
+  border-radius: 1px;
+  opacity: 0.7;
 }
 
 /* obsidian-style scrollbar */
@@ -1073,7 +1081,7 @@ html.light .glass-card-active {
   --crepe-color-hover: color-mix(in srgb, var(--md-accent) 10%, var(--color-surface));
   --crepe-color-selected: var(--md-selection);
   --crepe-color-inline-area: var(--md-inline-code-bg);
-  --crepe-font-title: var(--font-source-serif), ui-serif, Georgia, serif;
+  --crepe-font-title: var(--font-dm-sans), ui-sans-serif, system-ui, sans-serif;
   --crepe-font-default: var(--font-dm-sans), ui-sans-serif, system-ui, sans-serif;
   --crepe-font-code: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --crepe-shadow-1: 0 1px 3px rgb(0 0 0 / 0.22);
@@ -1126,7 +1134,7 @@ html.light .glass-card-active {
 .oghma-milkdown-editor .milkdown .ProseMirror h4,
 .oghma-milkdown-editor .milkdown .ProseMirror h5,
 .oghma-milkdown-editor .milkdown .ProseMirror h6 {
-  font-family: var(--font-serif);
+  font-family: var(--font-sans);
   font-optical-sizing: auto;
   letter-spacing: -0.018em;
   text-wrap: balance;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -753,19 +753,13 @@ select option:disabled {
   padding: 0 !important;
 }
 
-/* drop target: subtle blue highlight on the folder row */
-.rct-tree-item-title-container-draggingover {
-  background-color: rgba(59, 130, 246, 0.08) !important;
-  border-radius: 3px !important;
-  border: none !important;
-}
-
 /* drag-between line indicator */
 .rct-tree-drag-between-line {
-  height: 2px !important;
-  background: rgb(59, 130, 246) !important;
-  border-radius: 1px;
-  opacity: 0.6;
+  height: 3px !important;
+  background: rgb(96, 165, 250) !important;
+  border-radius: 999px;
+  box-shadow: 0 0 0 1px rgb(15 23 42 / 0.85), 0 0 8px rgb(96 165 250 / 0.65);
+  opacity: 1;
 }
 
 /* obsidian-style scrollbar */

--- a/src/components/breadcrumb.tsx
+++ b/src/components/breadcrumb.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { HomeIcon } from '@heroicons/react/20/solid'
+import { ChevronRightIcon, HomeIcon } from '@heroicons/react/20/solid'
 import Link from 'next/link'
 import useI18n from '@/lib/notes/hooks/use-i18n'
 
@@ -31,9 +31,7 @@ export function Breadcrumb({ pages = [], homeHref = '/' }: BreadcrumbProps) {
         {pages.map((page) => (
           <li key={page.name}>
             <div className="flex items-center gap-2 truncate">
-              <svg fill="currentColor" viewBox="0 0 20 20" aria-hidden="true" className="size-4 shrink-0 text-text-tertiary">
-                <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-              </svg>
+              <ChevronRightIcon aria-hidden="true" className="size-4 shrink-0 text-text-tertiary" />
               <Link
                 href={page.href}
                 aria-current={page.current ? 'page' : undefined}

--- a/src/components/canvas/canvas-import-status-bar.jsx
+++ b/src/components/canvas/canvas-import-status-bar.jsx
@@ -2,6 +2,12 @@
 
 import { useEffect, useState } from "react";
 import useI18n from "@/lib/notes/hooks/use-i18n";
+import {
+  ArrowPathIcon,
+  CheckIcon,
+  ExclamationTriangleIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
 
 /**
  * Subtle bottom-bar notification for Canvas imports.
@@ -93,51 +99,13 @@ export default function CanvasImportStatusBar({
       <div className="flex items-center justify-between px-4 py-1.5 bg-background/95 backdrop-blur-sm border-t border-border-subtle text-xs">
         <div className="flex items-center gap-2 min-w-0">
           {isProcessing && (
-            <svg
-              className="w-3 h-3 animate-spin text-primary-400 shrink-0"
-              viewBox="0 0 24 24"
-              fill="none"
-            >
-              <circle
-                className="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeWidth="3"
-              />
-              <path
-                className="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-              />
-            </svg>
+            <ArrowPathIcon className="h-3 w-3 shrink-0 animate-spin text-primary-400" aria-hidden="true" />
           )}
           {isComplete && !hasIssues && (
-            <svg
-              className="w-3 h-3 text-green-400 shrink-0"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fillRule="evenodd"
-                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                clipRule="evenodd"
-              />
-            </svg>
+            <CheckIcon className="h-3 w-3 shrink-0 text-green-400" aria-hidden="true" />
           )}
           {isComplete && hasIssues && (
-            <svg
-              className="w-3 h-3 text-orange-400 shrink-0"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fillRule="evenodd"
-                d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
-                clipRule="evenodd"
-              />
-            </svg>
+            <ExclamationTriangleIcon className="h-3 w-3 shrink-0 text-orange-400" aria-hidden="true" />
           )}
           <span className="text-text-tertiary truncate">{text}</span>
         </div>
@@ -163,13 +131,7 @@ export default function CanvasImportStatusBar({
             }}
             className="text-text-tertiary hover:text-text-secondary p-0.5"
           >
-            <svg className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
-              <path
-                fillRule="evenodd"
-                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                clipRule="evenodd"
-              />
-            </svg>
+            <XMarkIcon className="h-3 w-3" aria-hidden="true" />
           </button>
         </div>
       </div>

--- a/src/components/editor/editor-pane.tsx
+++ b/src/components/editor/editor-pane.tsx
@@ -159,6 +159,10 @@ const EditorPane: FC<EditorPaneProps> = ({
 
   const showFirstRunOnboarding =
     pane === "A" && initLoaded && rootChildCount === 0;
+  const aiChatIsOpen = rightPanelOpen && rightPanelTab === "ai";
+  const aiChatLabel = aiChatIsOpen
+    ? `${t("Close")} ${t("AI Chat")}`
+    : t("Open AI chat");
 
   // empty state — no file assigned to this pane
   if (!file || !file.fileId) {
@@ -263,13 +267,15 @@ const EditorPane: FC<EditorPaneProps> = ({
           <button
             onClick={() => openRightPanelTab("ai")}
             className={`flex h-10 w-10 items-center justify-center rounded transition-colors md:h-auto md:w-auto md:p-1 ${
-              rightPanelOpen && rightPanelTab === "ai"
+              aiChatIsOpen
                 ? "bg-subtle text-text-secondary"
                 : "text-text-tertiary hover:bg-subtle hover:text-text-secondary"
             }`}
-            title={t("Toggle AI assistant panel")}
+            title={aiChatLabel}
+            aria-label={aiChatLabel}
+            aria-expanded={aiChatIsOpen}
           >
-            <SparklesIcon className="w-3.5 h-3.5" />
+            <SparklesIcon className="w-3.5 h-3.5" aria-hidden="true" />
           </button>
           {pane === "B" && (
             <button

--- a/src/components/editor/editor-pane.tsx
+++ b/src/components/editor/editor-pane.tsx
@@ -8,7 +8,7 @@ import {
   DocumentIcon,
   RectangleGroupIcon,
   XMarkIcon,
-  CpuChipIcon,
+  SparklesIcon,
 } from "@heroicons/react/24/outline";
 import useLayoutStore from "@/lib/notes/state/layout.zustand";
 import useI18n from "@/lib/notes/hooks/use-i18n";
@@ -269,7 +269,7 @@ const EditorPane: FC<EditorPaneProps> = ({
             }`}
             title={t("Toggle AI assistant panel")}
           >
-            <CpuChipIcon className="w-3.5 h-3.5" />
+            <SparklesIcon className="w-3.5 h-3.5" />
           </button>
           {pane === "B" && (
             <button

--- a/src/components/editor/editor-pane.tsx
+++ b/src/components/editor/editor-pane.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { FileSpec } from "@/lib/notes/state/layout.zustand";
 import {
+  ClipboardDocumentCheckIcon,
   DocumentIcon,
   RectangleGroupIcon,
   XMarkIcon,
@@ -50,6 +51,7 @@ const EditorPane: FC<EditorPaneProps> = ({
     (s) => s.tree.items.root?.children?.length ?? 0,
   );
   const genNewId = useNoteTreeStore((s) => s.genNewId);
+  const setRenamingId = useNoteTreeStore((s) => s.setRenamingId);
   const createNote = useNoteStore((s) => s.createNote);
 
   const paneRef = useRef<HTMLDivElement>(null);
@@ -149,17 +151,28 @@ const EditorPane: FC<EditorPaneProps> = ({
       }
 
       setPaneA(buildFileSpec(note));
+      setRenamingId(id);
       router.push(`/notes/${id}`);
     } catch {
       toast.error(t("Could not create your first note. Please try again."));
     } finally {
       setIsCreatingFirstNote(false);
     }
-  }, [createNote, genNewId, isCreatingFirstNote, router, setPaneA, t]);
+  }, [
+    createNote,
+    genNewId,
+    isCreatingFirstNote,
+    router,
+    setPaneA,
+    setRenamingId,
+    t,
+  ]);
 
   const showFirstRunOnboarding =
     pane === "A" && initLoaded && rootChildCount === 0;
   const aiChatIsOpen = rightPanelOpen && rightPanelTab === "ai";
+  const metadataIsOpen = rightPanelOpen && rightPanelTab === "meta";
+  const tasksAreOpen = rightPanelOpen && rightPanelTab === "tasks";
   const aiChatLabel = aiChatIsOpen
     ? `${t("Close")} ${t("AI Chat")}`
     : t("Open AI chat");
@@ -254,19 +267,23 @@ const EditorPane: FC<EditorPaneProps> = ({
 
         <div className="flex items-center gap-0.5">
           <button
+            type="button"
             onClick={() => openRightPanelTab("meta")}
-            className={`flex h-10 w-10 items-center justify-center rounded transition-colors md:h-auto md:w-auto md:p-1 ${
-              rightPanelOpen && rightPanelTab === "meta"
+            className={`flex h-10 w-10 items-center justify-center rounded transition-colors md:h-7 md:w-7 ${
+              metadataIsOpen
                 ? "bg-subtle text-text-secondary"
                 : "text-text-tertiary hover:bg-subtle hover:text-text-secondary"
             }`}
             title={t("Toggle metadata panel")}
+            aria-label={t("Toggle metadata panel")}
+            aria-expanded={metadataIsOpen}
           >
-            <RectangleGroupIcon className="w-3.5 h-3.5" />
+            <RectangleGroupIcon className="h-5 w-5" aria-hidden="true" />
           </button>
           <button
+            type="button"
             onClick={() => openRightPanelTab("ai")}
-            className={`flex h-10 w-10 items-center justify-center rounded transition-colors md:h-auto md:w-auto md:p-1 ${
+            className={`flex h-10 w-10 items-center justify-center rounded transition-colors md:h-7 md:w-7 ${
               aiChatIsOpen
                 ? "bg-subtle text-text-secondary"
                 : "text-text-tertiary hover:bg-subtle hover:text-text-secondary"
@@ -275,7 +292,21 @@ const EditorPane: FC<EditorPaneProps> = ({
             aria-label={aiChatLabel}
             aria-expanded={aiChatIsOpen}
           >
-            <SparklesIcon className="w-3.5 h-3.5" aria-hidden="true" />
+            <SparklesIcon className="h-5 w-5" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            onClick={() => openRightPanelTab("tasks")}
+            className={`flex h-10 w-10 items-center justify-center rounded transition-colors md:h-7 md:w-7 ${
+              tasksAreOpen
+                ? "bg-subtle text-text-secondary"
+                : "text-text-tertiary hover:bg-subtle hover:text-text-secondary"
+            }`}
+            title={t("Global Tasks")}
+            aria-label={t("Global Tasks")}
+            aria-expanded={tasksAreOpen}
+          >
+            <ClipboardDocumentCheckIcon className="h-5 w-5" aria-hidden="true" />
           </button>
           {pane === "B" && (
             <button

--- a/src/components/editor/pdf-viewer.tsx
+++ b/src/components/editor/pdf-viewer.tsx
@@ -7,6 +7,8 @@ import {
   MagnifyingGlassMinusIcon,
   MagnifyingGlassPlusIcon,
   ArrowsPointingOutIcon,
+  ArrowPathIcon,
+  ExclamationTriangleIcon,
 } from "@heroicons/react/24/outline";
 import { usePdfCache } from "@/lib/notes/pdf-cache/use-pdf-cache";
 import useI18n from "@/lib/notes/hooks/use-i18n";
@@ -146,44 +148,20 @@ const PDFViewer: FC<PDFViewerProps> = ({ file, pane: _pane }) => {
       >
         {loading ? (
           <div className="flex flex-col items-center gap-3 mt-16">
-            <svg
-              className="w-6 h-6 animate-spin text-text-tertiary"
-              viewBox="0 0 24 24"
-              fill="none"
-            >
-              <circle
-                className="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeWidth="3"
-              />
-              <path
-                className="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-              />
-            </svg>
+            <ArrowPathIcon
+              className="h-6 w-6 animate-spin text-text-tertiary"
+              aria-hidden="true"
+            />
             <span className="text-sm text-text-tertiary">
               {t("pdf_viewer.loading")}
             </span>
           </div>
         ) : !pdfPath ? (
           <div className="flex flex-col items-center gap-3 mt-16 text-center px-6">
-            <svg
-              className="w-8 h-8 text-red-400/60"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
-              />
-            </svg>
+            <ExclamationTriangleIcon
+              className="h-8 w-8 text-red-400/60"
+              aria-hidden="true"
+            />
             <p className="text-sm text-red-400/80">{t("pdf_viewer.error")}</p>
             <p className="text-xs text-text-tertiary">
               {urlError === "http-404"
@@ -199,25 +177,10 @@ const PDFViewer: FC<PDFViewerProps> = ({ file, pane: _pane }) => {
             onLoadSuccess={onDocumentLoadSuccess}
             loading={
               <div className="flex flex-col items-center gap-3 mt-16">
-                <svg
-                  className="w-6 h-6 animate-spin text-text-tertiary"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="3"
-                  />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                  />
-                </svg>
+                <ArrowPathIcon
+                  className="h-6 w-6 animate-spin text-text-tertiary"
+                  aria-hidden="true"
+                />
                 <span className="text-sm text-text-tertiary">
                   {t("pdf_viewer.preparing")}
                 </span>

--- a/src/components/notes/note-inspector-panel.tsx
+++ b/src/components/notes/note-inspector-panel.tsx
@@ -31,6 +31,27 @@ interface InspectorNote {
   updatedAt?: string;
 }
 
+function formatTimestamp(value?: string) {
+  if (!value) return null;
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+
+  return {
+    iso: date.toISOString(),
+    label: new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      fractionalSecondDigits: 3,
+      timeZoneName: "shortOffset",
+    }).format(date),
+  };
+}
+
 export default function NoteInspectorPanel({
   presentation = "desktop",
 }: {
@@ -88,6 +109,14 @@ export default function NoteInspectorPanel({
   }, [activeFile?.fileId]);
 
   const tags = useMemo(() => extractTags(note?.content), [note?.content]);
+  const createdTimestamp = useMemo(
+    () => formatTimestamp(note?.createdAt),
+    [note?.createdAt],
+  );
+  const updatedTimestamp = useMemo(
+    () => formatTimestamp(note?.updatedAt),
+    [note?.updatedAt],
+  );
 
   // inline tag editing
   const [newTag, setNewTag] = useState("");
@@ -238,17 +267,31 @@ export default function NoteInspectorPanel({
                   <div>
                     <dt className="text-xs text-text-tertiary">{t("Created")}</dt>
                     <dd className="mt-0.5 text-text-tertiary text-sm">
-                      {note.createdAt
-                        ? new Date(note.createdAt).toLocaleDateString()
-                        : t("Unknown")}
+                      {createdTimestamp ? (
+                        <time
+                          dateTime={createdTimestamp.iso}
+                          title={createdTimestamp.iso}
+                        >
+                          {createdTimestamp.label}
+                        </time>
+                      ) : (
+                        t("Unknown")
+                      )}
                     </dd>
                   </div>
                   <div>
                     <dt className="text-xs text-text-tertiary">{t("Updated")}</dt>
                     <dd className="mt-0.5 text-text-tertiary text-sm">
-                      {note.updatedAt
-                        ? new Date(note.updatedAt).toLocaleDateString()
-                        : t("Unknown")}
+                      {updatedTimestamp ? (
+                        <time
+                          dateTime={updatedTimestamp.iso}
+                          title={updatedTimestamp.iso}
+                        >
+                          {updatedTimestamp.label}
+                        </time>
+                      ) : (
+                        t("Unknown")
+                      )}
                     </dd>
                   </div>
                   <div>

--- a/src/components/notes/note-inspector-panel.tsx
+++ b/src/components/notes/note-inspector-panel.tsx
@@ -27,9 +27,8 @@ interface InspectorNote {
   id: string;
   title?: string;
   content?: string;
-  created_at?: string;
-  updated_at?: string;
-  note_id?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export default function NoteInspectorPanel({
@@ -239,23 +238,23 @@ export default function NoteInspectorPanel({
                   <div>
                     <dt className="text-xs text-text-tertiary">{t("Created")}</dt>
                     <dd className="mt-0.5 text-text-tertiary text-sm">
-                      {note.created_at
-                        ? new Date(note.created_at).toLocaleDateString()
+                      {note.createdAt
+                        ? new Date(note.createdAt).toLocaleDateString()
                         : t("Unknown")}
                     </dd>
                   </div>
                   <div>
                     <dt className="text-xs text-text-tertiary">{t("Updated")}</dt>
                     <dd className="mt-0.5 text-text-tertiary text-sm">
-                      {note.updated_at
-                        ? new Date(note.updated_at).toLocaleDateString()
+                      {note.updatedAt
+                        ? new Date(note.updatedAt).toLocaleDateString()
                         : t("Unknown")}
                     </dd>
                   </div>
                   <div>
                     <dt className="text-xs text-text-tertiary">{t("ID")}</dt>
                     <dd className="mt-0.5 break-all font-mono text-xs text-text-tertiary/50">
-                      {note.note_id || note.id || activeFile.fileId}
+                      {note.id || activeFile.fileId}
                     </dd>
                   </div>
                 </dl>

--- a/src/components/notes/notes-workspace.tsx
+++ b/src/components/notes/notes-workspace.tsx
@@ -3,6 +3,11 @@
 import { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { FolderOpenIcon } from "@heroicons/react/24/outline";
+import {
+  Group as PanelGroup,
+  Panel,
+  Separator as PanelResizeHandle,
+} from "react-resizable-panels";
 import useLayoutStore from "@/lib/notes/state/layout.zustand";
 import useNoteTreeStore from "@/lib/notes/state/tree";
 import { schedulePrefetch } from "@/lib/notes/prefetch";
@@ -30,6 +35,8 @@ export default function NotesWorkspace() {
   const rightPanelOpen = useLayoutStore((s) => s.rightPanelOpen);
   const rightPanelTab = useLayoutStore((s) => s.rightPanelTab);
   const setRightPanelOpen = useLayoutStore((s) => s.setRightPanelOpen);
+  const splitPosition = useLayoutStore((s) => s.splitPosition);
+  const setSizes = useLayoutStore((s) => s.setSizes);
   const setPaneA = useLayoutStore((s) => s.setPaneA);
   const paneAFileId = useLayoutStore((s) => s.paneA.fileId);
 
@@ -51,7 +58,8 @@ export default function NotesWorkspace() {
     const controller = new AbortController();
     void fetch(`/api/notes/${fileId}`, { signal: controller.signal })
       .then(async (response) => {
-        if (!response.ok) throw new Error(`note fetch failed: ${response.status}`);
+        if (!response.ok)
+          throw new Error(`note fetch failed: ${response.status}`);
         const note = await response.json();
         setPaneA(buildFileSpec(note));
       })
@@ -85,7 +93,8 @@ export default function NotesWorkspace() {
       const target = event.target;
       const canSwitchPane =
         target === document.body ||
-        (target instanceof HTMLElement && target.dataset.paneShortcut === "true");
+        (target instanceof HTMLElement &&
+          target.dataset.paneShortcut === "true");
 
       if (
         event.key === "Tab" &&
@@ -160,56 +169,96 @@ export default function NotesWorkspace() {
         </>
       )}
 
-      <div
-        className="min-h-0 flex-1 overflow-hidden md:grid"
-        style={
-          isDesktop === true
-            ? {
-                gridTemplateColumns: `3rem ${treeWidth}px 1fr ${rightPanelOpen ? rightPanelWidth : 0}px`,
-                gap: "0",
-              }
-            : undefined
-        }
-      >
+      <div className="flex min-h-0 flex-1 overflow-hidden">
         {isDesktop === true && (
           <div
             key="navigation"
-            className="flex flex-col overflow-hidden border-r border-border-subtle bg-background"
+            className="w-12 shrink-0 flex-col overflow-hidden border-r border-border-subtle bg-background md:flex"
           >
             <PrimaryNavigation />
           </div>
         )}
 
         {isDesktop === true && (
-          <div
-            key="tree"
-            className="flex flex-col overflow-hidden border-r border-border-subtle bg-background"
-          >
-            <NoteTreePanel />
-          </div>
+          <PanelGroup orientation="horizontal" className="min-w-0 flex-1">
+            <Panel
+              id="note-tree"
+              defaultSize={`${treeWidth}px`}
+              minSize="200px"
+              maxSize="600px"
+              groupResizeBehavior="preserve-pixel-size"
+              onResize={({ inPixels }, _id, previousSize) => {
+                if (previousSize)
+                  setSizes(inPixels, rightPanelWidth, splitPosition);
+              }}
+              className="flex min-w-0"
+            >
+              <div className="flex h-full w-full flex-col overflow-hidden bg-background">
+                <NoteTreePanel />
+              </div>
+            </Panel>
+
+            <PanelResizeHandle
+              aria-label={t("Resize notes panel")}
+              className="w-px cursor-col-resize bg-border-subtle transition-colors hover:bg-primary-500/40 active:bg-primary-500/60"
+            />
+
+            <Panel id="note-editor" minSize="320px" className="flex min-w-0">
+              <main
+                aria-label={t("Note editor")}
+                className="h-full min-h-0 w-full overflow-hidden bg-background"
+              >
+                {!noteDependenciesReady ? (
+                  <div className="flex h-full items-center justify-center text-sm text-text-tertiary">
+                    {t("Loading...")}
+                  </div>
+                ) : (
+                  <SplitEditorPane />
+                )}
+              </main>
+            </Panel>
+
+            {rightPanelOpen && (
+              <PanelResizeHandle
+                aria-label={t("Resize details panel")}
+                className="w-px cursor-col-resize bg-border-subtle transition-colors hover:bg-primary-500/40 active:bg-primary-500/60"
+              />
+            )}
+
+            {rightPanelOpen && (
+              <Panel
+                id="note-inspector"
+                defaultSize={`${rightPanelWidth}px`}
+                minSize="250px"
+                maxSize="400px"
+                groupResizeBehavior="preserve-pixel-size"
+                onResize={({ inPixels }, _id, previousSize) => {
+                  if (previousSize)
+                    setSizes(treeWidth, inPixels, splitPosition);
+                }}
+                className="flex min-w-0"
+              >
+                <div className="glass-panel flex h-full w-full flex-col overflow-hidden">
+                  <NoteInspectorPanel />
+                </div>
+              </Panel>
+            )}
+          </PanelGroup>
         )}
 
-        <main
-          key="editor"
-          aria-label={t("Note editor")}
-          className="h-full min-h-0 overflow-hidden bg-background"
-        >
-          {isDesktop === null || !noteDependenciesReady ? (
-            <div className="flex h-full items-center justify-center text-sm text-text-tertiary">
-              {t("Loading...")}
-            </div>
-          ) : (
-            <SplitEditorPane />
-          )}
-        </main>
-
-        {isDesktop === true && rightPanelOpen && (
-          <div
-            key="inspector"
-            className="glass-panel flex flex-col overflow-hidden"
+        {isDesktop !== true && (
+          <main
+            aria-label={t("Note editor")}
+            className="h-full min-h-0 w-full overflow-hidden bg-background"
           >
-            <NoteInspectorPanel />
-          </div>
+            {isDesktop === null || !noteDependenciesReady ? (
+              <div className="flex h-full items-center justify-center text-sm text-text-tertiary">
+                {t("Loading...")}
+              </div>
+            ) : (
+              <SplitEditorPane />
+            )}
+          </main>
         )}
       </div>
     </div>

--- a/src/components/notes/notes-workspace.tsx
+++ b/src/components/notes/notes-workspace.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { FolderOpenIcon } from "@heroicons/react/24/outline";
 import {
@@ -39,6 +39,8 @@ export default function NotesWorkspace() {
   const setSizes = useLayoutStore((s) => s.setSizes);
   const setPaneA = useLayoutStore((s) => s.setPaneA);
   const paneAFileId = useLayoutStore((s) => s.paneA.fileId);
+  const treeWidthRef = useRef(treeWidth);
+  const rightPanelWidthRef = useRef(rightPanelWidth);
 
   useEffect(() => {
     const route = resolveNoteRoute(pathname);
@@ -184,6 +186,13 @@ export default function NotesWorkspace() {
             key={rightPanelOpen ? "with-inspector" : "without-inspector"}
             orientation="horizontal"
             className="min-w-0 flex-1"
+            onLayoutChanged={() => {
+              setSizes(
+                treeWidthRef.current,
+                rightPanelWidthRef.current,
+                splitPosition,
+              );
+            }}
           >
             <Panel
               id="note-tree"
@@ -191,9 +200,8 @@ export default function NotesWorkspace() {
               minSize="200px"
               maxSize="600px"
               groupResizeBehavior="preserve-pixel-size"
-              onResize={({ inPixels }, _id, previousSize) => {
-                if (previousSize)
-                  setSizes(inPixels, rightPanelWidth, splitPosition);
+              onResize={({ inPixels }) => {
+                treeWidthRef.current = inPixels;
               }}
               className="flex min-w-0"
             >
@@ -236,9 +244,8 @@ export default function NotesWorkspace() {
                 minSize="250px"
                 maxSize="600px"
                 groupResizeBehavior="preserve-pixel-size"
-                onResize={({ inPixels }, _id, previousSize) => {
-                  if (previousSize)
-                    setSizes(treeWidth, inPixels, splitPosition);
+                onResize={({ inPixels }) => {
+                  rightPanelWidthRef.current = inPixels;
                 }}
                 className="flex min-w-0"
               >

--- a/src/components/notes/notes-workspace.tsx
+++ b/src/components/notes/notes-workspace.tsx
@@ -180,7 +180,11 @@ export default function NotesWorkspace() {
         )}
 
         {isDesktop === true && (
-          <PanelGroup orientation="horizontal" className="min-w-0 flex-1">
+          <PanelGroup
+            key={rightPanelOpen ? "with-inspector" : "without-inspector"}
+            orientation="horizontal"
+            className="min-w-0 flex-1"
+          >
             <Panel
               id="note-tree"
               defaultSize={`${treeWidth}px`}
@@ -230,7 +234,7 @@ export default function NotesWorkspace() {
                 id="note-inspector"
                 defaultSize={`${rightPanelWidth}px`}
                 minSize="250px"
-                maxSize="400px"
+                maxSize="600px"
                 groupResizeBehavior="preserve-pixel-size"
                 onResize={({ inPixels }, _id, previousSize) => {
                   if (previousSize)

--- a/src/components/notes/sidebar/note-context-menu.tsx
+++ b/src/components/notes/sidebar/note-context-menu.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import useI18n from "@/lib/notes/hooks/use-i18n";
 import useContextMenuStore from "@/lib/notes/state/context-menu";
 import {
+  ChatBubbleLeftRightIcon,
   DocumentPlusIcon,
   FolderPlusIcon,
   PencilSquareIcon,
@@ -21,6 +22,7 @@ interface NoteContextMenuPortalProps {
   onCreateNote: (parentId: string) => void;
   onCreateFolder: (parentId: string) => void;
   onOpenInSplit: (id: string) => void;
+  onOpenInAIChat: (id: string) => void;
 }
 
 // menu item component for consistency
@@ -73,6 +75,7 @@ export default function NoteContextMenuPortal({
   onCreateNote,
   onCreateFolder,
   onOpenInSplit,
+  onOpenInAIChat,
 }: NoteContextMenuPortalProps) {
   const { t } = useI18n();
   const {
@@ -160,6 +163,7 @@ export default function NoteContextMenuPortal({
     newNote: <DocumentPlusIcon className="h-3.5 w-3.5" aria-hidden="true" />,
     newFolder: <FolderPlusIcon className="h-3.5 w-3.5" aria-hidden="true" />,
     split: <ViewColumnsIcon className="h-3.5 w-3.5" aria-hidden="true" />,
+    chat: <ChatBubbleLeftRightIcon className="h-3.5 w-3.5" aria-hidden="true" />,
     trash: <TrashIcon className="h-3.5 w-3.5" aria-hidden="true" />,
   };
 
@@ -189,6 +193,12 @@ export default function NoteContextMenuPortal({
               onClick={() => run(() => onTogglePin(openMenuId))}
             />
           )}
+
+          <MenuItem
+            label={isFolder ? t("Chat with folder") : t("Chat with note")}
+            icon={icons.chat}
+            onClick={() => run(() => onOpenInAIChat(openMenuId))}
+          />
 
           <MenuItem
             label={t("Rename")}

--- a/src/components/notes/sidebar/note-context-menu.tsx
+++ b/src/components/notes/sidebar/note-context-menu.tsx
@@ -4,6 +4,14 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import useI18n from "@/lib/notes/hooks/use-i18n";
 import useContextMenuStore from "@/lib/notes/state/context-menu";
+import {
+  DocumentPlusIcon,
+  FolderPlusIcon,
+  PencilSquareIcon,
+  Square2StackIcon,
+  TrashIcon,
+  ViewColumnsIcon,
+} from "@heroicons/react/24/outline";
 
 interface NoteContextMenuPortalProps {
   onRename: (id: string) => void;
@@ -133,89 +141,26 @@ export default function NoteContextMenuPortal({
   };
   const isMultiSelectMenu = selectedCount > 1;
 
-  // svg icons inline for crisp rendering
   const icons = {
     pin: (
       <svg
-        className="w-3.5 h-3.5"
+        className="h-3.5 w-3.5"
         viewBox="0 0 20 20"
         fill="none"
         stroke="currentColor"
         strokeWidth="1.5"
+        aria-hidden="true"
       >
         <path d="M11.5 3.5l5 5-3 3-1-1-4 4-2.5-2.5 4-4-1-1-3 3" />
         <path d="M6 14l-2.5 2.5" />
       </svg>
     ),
-    rename: (
-      <svg
-        className="w-3.5 h-3.5"
-        viewBox="0 0 20 20"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      >
-        <path d="M13.586 3.586a2 2 0 112.828 2.828l-9.5 9.5-3.5 1 1-3.5 9.172-9.828z" />
-      </svg>
-    ),
-    duplicate: (
-      <svg
-        className="w-3.5 h-3.5"
-        viewBox="0 0 20 20"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      >
-        <rect x="5" y="5" width="11" height="11" rx="1" />
-        <path d="M4 15V4a1 1 0 011-1h11" />
-      </svg>
-    ),
-    newNote: (
-      <svg
-        className="w-3.5 h-3.5"
-        viewBox="0 0 20 20"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      >
-        <path d="M4 4h8l4 4v8a1 1 0 01-1 1H4a1 1 0 01-1-1V5a1 1 0 011-1z" />
-        <path d="M12 4v4h4" />
-      </svg>
-    ),
-    newFolder: (
-      <svg
-        className="w-3.5 h-3.5"
-        viewBox="0 0 20 20"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      >
-        <path d="M3 5a1 1 0 011-1h4l2 2h6a1 1 0 011 1v8a1 1 0 01-1 1H4a1 1 0 01-1-1V5z" />
-      </svg>
-    ),
-    split: (
-      <svg
-        className="w-3.5 h-3.5"
-        viewBox="0 0 20 20"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      >
-        <rect x="2" y="3" width="16" height="14" rx="1" />
-        <line x1="10" y1="3" x2="10" y2="17" />
-      </svg>
-    ),
-    trash: (
-      <svg
-        className="w-3.5 h-3.5"
-        viewBox="0 0 20 20"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      >
-        <path d="M5 6h10M8 6V4h4v2M6 6v10a1 1 0 001 1h6a1 1 0 001-1V6" />
-      </svg>
-    ),
+    rename: <PencilSquareIcon className="h-3.5 w-3.5" aria-hidden="true" />,
+    duplicate: <Square2StackIcon className="h-3.5 w-3.5" aria-hidden="true" />,
+    newNote: <DocumentPlusIcon className="h-3.5 w-3.5" aria-hidden="true" />,
+    newFolder: <FolderPlusIcon className="h-3.5 w-3.5" aria-hidden="true" />,
+    split: <ViewColumnsIcon className="h-3.5 w-3.5" aria-hidden="true" />,
+    trash: <TrashIcon className="h-3.5 w-3.5" aria-hidden="true" />,
   };
 
   return createPortal(

--- a/src/components/notes/sidebar/selection-utils.ts
+++ b/src/components/notes/sidebar/selection-utils.ts
@@ -1,4 +1,5 @@
 import { ROOT_ID, TreeModel } from "@/lib/notes/types/tree";
+export { treeItemContainsId } from "@/lib/notes/state/tree-cycle";
 
 export function getVisibleTreeItemIds(
   tree: TreeModel,
@@ -9,10 +10,12 @@ export function getVisibleTreeItemIds(
   if (!root) return [];
 
   const result: string[] = [];
+  const visited = new Set<string>();
 
   const visit = (id: string) => {
-    if (id === ROOT_ID || !tree.items[id]) return;
+    if (id === ROOT_ID || !tree.items[id] || visited.has(id)) return;
 
+    visited.add(id);
     result.push(id);
 
     if (!expandedIds.has(id)) return;
@@ -75,27 +78,14 @@ export function getTopLevelSelectedIds(
 
   return Array.from(selected).filter((id) => {
     let parentId = parentById.get(id);
+    const visited = new Set<string>();
     while (parentId) {
+      if (visited.has(parentId)) return true;
+      visited.add(parentId);
       if (selected.has(parentId)) return false;
       if (parentId === ROOT_ID) return true;
       parentId = parentById.get(parentId);
     }
     return true;
   });
-}
-
-export function treeItemContainsId(
-  tree: TreeModel,
-  ancestorId: string,
-  descendantId: string,
-): boolean {
-  const ancestor = tree.items[ancestorId];
-  if (!ancestor) return false;
-
-  for (const childId of ancestor.children) {
-    if (childId === descendantId) return true;
-    if (treeItemContainsId(tree, childId, descendantId)) return true;
-  }
-
-  return false;
 }

--- a/src/components/notes/sidebar/sidebar-list-item.tsx
+++ b/src/components/notes/sidebar/sidebar-list-item.tsx
@@ -14,7 +14,6 @@ import React, {
 import { useRouter, usePathname } from "next/navigation";
 import IconButton from "@/components/icon-button";
 import useNoteTreeStore from "@/lib/notes/state/tree";
-import useNoteStore from "@/lib/notes/state/note";
 import usePortalStore from "@/lib/notes/state/portal";
 import useSyncStatusStore from "@/lib/notes/state/sync-status";
 import useI18n from "@/lib/notes/hooks/use-i18n";
@@ -53,8 +52,7 @@ const SidebarListItem: FC<{
   const { t } = useI18n();
   const router = useRouter();
   const pathname = usePathname();
-  const { mutateItem, initLoaded, genNewId } = useNoteTreeStore();
-  const { createNote } = useNoteStore();
+  const { initLoaded } = useNoteTreeStore();
   const {
     activePane: _activePane,
     setPaneA,
@@ -104,29 +102,6 @@ const SidebarListItem: FC<{
     }
     return `/${item.id}`;
   }, [pathname, item.id, isFolder]);
-
-  const onAddNote = useCallback(
-    async (e: React.MouseEvent) => {
-      e.preventDefault();
-      // Create a new note under this item without navigation
-      const newId = genNewId();
-      const newNote = await createNote({
-        id: newId,
-        title: "Untitled",
-        content: "\n",
-        pid: item.id,
-      });
-
-      if (newNote) {
-        // Expand the parent and navigate to the new note
-        await mutateItem(item.id, {
-          isExpanded: true,
-        });
-        router.push(`/notes/${newId}`);
-      }
-    },
-    [item.id, mutateItem, genNewId, createNote, router],
-  );
 
   const handleClickMenu = useCallback(
     (event: React.MouseEvent) => {
@@ -229,16 +204,6 @@ const SidebarListItem: FC<{
     if (emoji?.length === 1) return emoji[0];
     return undefined;
   }, [item.title]);
-
-  // Determine if this is a true folder (use isFolder flag primarily, with emoji fallback)
-  const isActualFolder = useMemo(() => {
-    // Primary check: use the isFolder flag from database
-    if (item.isFolder === true) return true;
-    // Emoji check: title contains folder emoji
-    if (item.title?.includes("📁")) return true;
-    // Secondary check: if it has children, it's a folder
-    return hasChildren;
-  }, [item.isFolder, item.title, hasChildren]);
 
   return (
     <>
@@ -366,15 +331,6 @@ const SidebarListItem: FC<{
           aria-label={t("Note actions")}
         ></IconButton>
 
-        {isActualFolder && (
-          <IconButton
-            icon="Plus"
-            onClick={onAddNote}
-            className="p-1 ml-1 text-text-tertiary hover:text-text-secondary rounded-radius-sm transition-colors hidden group-hover:block flex-shrink-0"
-            title={t("Add a page inside this folder")}
-            aria-label={t("Add note")}
-          ></IconButton>
-        )}
       </div>
 
       {isFolder && !hasChildren && isExpanded && (

--- a/src/components/notes/sidebar/sidebar-list.tsx
+++ b/src/components/notes/sidebar/sidebar-list.tsx
@@ -9,7 +9,15 @@ import React, { memo, useMemo, useState, useCallback } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import useI18n from "@/lib/notes/hooks/use-i18n";
 import { Favorites } from "./favorites";
-import { TrashIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import {
+  ArrowPathIcon,
+  ArrowsPointingInIcon,
+  DocumentPlusIcon,
+  EllipsisHorizontalIcon,
+  FolderPlusIcon,
+  TrashIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
 import {
   ControlledTreeEnvironment,
   Tree,
@@ -215,105 +223,63 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
             {t("Notes")}
           </span>
           {!initLoaded && (
-            <svg
-              className="animate-spin h-3 w-3 text-text-tertiary mr-1"
-              viewBox="0 0 24 24"
-              fill="none"
-            >
-              <circle
-                className="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeWidth="4"
-              />
-              <path
-                className="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-              />
-            </svg>
+            <ArrowPathIcon
+              className="mr-1 h-3 w-3 animate-spin text-text-tertiary"
+              aria-hidden="true"
+            />
           )}
           {/* action buttons - always visible */}
           <div className="flex items-center gap-0.5">
             <button
+              type="button"
               onClick={handleQuickNewNote}
-              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary md:h-auto md:w-auto md:p-0.5"
+              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-auto md:w-auto md:p-0.5"
               title={t("New note")}
+              aria-label={t("New note")}
             >
-              <svg
-                className="w-3.5 h-3.5"
-                viewBox="0 0 20 20"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-              >
-                <path d="M4 4h8l4 4v8a1 1 0 01-1 1H4a1 1 0 01-1-1V5a1 1 0 011-1z" />
-                <path d="M12 4v4h4" />
-              </svg>
+              <DocumentPlusIcon className="h-4 w-4" aria-hidden="true" />
             </button>
             <button
+              type="button"
               onClick={handleQuickNewFolder}
-              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary md:h-auto md:w-auto md:p-0.5"
+              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-auto md:w-auto md:p-0.5"
               title={t("New folder")}
+              aria-label={t("New folder")}
             >
-              <svg
-                className="w-3.5 h-3.5"
-                viewBox="0 0 20 20"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-              >
-                <path d="M3 5a1 1 0 011-1h4l2 2h6a1 1 0 011 1v8a1 1 0 01-1 1H4a1 1 0 01-1-1V5z" />
-                <path d="M10 9v4M8 11h4" />
-              </svg>
+              <FolderPlusIcon className="h-4 w-4" aria-hidden="true" />
             </button>
             <button
+              type="button"
               onClick={handleCollapseAll}
-              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary md:h-auto md:w-auto md:p-0.5"
+              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-auto md:w-auto md:p-0.5"
               title={t("Collapse all")}
+              aria-label={t("Collapse all")}
             >
-              <svg
-                className="w-3.5 h-3.5"
-                viewBox="0 0 20 20"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-              >
-                <path d="M4 8l6-4 6 4M4 12l6 4 6-4" />
-              </svg>
+              <ArrowsPointingInIcon className="h-4 w-4" aria-hidden="true" />
             </button>
             <button
+              type="button"
               onClick={handleRefreshTree}
               disabled={isRefreshing}
-              className={`flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary md:h-auto md:w-auto md:p-0.5 ${
+              className={`flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-auto md:w-auto md:p-0.5 ${
                 isRefreshing ? "opacity-50 cursor-not-allowed" : ""
               }`}
               title={t("Refresh filetree")}
+              aria-label={t("Refresh filetree")}
             >
-              <svg
-                className={`w-3.5 h-3.5 ${isRefreshing ? "animate-spin" : ""}`}
-                viewBox="0 0 20 20"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-              >
-                <path d="M4 10a6 6 0 1010.5-5.5M10 3V1m0 2V1" />
-              </svg>
+              <ArrowPathIcon
+                className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
+                aria-hidden="true"
+              />
             </button>
             <button
+              type="button"
               onClick={() => setIsModalOpen(true)}
-              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary md:h-auto md:w-auto md:p-0.5"
+              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-auto md:w-auto md:p-0.5"
               title={t("More options")}
+              aria-label={t("More options")}
             >
-              <svg
-                className="w-3.5 h-3.5"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z" />
-              </svg>
+              <EllipsisHorizontalIcon className="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/src/components/notes/sidebar/sidebar-list.tsx
+++ b/src/components/notes/sidebar/sidebar-list.tsx
@@ -198,7 +198,7 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
 
         {/* Section header - obsidian style */}
         <div
-          className="group mt-1 flex h-12 items-center px-2 md:h-7"
+          className="group mt-1 flex h-12 items-center px-2 md:h-11"
           role="toolbar"
           aria-label={t("Notes actions")}
         >
@@ -216,29 +216,29 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
             <button
               type="button"
               onClick={handleQuickNewNote}
-              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-auto md:w-auto md:p-0.5"
+              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-8 md:w-8"
               title={t("New note")}
               aria-label={t("New note")}
             >
-              <DocumentPlusIcon className="h-4 w-4" aria-hidden="true" />
+              <DocumentPlusIcon className="h-5 w-5" aria-hidden="true" />
             </button>
             <button
               type="button"
               onClick={handleQuickNewFolder}
-              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-auto md:w-auto md:p-0.5"
+              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-8 md:w-8"
               title={t("New folder")}
               aria-label={t("New folder")}
             >
-              <FolderPlusIcon className="h-4 w-4" aria-hidden="true" />
+              <FolderPlusIcon className="h-5 w-5" aria-hidden="true" />
             </button>
             <button
               type="button"
               onClick={() => uploadInputRef.current?.click()}
-              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-auto md:w-auto md:p-0.5"
+              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-8 md:w-8"
               title={t("Upload")}
               aria-label={t("Upload")}
             >
-              <ArrowUpTrayIcon className="h-4 w-4" aria-hidden="true" />
+              <ArrowUpTrayIcon className="h-5 w-5" aria-hidden="true" />
             </button>
             <input
               ref={uploadInputRef}
@@ -380,11 +380,6 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
                       }
                       setRenamingId(null);
                     }}
-                    onAddNote={async (e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      await handleContextCreateNote(itemId);
-                    }}
                     onDotsClick={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
@@ -407,11 +402,6 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
                         setSelectedIds(new Set([itemId]));
                         setSelectionAnchorId(itemId);
                       }
-                    }}
-                    onOpenInAIChat={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      handleOpenInAIChat(itemId, nodeData, !!isFolder);
                     }}
                     initLoaded={initLoaded}
                   >
@@ -438,6 +428,12 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
         onCreateNote={handleContextCreateNote}
         onCreateFolder={handleCreateFolder}
         onOpenInSplit={handleOpenInSplit}
+        onOpenInAIChat={(id) => {
+          const item = tree.items[id];
+          const nodeData = item?.data;
+          const isFolder = !!(nodeData?.isFolder || item?.children?.length);
+          handleOpenInAIChat(id, nodeData, isFolder);
+        }}
       />
 
       {/* delete confirmation overlay */}

--- a/src/components/notes/sidebar/sidebar-list.tsx
+++ b/src/components/notes/sidebar/sidebar-list.tsx
@@ -198,7 +198,7 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
 
         {/* Section header - obsidian style */}
         <div
-          className="group mt-1 flex h-12 items-center px-2 md:h-11"
+          className="group mt-1 flex h-12 items-center px-2 md:h-9"
           role="toolbar"
           aria-label={t("Notes actions")}
         >
@@ -216,29 +216,29 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
             <button
               type="button"
               onClick={handleQuickNewNote}
-              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-8 md:w-8"
+              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-7 md:w-7"
               title={t("New note")}
               aria-label={t("New note")}
             >
-              <DocumentPlusIcon className="h-5 w-5" aria-hidden="true" />
+              <DocumentPlusIcon className="h-[18px] w-[18px]" aria-hidden="true" />
             </button>
             <button
               type="button"
               onClick={handleQuickNewFolder}
-              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-8 md:w-8"
+              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-7 md:w-7"
               title={t("New folder")}
               aria-label={t("New folder")}
             >
-              <FolderPlusIcon className="h-5 w-5" aria-hidden="true" />
+              <FolderPlusIcon className="h-[18px] w-[18px]" aria-hidden="true" />
             </button>
             <button
               type="button"
               onClick={() => uploadInputRef.current?.click()}
-              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-8 md:w-8"
+              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-7 md:w-7"
               title={t("Upload")}
               aria-label={t("Upload")}
             >
-              <ArrowUpTrayIcon className="h-5 w-5" aria-hidden="true" />
+              <ArrowUpTrayIcon className="h-[18px] w-[18px]" aria-hidden="true" />
             </button>
             <input
               ref={uploadInputRef}

--- a/src/components/notes/sidebar/sidebar-list.tsx
+++ b/src/components/notes/sidebar/sidebar-list.tsx
@@ -5,15 +5,14 @@ import useNoteTreeStore from "@/lib/notes/state/tree";
 import useLayoutStore from "@/lib/notes/state/layout.zustand";
 import useContextMenuStore from "@/lib/notes/state/context-menu";
 import { buildFileSpec } from "@/lib/notes/utils/file-spec";
-import React, { memo, useMemo, useState, useCallback } from "react";
+import React, { memo, useMemo, useState, useCallback, useRef } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import useI18n from "@/lib/notes/hooks/use-i18n";
 import { Favorites } from "./favorites";
 import {
   ArrowPathIcon,
-  ArrowsPointingInIcon,
+  ArrowUpTrayIcon,
   DocumentPlusIcon,
-  EllipsisHorizontalIcon,
   FolderPlusIcon,
   TrashIcon,
   XMarkIcon,
@@ -26,7 +25,6 @@ import {
 import "react-complex-tree/lib/style.css";
 import { NOTE_PINNED } from "@/lib/notes/types/meta";
 import { NoteModel } from "@/lib/notes/types/note";
-import CreateNoteModal from "@/components/notes/create-note-modal";
 import { useTreeData } from "./use-tree-data";
 import { DeleteConfirmTarget, useSidebarActions } from "./use-sidebar-actions";
 import {
@@ -45,28 +43,16 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
   const router = useRouter();
   const pathname = usePathname();
 
-  const { loadingChildren, selectedIds, setSelectedIds, focusedId, setFocusedId, refreshTree } =
+  const { loadingChildren, selectedIds, setSelectedIds, focusedId, setFocusedId } =
     useNoteTreeStore();
 
   const [renamingId, setRenamingId] = useState<string | null>(null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const uploadInputRef = useRef<HTMLInputElement>(null);
   const [deleteConfirmTarget, setDeleteConfirmTarget] =
     useState<DeleteConfirmTarget>(null);
   const [selectionAnchorId, setSelectionAnchorId] = useState<string | null>(
     null,
   );
-  const [isRefreshing, setIsRefreshing] = useState(false);
-
-  const handleRefreshTree = useCallback(async () => {
-    setIsRefreshing(true);
-    try {
-      await refreshTree();
-    } catch (error) {
-      console.error("Failed to refresh filetree:", error);
-    } finally {
-      setIsRefreshing(false);
-    }
-  }, [refreshTree]);
 
   // active note from URL
   const activeId = useMemo(() => {
@@ -87,12 +73,9 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
     handleExpandItem,
     handleCollapseItem,
     onMissingItems,
-    handleCreateNote,
-    handleCreateFolderFromModal,
     handleQuickNewNote,
     handleQuickNewFolder,
     handleUploadFiles,
-    handleCollapseAll,
     handleRename,
     handleDeleteRequest,
     handleBulkDeleteRequest,
@@ -250,37 +233,24 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
             </button>
             <button
               type="button"
-              onClick={handleCollapseAll}
+              onClick={() => uploadInputRef.current?.click()}
               className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-auto md:w-auto md:p-0.5"
-              title={t("Collapse all")}
-              aria-label={t("Collapse all")}
+              title={t("Upload")}
+              aria-label={t("Upload")}
             >
-              <ArrowsPointingInIcon className="h-4 w-4" aria-hidden="true" />
+              <ArrowUpTrayIcon className="h-4 w-4" aria-hidden="true" />
             </button>
-            <button
-              type="button"
-              onClick={handleRefreshTree}
-              disabled={isRefreshing}
-              className={`flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-auto md:w-auto md:p-0.5 ${
-                isRefreshing ? "opacity-50 cursor-not-allowed" : ""
-              }`}
-              title={t("Refresh filetree")}
-              aria-label={t("Refresh filetree")}
-            >
-              <ArrowPathIcon
-                className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
-                aria-hidden="true"
-              />
-            </button>
-            <button
-              type="button"
-              onClick={() => setIsModalOpen(true)}
-              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-auto md:w-auto md:p-0.5"
-              title={t("More options")}
-              aria-label={t("More options")}
-            >
-              <EllipsisHorizontalIcon className="h-4 w-4" aria-hidden="true" />
-            </button>
+            <input
+              ref={uploadInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={(event) => {
+                const files = Array.from(event.target.files ?? []);
+                event.target.value = "";
+                if (files.length > 0) void handleUploadFiles(files);
+              }}
+            />
           </div>
         </div>
 
@@ -453,14 +423,6 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
           </ControlledTreeEnvironment>
         </div>
       </section>
-
-      <CreateNoteModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        onCreateNote={handleCreateNote}
-        onCreateFolder={handleCreateFolderFromModal}
-        onUploadFiles={handleUploadFiles}
-      />
 
       <NoteContextMenu
         onRename={handleRename}

--- a/src/components/notes/sidebar/sidebar-list.tsx
+++ b/src/components/notes/sidebar/sidebar-list.tsx
@@ -33,6 +33,7 @@ import {
   toggleSelectedId,
 } from "./selection-utils";
 import { ROOT_ID } from "@/lib/notes/types/tree";
+import { clearPostDedupCache } from "@/lib/notes/api/request-deduplicator";
 
 interface SidebarListProps {
   onOpenNote?: () => void;
@@ -43,10 +44,17 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
   const router = useRouter();
   const pathname = usePathname();
 
-  const { loadingChildren, selectedIds, setSelectedIds, focusedId, setFocusedId } =
-    useNoteTreeStore();
+  const {
+    loadingChildren,
+    selectedIds,
+    setSelectedIds,
+    focusedId,
+    setFocusedId,
+    renamingId,
+    setRenamingId,
+    refreshTree,
+  } = useNoteTreeStore();
 
-  const [renamingId, setRenamingId] = useState<string | null>(null);
   const uploadInputRef = useRef<HTMLInputElement>(null);
   const [deleteConfirmTarget, setDeleteConfirmTarget] =
     useState<DeleteConfirmTarget>(null);
@@ -89,7 +97,6 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
     handleItemContextMenu,
     handleDrop,
   } = useSidebarActions({
-    setRenamingId,
     setDeleteConfirmTarget,
     deleteConfirmTarget,
     activeId,
@@ -205,14 +212,24 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
           <span className="flex-1 text-xs font-semibold uppercase tracking-wider text-text-tertiary select-none">
             {t("Notes")}
           </span>
-          {!initLoaded && (
-            <ArrowPathIcon
-              className="mr-1 h-3 w-3 animate-spin text-text-tertiary"
-              aria-hidden="true"
-            />
-          )}
           {/* action buttons - always visible */}
           <div className="flex items-center gap-0.5">
+            <button
+              type="button"
+              onClick={() => {
+                clearPostDedupCache();
+                void refreshTree();
+              }}
+              disabled={!initLoaded}
+              className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 disabled:cursor-wait disabled:opacity-40 md:h-7 md:w-7"
+              title={t("Refresh notes")}
+              aria-label={t("Refresh notes")}
+            >
+              <ArrowPathIcon
+                className={`h-[18px] w-[18px] ${!initLoaded ? "animate-spin" : ""}`}
+                aria-hidden="true"
+              />
+            </button>
             <button
               type="button"
               onClick={handleQuickNewNote}
@@ -327,6 +344,7 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
                   item.isFolder || nodeData?.isFolder || hasChildren;
                 const _isPinned = nodeData?.pinned === NOTE_PINNED.PINNED;
                 const isDragging = (context as any)?.isDragging === true;
+                const isDraggingOver = context.isDraggingOver === true;
                 const isExpanded = expandedIds.has(item.index as string);
                 const isActive = activeId === item.index;
                 const isItemRenaming = renamingId === item.index;
@@ -343,6 +361,7 @@ const SidebarList = ({ onOpenNote }: SidebarListProps) => {
                     isActive={!!isActive}
                     isSelected={isSelected}
                     isDragging={isDragging}
+                    isDraggingOver={isDraggingOver}
                     isLoading={loadingChildren.has(itemId)}
                     hasChildren={hasChildren}
                     depth={depth}

--- a/src/components/notes/sidebar/tree-item.tsx
+++ b/src/components/notes/sidebar/tree-item.tsx
@@ -2,6 +2,14 @@ import React, { memo, useEffect, useRef, useState } from "react";
 import useI18n from "@/lib/notes/hooks/use-i18n";
 import { NoteModel } from "@/lib/notes/types/note";
 import useSyncStatusStore from "@/lib/notes/state/sync-status";
+import {
+  ArrowPathIcon,
+  ChatBubbleLeftRightIcon,
+  ChevronRightIcon,
+  DocumentIcon,
+  EllipsisHorizontalIcon,
+  PlusIcon,
+} from "@heroicons/react/24/outline";
 
 const INDENT_PX = 14;
 
@@ -160,45 +168,20 @@ const TreeItem: React.FC<TreeItemProps> = memo(
             }}
           >
             {isLoading ? (
-              <svg
-                className="w-3 h-3 animate-spin text-text-tertiary"
-                viewBox="0 0 24 24"
-                fill="none"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="3"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                />
-              </svg>
+              <ArrowPathIcon
+                className="h-3 w-3 animate-spin text-text-tertiary"
+                aria-hidden="true"
+              />
             ) : isFolder ? (
-              <svg
-                className={`w-[10px] h-[10px] text-text-tertiary transition-transform duration-100 ${isExpanded ? "rotate-90" : ""}`}
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M7.293 4.707a1 1 0 011.414 0l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414-1.414L11.586 10 7.293 5.707a1 1 0 010-1.414z"
-                  clipRule="evenodd"
-                />
-              </svg>
+              <ChevronRightIcon
+                className={`h-3 w-3 text-text-tertiary transition-transform duration-100 ${isExpanded ? "rotate-90" : ""}`}
+                aria-hidden="true"
+              />
             ) : (
-              <svg
-                className="w-1 h-1 text-text-tertiary/50"
-                viewBox="0 0 6 6"
-                fill="currentColor"
-              >
-                <circle cx="3" cy="3" r="2.5" />
-              </svg>
+              <DocumentIcon
+                className="h-3.5 w-3.5 text-text-tertiary"
+                aria-hidden="true"
+              />
             )}
           </span>
 
@@ -252,56 +235,35 @@ const TreeItem: React.FC<TreeItemProps> = memo(
           {!isRenaming && (
             <span className="flex-shrink-0 flex items-center gap-0 ml-0.5">
               <button
+                type="button"
                 className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary md:h-auto md:w-auto md:p-0.5"
                 onClick={onDotsClick}
                 title={t("More actions")}
+                aria-label={t("More actions")}
                 tabIndex={-1}
               >
-                <svg
-                  className="w-3.5 h-3.5"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                >
-                  <path d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z" />
-                </svg>
+                <EllipsisHorizontalIcon className="h-4 w-4" aria-hidden="true" />
               </button>
               <button
+                type="button"
                 className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-primary-600/20 hover:text-primary-300 md:h-auto md:w-auto md:p-0.5"
                 onClick={onOpenInAIChat}
                 title={isFolder ? t("Chat with folder") : t("Chat with note")}
+                aria-label={isFolder ? t("Chat with folder") : t("Chat with note")}
                 tabIndex={-1}
               >
-                <svg
-                  className="w-3.5 h-3.5"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <rect x="7" y="7" width="10" height="10" rx="1" />
-                  <path d="M9 4v3M12 4v3M15 4v3M9 17v3M12 17v3M15 17v3M4 9h3M4 12h3M4 15h3M17 9h3M17 12h3M17 15h3" />
-                </svg>
+                <ChatBubbleLeftRightIcon className="h-4 w-4" aria-hidden="true" />
               </button>
               {isFolder && (
                 <button
+                  type="button"
                   className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary md:h-auto md:w-auto md:p-0.5"
                   onClick={onAddNote}
                   title={t("New note inside")}
+                  aria-label={t("New note inside")}
                   tabIndex={-1}
                 >
-                  <svg
-                    className="w-3.5 h-3.5"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
+                  <PlusIcon className="h-4 w-4" aria-hidden="true" />
                 </button>
               )}
             </span>

--- a/src/components/notes/sidebar/tree-item.tsx
+++ b/src/components/notes/sidebar/tree-item.tsx
@@ -2,9 +2,11 @@ import React, { memo, useEffect, useRef, useState } from "react";
 import useI18n from "@/lib/notes/hooks/use-i18n";
 import { NoteModel } from "@/lib/notes/types/note";
 import useSyncStatusStore from "@/lib/notes/state/sync-status";
+import { inferFileType } from "@/lib/notes/utils/file-spec";
 import {
   ArrowPathIcon,
   ChevronRightIcon,
+  DocumentIcon,
   DocumentTextIcon,
   EllipsisHorizontalIcon,
 } from "@heroicons/react/24/outline";
@@ -63,6 +65,8 @@ const TreeItem: React.FC<TreeItemProps> = memo(
     const escapedRef = useRef(false);
     const committedRef = useRef(false);
     const pl = depth * INDENT_PX;
+    const isPdf =
+      inferFileType(nodeData?.title, nodeData?.mimeType) === "pdf";
 
     useEffect(() => {
       renameValueRef.current = renameValue;
@@ -172,10 +176,17 @@ const TreeItem: React.FC<TreeItemProps> = memo(
                 aria-hidden="true"
               />
             ) : (
-              <DocumentTextIcon
-                className="h-3.5 w-3.5 text-text-tertiary"
-                aria-hidden="true"
-              />
+              isPdf ? (
+                <DocumentIcon
+                  className="h-3.5 w-3.5 text-red-400"
+                  aria-hidden="true"
+                />
+              ) : (
+                <DocumentTextIcon
+                  className="h-3.5 w-3.5 text-text-tertiary"
+                  aria-hidden="true"
+                />
+              )
             )}
           </span>
 

--- a/src/components/notes/sidebar/tree-item.tsx
+++ b/src/components/notes/sidebar/tree-item.tsx
@@ -21,6 +21,7 @@ export interface TreeItemProps {
   isActive: boolean;
   isSelected: boolean;
   isDragging: boolean;
+  isDraggingOver: boolean;
   isLoading: boolean;
   hasChildren: boolean;
   depth: number;
@@ -44,6 +45,7 @@ const TreeItem: React.FC<TreeItemProps> = memo(
     isActive,
     isSelected,
     isDragging,
+    isDraggingOver,
     isLoading,
     hasChildren,
     depth,
@@ -142,6 +144,7 @@ const TreeItem: React.FC<TreeItemProps> = memo(
             }
             ${isActive && isSelected ? "ring-1 ring-primary-500/20" : ""}
             ${isDragging ? "opacity-40" : ""}
+            ${isDraggingOver ? "bg-primary-500/20 text-text-secondary ring-2 ring-inset ring-primary-400/70 shadow-[inset_3px_0_0_rgb(96_165_250)]" : ""}
           `}
           style={{ paddingLeft: `${pl + 4}px` }}
           draggable={true}

--- a/src/components/notes/sidebar/tree-item.tsx
+++ b/src/components/notes/sidebar/tree-item.tsx
@@ -4,11 +4,9 @@ import { NoteModel } from "@/lib/notes/types/note";
 import useSyncStatusStore from "@/lib/notes/state/sync-status";
 import {
   ArrowPathIcon,
-  ChatBubbleLeftRightIcon,
   ChevronRightIcon,
-  DocumentIcon,
+  DocumentTextIcon,
   EllipsisHorizontalIcon,
-  PlusIcon,
 } from "@heroicons/react/24/outline";
 
 const INDENT_PX = 14;
@@ -32,9 +30,7 @@ export interface TreeItemProps {
   onToggle: () => void;
   onClick: (e: React.MouseEvent) => void;
   onRenameComplete: (newTitle: string) => void | Promise<void>;
-  onAddNote: (e: React.MouseEvent) => void | Promise<void>;
   onDotsClick: (e: React.MouseEvent) => void;
-  onOpenInAIChat: (e: React.MouseEvent) => void;
 }
 
 const TreeItem: React.FC<TreeItemProps> = memo(
@@ -57,9 +53,7 @@ const TreeItem: React.FC<TreeItemProps> = memo(
     onToggle,
     onClick,
     onRenameComplete,
-    onAddNote,
     onDotsClick,
-    onOpenInAIChat,
   }) => {
     const { t } = useI18n();
     const syncStatus = useSyncStatusStore((s) => s.status[itemId]);
@@ -178,7 +172,7 @@ const TreeItem: React.FC<TreeItemProps> = memo(
                 aria-hidden="true"
               />
             ) : (
-              <DocumentIcon
+              <DocumentTextIcon
                 className="h-3.5 w-3.5 text-text-tertiary"
                 aria-hidden="true"
               />
@@ -233,39 +227,16 @@ const TreeItem: React.FC<TreeItemProps> = memo(
             )}
 
           {!isRenaming && (
-            <span className="flex-shrink-0 flex items-center gap-0 ml-0.5">
+            <span className="flex-shrink-0 ml-0.5">
               <button
                 type="button"
-                className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary md:h-auto md:w-auto md:p-0.5"
+                className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-[color,background-color,opacity] hover:bg-subtle hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500/50 md:h-5 md:w-5 md:opacity-0 md:group-hover/item:opacity-100 md:group-focus-within/item:opacity-100"
                 onClick={onDotsClick}
                 title={t("More actions")}
                 aria-label={t("More actions")}
-                tabIndex={-1}
               >
                 <EllipsisHorizontalIcon className="h-4 w-4" aria-hidden="true" />
               </button>
-              <button
-                type="button"
-                className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-primary-600/20 hover:text-primary-300 md:h-auto md:w-auto md:p-0.5"
-                onClick={onOpenInAIChat}
-                title={isFolder ? t("Chat with folder") : t("Chat with note")}
-                aria-label={isFolder ? t("Chat with folder") : t("Chat with note")}
-                tabIndex={-1}
-              >
-                <ChatBubbleLeftRightIcon className="h-4 w-4" aria-hidden="true" />
-              </button>
-              {isFolder && (
-                <button
-                  type="button"
-                  className="flex h-10 w-10 items-center justify-center rounded-radius-sm text-text-tertiary transition-colors hover:bg-subtle hover:text-text-secondary md:h-auto md:w-auto md:p-0.5"
-                  onClick={onAddNote}
-                  title={t("New note inside")}
-                  aria-label={t("New note inside")}
-                  tabIndex={-1}
-                >
-                  <PlusIcon className="h-4 w-4" aria-hidden="true" />
-                </button>
-              )}
             </span>
           )}
         </div>

--- a/src/components/notes/sidebar/tree-item.tsx
+++ b/src/components/notes/sidebar/tree-item.tsx
@@ -191,7 +191,10 @@ const TreeItem: React.FC<TreeItemProps> = memo(
           </span>
 
           {isRenaming ? (
-            <div onKeyDownCapture={(e) => e.stopPropagation()}>
+            <div
+              className="min-w-0 flex-1"
+              onKeyDownCapture={(e) => e.stopPropagation()}
+            >
               <input
                 ref={renameInputRef}
                 type="text"
@@ -209,7 +212,7 @@ const TreeItem: React.FC<TreeItemProps> = memo(
                   }
                 }}
                 onClick={(e) => e.stopPropagation()}
-                className="flex-1 min-w-0 truncate bg-subtle border border-primary-500/50 rounded-radius-sm px-1 py-0 outline-none text-text-secondary text-[13px] leading-tight"
+                className="w-full min-w-0 truncate bg-subtle border border-primary-500/50 rounded-radius-sm px-1 py-0 outline-none text-text-secondary text-[13px] leading-tight"
               />
             </div>
           ) : (

--- a/src/components/notes/sidebar/use-sidebar-actions.ts
+++ b/src/components/notes/sidebar/use-sidebar-actions.ts
@@ -10,6 +10,7 @@ import { NOTE_PINNED } from "@/lib/notes/types/meta";
 import { NoteModel } from "@/lib/notes/types/note";
 import { getTopLevelSelectedIds, treeItemContainsId } from "./selection-utils";
 import useI18n from "@/lib/notes/hooks/use-i18n";
+import { wouldCreateTreeCycle } from "@/lib/notes/state/tree-cycle";
 
 export type DeleteConfirmTarget =
   | { mode: "single"; ids: [string] }
@@ -449,6 +450,15 @@ export function useSidebarActions(deps: {
       }
 
       if (typeof destParentId !== "string") return;
+      if (
+        wouldCreateTreeCycle(
+          useNoteTreeStore.getState().tree,
+          dragId,
+          destParentId,
+        )
+      ) {
+        return;
+      }
 
       moveItem({
         source: { parentId: sourceParentId, index: sourceIndex },

--- a/src/components/notes/sidebar/use-sidebar-actions.ts
+++ b/src/components/notes/sidebar/use-sidebar-actions.ts
@@ -19,7 +19,6 @@ export type DeleteConfirmTarget =
 
 // sidebar CRUD operations and action callbacks
 export function useSidebarActions(deps: {
-  setRenamingId: (id: string | null) => void;
   setDeleteConfirmTarget: (target: DeleteConfirmTarget) => void;
   deleteConfirmTarget: DeleteConfirmTarget;
   activeId: string | null;
@@ -27,7 +26,6 @@ export function useSidebarActions(deps: {
   onDeleteSelectionCleared: () => void;
 }) {
   const {
-    setRenamingId,
     setDeleteConfirmTarget,
     deleteConfirmTarget,
     activeId,
@@ -49,53 +47,64 @@ export function useSidebarActions(deps: {
     setExpandedIds,
     selectedIds,
     setSelectedIds,
+    setRenamingId,
     refreshTree,
   } = useNoteTreeStore();
   const { createNote, createFolder, mutateNote, removeNote } = useNoteStore();
 
-  // create note from modal with title and language
-  const handleCreateNote = useCallback(
-    async (title: string, _language: string) => {
-      const newId = genNewId();
-      const newNote = await createNote({
-        id: newId,
-        title: title,
-        content: "\n",
-        pid: undefined,
-      });
-      if (newNote) router.push(`/notes/${newId}`);
+  const revealCreatedItem = useCallback(
+    async (itemId: string, parentId: string) => {
+      if (parentId !== "root") {
+        const newExpandedIds = new Set(expandedIds);
+        newExpandedIds.add(parentId);
+        setExpandedIds(newExpandedIds);
+        await mutateItem(parentId, { isExpanded: true });
+      }
+      setRenamingId(itemId);
     },
-    [genNewId, createNote, router],
+    [expandedIds, mutateItem, setExpandedIds, setRenamingId],
   );
 
-  // create folder from modal
-  const handleCreateFolderFromModal = useCallback(async () => {
-    await createFolder(undefined);
-  }, [createFolder]);
+  const createNoteAndStartRename = useCallback(
+    async (parentId: string) => {
+      const newId = genNewId();
+      const pid = parentId === "root" ? undefined : parentId;
+      const newNote = await createNote({
+        id: newId,
+        title: t("Untitled"),
+        content: "\n",
+        pid,
+      });
+      if (newNote) {
+        await revealCreatedItem(newId, parentId);
+        router.push(`/notes/${newId}`);
+      }
+    },
+    [createNote, genNewId, revealCreatedItem, router, t],
+  );
+
+  const createFolderAndStartRename = useCallback(
+    async (parentId: string) => {
+      const pid = parentId === "root" ? undefined : parentId;
+      const newFolder = await createFolder(pid);
+      if (newFolder) {
+        await revealCreatedItem(newFolder.id, parentId);
+      }
+    },
+    [createFolder, revealCreatedItem],
+  );
 
   // quick new note from toolbar button
-  const handleQuickNewNote = useCallback(async () => {
-    const newId = genNewId();
-    const newNote = await createNote({
-      id: newId,
-      title: t("Untitled"),
-      content: "\n",
-      pid: undefined,
-    });
-    if (newNote) {
-      setRenamingId(newId);
-      router.push(`/notes/${newId}`);
-    }
-  }, [genNewId, createNote, router, setRenamingId, t]);
+  const handleQuickNewNote = useCallback(
+    () => createNoteAndStartRename("root"),
+    [createNoteAndStartRename],
+  );
 
   // quick new folder from toolbar button
-  const handleQuickNewFolder = useCallback(async () => {
-    const newFolder = await createFolder(undefined);
-    if (newFolder) {
-      const folderId = typeof newFolder === "string" ? newFolder : newFolder.id;
-      if (folderId) setRenamingId(folderId);
-    }
-  }, [createFolder, setRenamingId]);
+  const handleQuickNewFolder = useCallback(
+    () => createFolderAndStartRename("root"),
+    [createFolderAndStartRename],
+  );
 
   // upload one file and create a note for it
   const uploadFile = useCallback(
@@ -306,53 +315,14 @@ export function useSidebarActions(deps: {
 
   // create note inside a folder (from context menu)
   const handleContextCreateNote = useCallback(
-    async (parentId: string) => {
-      const newId = genNewId();
-      const pid = parentId === "root" ? undefined : parentId;
-      const newNote = await createNote({
-        id: newId,
-        title: t("Untitled"),
-        content: "\n",
-        pid,
-      });
-      if (newNote) {
-        if (parentId !== "root") {
-          const newExpandedIds = new Set(expandedIds);
-          newExpandedIds.add(parentId);
-          setExpandedIds(newExpandedIds);
-          await mutateItem(parentId, { isExpanded: true });
-        }
-        setRenamingId(newId);
-        router.push(`/notes/${newId}`);
-      }
-    },
-    [
-      genNewId,
-      createNote,
-      mutateItem,
-      router,
-      expandedIds,
-      setExpandedIds,
-      setRenamingId,
-      t,
-    ],
+    (parentId: string) => createNoteAndStartRename(parentId),
+    [createNoteAndStartRename],
   );
 
   // create folder inside a folder (from context menu)
   const handleCreateFolder = useCallback(
-    async (parentId: string) => {
-      const pid = parentId === "root" ? undefined : parentId;
-      const newFolder = await createFolder(pid);
-      if (newFolder) {
-        if (parentId !== "root") {
-          const newExpandedIds = new Set(expandedIds);
-          newExpandedIds.add(parentId);
-          setExpandedIds(newExpandedIds);
-          await mutateItem(parentId, { isExpanded: true });
-        }
-      }
-    },
-    [createFolder, mutateItem, expandedIds, setExpandedIds],
+    (parentId: string) => createFolderAndStartRename(parentId),
+    [createFolderAndStartRename],
   );
 
   // open in split pane
@@ -514,8 +484,6 @@ export function useSidebarActions(deps: {
       [loadChildren],
     ),
     // CRUD actions
-    handleCreateNote,
-    handleCreateFolderFromModal,
     handleQuickNewNote,
     handleQuickNewFolder,
     handleUploadFiles,

--- a/src/components/notes/sidebar/use-tree-data.ts
+++ b/src/components/notes/sidebar/use-tree-data.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import useNoteTreeStore from "@/lib/notes/state/tree";
+import { getCycleSafeChildren } from "@/lib/notes/state/tree-cycle";
 
 // converts the flat note tree to react-complex-tree format
 export function useTreeData() {
@@ -7,7 +8,7 @@ export function useTreeData() {
 
   return useMemo(() => {
     const result: Record<string, any> = {};
-    const dedup = (arr: string[]) => [...new Set(arr)];
+    const safeChildren = getCycleSafeChildren(tree);
 
     const root = tree.items["root"];
     if (root) {
@@ -15,7 +16,7 @@ export function useTreeData() {
         index: "root",
         canMove: false,
         canRename: false,
-        children: dedup(root.children),
+        children: safeChildren.root ?? [],
         isFolder: true,
         data: { title: "Root", isFolder: true },
       };
@@ -35,7 +36,7 @@ export function useTreeData() {
         index: id,
         canMove: true,
         canRename: false,
-        children: dedup(item.children || []),
+        children: safeChildren[id] ?? [],
         data: item.data,
         isFolder,
         canDropOn: isFolder,

--- a/src/components/settings/account-section.jsx
+++ b/src/components/settings/account-section.jsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { toast } from "sonner";
-import { UserCircleIcon } from "@heroicons/react/24/outline";
+import { ArrowPathIcon, UserCircleIcon } from "@heroicons/react/24/outline";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
 import LanguageSelector from "@/components/common/language-selector";
 import useI18n from "@/lib/notes/hooks/use-i18n";
@@ -144,26 +144,10 @@ export default function AccountSection({
                 onClick={() => avatarInputRef.current?.click()}
               >
                 {isUploadingAvatar && (
-                  <svg
-                    className="animate-spin size-4"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                    />
-                  </svg>
+                  <ArrowPathIcon
+                    className="size-4 animate-spin"
+                    aria-hidden="true"
+                  />
                 )}
                 {isUploadingAvatar ? t("Uploading...") : t("Change avatar")}
               </button>

--- a/src/components/settings/canvas/canvas-connection-form.jsx
+++ b/src/components/settings/canvas/canvas-connection-form.jsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
+import {
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+} from "@heroicons/react/24/outline";
 import useI18n from "@/lib/notes/hooks/use-i18n";
 
 export default function CanvasConnectionForm({
@@ -19,19 +22,10 @@ export default function CanvasConnectionForm({
       {/* expired / invalid token warning */}
       {connectionWarning && (
         <div className="flex items-center gap-2 rounded-radius-md bg-yellow-500/10 px-3 py-2 text-sm text-yellow-400 ring-1 ring-yellow-500/20">
-          <svg
+          <ExclamationTriangleIcon
             className="size-4 shrink-0"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={1.5}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
-            />
-          </svg>
+            aria-hidden="true"
+          />
           {connectionWarning}
         </div>
       )}

--- a/src/components/settings/canvas/canvas-helpers.jsx
+++ b/src/components/settings/canvas/canvas-helpers.jsx
@@ -1,5 +1,10 @@
 "use client";
 
+import {
+  CheckCircleIcon as HeroCheckCircleIcon,
+  ChevronDownIcon as HeroChevronDownIcon,
+} from "@heroicons/react/24/outline";
+
 // localStorage keys
 export const LS_SELECTED = "canvas_selected_courses";
 export const LS_ERRORS = "canvas_course_errors";
@@ -7,41 +12,16 @@ export const LS_ACTIVE_JOB = "canvas_active_job";
 export const LS_FORBIDDEN = "canvas_forbidden_courses";
 export const LS_SYNCED = "canvas_synced_courses";
 
-/** Inline SVG check */
 export function CheckCircleIcon({ className }) {
-  return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.5}
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"
-      />
-    </svg>
-  );
+  return <HeroCheckCircleIcon className={className} aria-hidden="true" />;
 }
 
-/** Inline SVG chevron down */
 export function ChevronDownIcon({ className, open }) {
   return (
-    <svg
+    <HeroChevronDownIcon
       className={`${className} transition-transform duration-200 ${open ? "rotate-180" : ""}`}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.5}
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M19.5 8.25l-7.5 7.5-7.5-7.5"
-      />
-    </svg>
+      aria-hidden="true"
+    />
   );
 }
 

--- a/src/lib/notes/state/layout.zustand.ts
+++ b/src/lib/notes/state/layout.zustand.ts
@@ -3,12 +3,7 @@ import { persist } from "zustand/middleware";
 
 export type FileType = "note" | "pdf" | "image" | "video";
 export type NavSection =
-  | "notes"
-  | "search"
-  | "calendar"
-  | "chat"
-  | "quiz"
-  | "settings";
+  "notes" | "search" | "calendar" | "chat" | "quiz" | "settings";
 export type RightPanelTab = "meta" | "ai" | "tasks";
 
 interface PaneState {
@@ -37,7 +32,7 @@ interface LayoutState {
 
   // UI sizes (persist to localStorage)
   treeWidth: number; // 200-600px
-  rightPanelWidth: number; // 250-400px
+  rightPanelWidth: number; // 250-600px
   splitPosition: number; // 0-100 between panes (%)
 
   // Tree state
@@ -185,7 +180,7 @@ const useLayoutStore = create<LayoutState>()(
       setSizes: (tree, right, split) => {
         set({
           treeWidth: Math.max(200, Math.min(600, tree)),
-          rightPanelWidth: Math.max(250, Math.min(400, right)),
+          rightPanelWidth: Math.max(250, Math.min(600, right)),
           splitPosition: Math.max(0, Math.min(100, split)),
         });
       },

--- a/src/lib/notes/state/tree-cycle.ts
+++ b/src/lib/notes/state/tree-cycle.ts
@@ -1,0 +1,59 @@
+import { ROOT_ID, TreeModel } from "@/lib/notes/types/tree";
+
+export function treeItemContainsId(
+  tree: TreeModel,
+  ancestorId: string,
+  descendantId: string,
+): boolean {
+  const pending = [...(tree.items[ancestorId]?.children ?? [])];
+  const visited = new Set<string>([ancestorId]);
+
+  while (pending.length > 0) {
+    const childId = pending.pop();
+    if (!childId || visited.has(childId)) continue;
+    if (childId === descendantId) return true;
+
+    visited.add(childId);
+    pending.push(...(tree.items[childId]?.children ?? []));
+  }
+
+  return false;
+}
+
+export function wouldCreateTreeCycle(
+  tree: TreeModel,
+  itemId: string,
+  parentId: string,
+): boolean {
+  return itemId === parentId || treeItemContainsId(tree, itemId, parentId);
+}
+
+export function getCycleSafeChildren(tree: TreeModel): Record<string, string[]> {
+  const safeChildren: Record<string, string[]> = {};
+  const visited = new Set<string>();
+
+  const visit = (id: string) => {
+    visited.add(id);
+    safeChildren[id] = [];
+
+    for (const childId of new Set(tree.items[id]?.children ?? [])) {
+      if (
+        childId === ROOT_ID ||
+        !tree.items[childId] ||
+        visited.has(childId)
+      ) {
+        continue;
+      }
+
+      safeChildren[id].push(childId);
+      visit(childId);
+    }
+  };
+
+  if (tree.items[ROOT_ID]) visit(ROOT_ID);
+  for (const id of Object.keys(tree.items)) {
+    if (!visited.has(id)) visit(id);
+  }
+
+  return safeChildren;
+}

--- a/src/lib/notes/state/tree.ts
+++ b/src/lib/notes/state/tree.ts
@@ -31,6 +31,7 @@ export interface NoteTreeState {
   expandedIds: Set<string>;
   selectedIds: Set<string>;
   focusedId: string | null;
+  renamingId: string | null;
   // API instances for dependency injection
   treeAPI: any;
   noteAPI: any;
@@ -64,6 +65,7 @@ export interface NoteTreeState {
   setExpandedIds: (ids: Set<string>) => void;
   setSelectedIds: (ids: Set<string>) => void;
   setFocusedId: (id: string | null) => void;
+  setRenamingId: (id: string | null) => void;
 }
 
 const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
@@ -76,6 +78,7 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
   expandedIds: new Set<string>(),
   selectedIds: new Set<string>(),
   focusedId: null,
+  renamingId: null,
   treeAPI: null,
   noteAPI: null,
   toast: null,
@@ -98,6 +101,10 @@ const useNoteTreeStore = create<NoteTreeState>((set, get) => ({
 
   setFocusedId: (id: string | null) => {
     set({ focusedId: id });
+  },
+
+  setRenamingId: (id: string | null) => {
+    set({ renamingId: id });
   },
 
   fetchNotes: async (tree: TreeModel) => {

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -781,6 +781,7 @@
   "Recovery": "استعادة",
   "Refining with semantic search...": "التنقيح مع البحث الدلالي ...",
   "Refresh filetree": "تحديث شجرة الملفات",
+  "Recent": "الأخيرة",
   "Regenerate URL": "إعادة إنشاء URL",
   "Registration failed": "فشل التسجيل",
   "Remember me": "تذكرني",

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -781,6 +781,7 @@
   "Recovery": "Wiederherstellung",
   "Refining with semantic search...": "Verfeinerung mit semantischer Suche...",
   "Refresh filetree": "Dateibaum aktualisieren",
+  "Recent": "Zuletzt",
   "Regenerate URL": "URL neu generieren",
   "Registration failed": "Die Registrierung ist fehlgeschlagen",
   "Remember me": "Angemeldet bleiben",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -781,6 +781,7 @@
   "Recovery": "Recovery",
   "Refining with semantic search...": "Refining with semantic search...",
   "Refresh filetree": "Refresh filetree",
+  "Recent": "Recent",
   "Regenerate URL": "Regenerate URL",
   "Registration failed": "Registration failed",
   "Remember me": "Remember me",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -781,6 +781,7 @@
   "Recovery": "Recuperación",
   "Refining with semantic search...": "Refinando con búsqueda semántica...",
   "Refresh filetree": "Actualizar árbol de archivos",
+  "Recent": "Recientes",
   "Regenerate URL": "Regenerar URL",
   "Registration failed": "Registro fallido",
   "Remember me": "Recuérdame",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -781,6 +781,7 @@
   "Recovery": "Récupération",
   "Refining with semantic search...": "Affiner avec la recherche sémantique...",
   "Refresh filetree": "Actualiser l'arborescence des fichiers",
+  "Recent": "Récentes",
   "Regenerate URL": "Régénérer URL",
   "Registration failed": "L'inscription a échoué",
   "Remember me": "Se souvenir de moi",

--- a/src/locales/ga.json
+++ b/src/locales/ga.json
@@ -781,6 +781,7 @@
   "Recovery": "Aisghabhála",
   "Refining with semantic search...": "Á scagadh le cuardach shéimeantach...",
   "Refresh filetree": "Athnuaigh crann comhaid",
+  "Recent": "Le déanaí",
   "Regenerate URL": "Athghin URL",
   "Registration failed": "Theip ar chlárú",
   "Remember me": "Cuimhnigh orm",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -781,6 +781,7 @@
   "Recovery": "पुनर्प्राप्ति",
   "Refining with semantic search...": "अर्थ संबंधी खोज के साथ परिशोधन...",
   "Refresh filetree": "फ़ाइलट्री ताज़ा करें",
+  "Recent": "हाल की",
   "Regenerate URL": "URL को पुन: उत्पन्न करें",
   "Registration failed": "पंजीकरण विफल रहा",
   "Remember me": "मुझे याद रखें",

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -781,6 +781,7 @@
   "Recovery": "Recupera",
   "Refining with semantic search...": "Perfezionamento con la ricerca semantica...",
   "Refresh filetree": "Aggiorna l'albero dei file",
+  "Recent": "Recenti",
   "Regenerate URL": "Rigenera URL",
   "Registration failed": "La registrazione non è riuscita",
   "Remember me": "Ricordami",

--- a/src/locales/nl-NL.json
+++ b/src/locales/nl-NL.json
@@ -781,6 +781,7 @@
   "Recovery": "Herstel",
   "Refining with semantic search...": "Verfijnen met semantisch zoeken...",
   "Refresh filetree": "Bestandsboom vernieuwen",
+  "Recent": "Onlangs",
   "Regenerate URL": "Genereer URL opnieuw",
   "Registration failed": "Registratie mislukt",
   "Remember me": "Onthoud mij",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -781,6 +781,7 @@
   "Recovery": "Восстановить",
   "Refining with semantic search...": "Уточнение с помощью семантического поиска...",
   "Refresh filetree": "Обновить дерево файлов",
+  "Recent": "Недавние",
   "Regenerate URL": "Восстановить URL",
   "Registration failed": "Регистрация не удалась",
   "Remember me": "Запомнить меня",

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -781,6 +781,7 @@
   "Recovery": "Återställning",
   "Refining with semantic search...": "Förfina med semantisk sökning...",
   "Refresh filetree": "Uppdatera filträdet",
+  "Recent": "Senaste",
   "Regenerate URL": "Återskapa URL",
   "Registration failed": "Registreringen misslyckades",
   "Remember me": "Kom ihåg mig",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -781,6 +781,7 @@
   "Recovery": "恢复",
   "Refining with semantic search...": "通过语义搜索进行细化...",
   "Refresh filetree": "刷新文件树",
+  "Recent": "最近",
   "Regenerate URL": "重新生成URL",
   "Registration failed": "注册失败",
   "Remember me": "记住我",

--- a/tests/e2e/smoke/chat.spec.ts
+++ b/tests/e2e/smoke/chat.spec.ts
@@ -74,7 +74,9 @@ test.describe("chat responsive smoke", () => {
       await page.getByRole("button", { name: "Pin to favorites" }).click();
       await expect(page.getByRole("button", { name: "Unpin" })).toBeVisible();
       await expect(page.getByRole("heading", { name: "Pinned" })).toBeVisible();
-      await expect(page.getByRole("link", { name: /Configure AI/ })).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "Settings" }),
+      ).toHaveCount(1);
     }
   });
 });


### PR DESCRIPTION
## What changed

- makes the Notes file tree and inspector panels resizable and persists their widths
- simplifies and standardizes file-tree actions and application icons
- improves note/folder creation, inline rename, drag-and-drop feedback, and manual tree refresh
- prevents cyclic/self-parent note trees in the client, API, and database
- adds direct Metadata, AI Chat, and Tasks controls with clearer icon sizing and accessibility states
- fixes and expands note timestamps through milliseconds and timezone offset
- unifies note-editor typography on DM Sans
- improves chat-history spacing, removes duplicate Settings, and adds a functional bounded Pinned disclosure with a Recent section

## Why

This promotes the completed sidebar, editor, metadata, and AI-chat UX polish from the development environment to production while preserving the existing `main`-only documentation and setup changes through the normal PR merge path.

## Deployment notes

Migration `048_prevent_tree_self_parent.sql` repairs existing self-parent rows and adds a constraint preventing recurrence. Jenkins will apply it through the existing prebuild migration step.

## Validation

- repository pre-commit checks passed
- ESLint and i18n audit passed
- TypeScript typecheck passed
- 135 test files / 916 tests passed
- Dockerfile.marker validation passed
- latest `dev` container deployed healthy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added resizable layouts for calendar, notes, and details panels, supporting widths up to 600px.
  - Added collapsible pinned conversations in chat.
  - Added “Chat with folder/note” actions to the notes sidebar.
  - New notes automatically enter rename mode after creation.
  - Added localized “Recent” labels across supported languages.

- **Bug Fixes**
  - Prevented invalid note-tree cycles and self-parenting, including safer drag-and-drop behavior.
  - Chat generation now stops cleanly after cancellation or disconnection, preserving partial results.

- **Style**
  - Standardized interface icons and improved editor typography.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->