### PR TITLE
Add assignment type icons

### DIFF
--- a/database/migrations/049_assignment_type_icons.sql
+++ b/database/migrations/049_assignment_type_icons.sql
@@ -1,0 +1,26 @@
+ALTER TABLE app.assignments
+  ADD COLUMN IF NOT EXISTS assignment_type TEXT NOT NULL DEFAULT 'unknown';
+
+UPDATE app.assignments
+SET assignment_type = 'manual'
+WHERE source = 'manual'
+  AND assignment_type <> 'manual';
+
+UPDATE app.assignments
+SET assignment_type = 'unknown'
+WHERE source = 'canvas'
+  AND assignment_type NOT IN ('quiz', 'assignment', 'unknown');
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'assignments_assignment_type_check'
+      AND conrelid = 'app.assignments'::regclass
+  ) THEN
+    ALTER TABLE app.assignments
+      ADD CONSTRAINT assignments_assignment_type_check
+      CHECK (assignment_type IN ('quiz', 'assignment', 'manual', 'unknown'));
+  END IF;
+END $$;

--- a/src/__tests__/lib/assignment-type.test.ts
+++ b/src/__tests__/lib/assignment-type.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAssignmentTypeLabel,
+  normalizeAssignmentType,
+} from "@/lib/notes/utils/assignment-type";
+
+describe("assignment type presentation", () => {
+  it("keeps known assignment types", () => {
+    expect(normalizeAssignmentType("quiz")).toBe("quiz");
+    expect(normalizeAssignmentType("assignment")).toBe("assignment");
+    expect(normalizeAssignmentType("manual")).toBe("manual");
+    expect(normalizeAssignmentType("unknown")).toBe("unknown");
+  });
+
+  it("falls back to unknown for missing or unexpected values", () => {
+    expect(normalizeAssignmentType(null)).toBe("unknown");
+    expect(normalizeAssignmentType("discussion")).toBe("unknown");
+  });
+
+  it("returns accessible labels", () => {
+    expect(getAssignmentTypeLabel("quiz")).toBe("Quiz");
+    expect(getAssignmentTypeLabel("assignment")).toBe("Assignment");
+    expect(getAssignmentTypeLabel("manual")).toBe("Manual task");
+    expect(getAssignmentTypeLabel("unknown")).toBe("Task");
+  });
+});

--- a/src/__tests__/lib/sync-assignments.test.ts
+++ b/src/__tests__/lib/sync-assignments.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { shouldSyncAssignment } from "@/lib/canvas/sync-assignments.js";
+import {
+  deriveAssignmentType,
+  shouldSyncAssignment,
+} from "@/lib/canvas/sync-assignments.js";
 
 describe("shouldSyncAssignment", () => {
   it("skips unpublished assignments", () => {
@@ -42,8 +45,26 @@ describe("shouldSyncAssignment", () => {
   });
 
   it("keeps dated assignments", () => {
-    expect(
-      shouldSyncAssignment({ published: true, due_at: "2026-03-01T10:00:00Z" }),
-    ).toBe(true);
+    expect(shouldSyncAssignment({ published: true, due_at: "2026-03-01T10:00:00Z" })).toBe(true);
+  });
+});
+
+describe("deriveAssignmentType", () => {
+  it("marks Canvas quiz assignments from structured quiz flags", () => {
+    expect(deriveAssignmentType({ is_quiz_assignment: true })).toBe("quiz");
+  });
+
+  it("marks Canvas quiz assignments from quiz submission types", () => {
+    expect(deriveAssignmentType({ submission_types: ["online_quiz"] })).toBe("quiz");
+    expect(deriveAssignmentType({ submission_types: ["quiz"] })).toBe("quiz");
+  });
+
+  it("marks normal Canvas assignments as assignment", () => {
+    expect(deriveAssignmentType({ submission_types: ["online_upload"] })).toBe("assignment");
+  });
+
+  it("falls back to unknown when Canvas does not expose enough signal", () => {
+    expect(deriveAssignmentType({})).toBe("unknown");
+    expect(deriveAssignmentType(null)).toBe("unknown");
   });
 });

--- a/src/app/api/assignments/route.ts
+++ b/src/app/api/assignments/route.ts
@@ -47,7 +47,7 @@ export const GET = withErrorHandler(async (request) => {
   const rows = await sql`
     SELECT a.id, a.user_id, a.canvas_course_id, a.canvas_assignment_id,
            a.title, a.description, a.course_name, a.course_color,
-           a.due_at, a.estimated_hours, a.logged_hours, a.source,
+           a.due_at, a.estimated_hours, a.logged_hours, a.source, a.assignment_type,
            ${effectiveStatus} AS status,
            a.submitted_at, a.score, a.points_possible,
            a.created_at, a.updated_at
@@ -92,15 +92,15 @@ export const POST = withErrorHandler(async (request) => {
   const [row] = await sql`
     INSERT INTO app.assignments (
       user_id, title, description, course_name, course_color,
-      due_at, estimated_hours, source, status
+      due_at, estimated_hours, source, assignment_type, status
     ) VALUES (
       ${user.user_id}::uuid, ${title.trim()}, ${description ?? null},
       ${course_name ?? null}, ${course_color ?? null},
-      ${due_at ?? null}, ${estimated_hours ?? null}, 'manual', ${initialStatus}
+      ${due_at ?? null}, ${estimated_hours ?? null}, 'manual', 'manual', ${initialStatus}
     )
     RETURNING id, user_id, canvas_course_id, canvas_assignment_id,
               title, description, course_name, course_color,
-              due_at, estimated_hours, logged_hours, source, status,
+              due_at, estimated_hours, logged_hours, source, assignment_type, status,
               submitted_at, score, points_possible,
               created_at, updated_at
   `;

--- a/src/app/api/time-blocks/route.ts
+++ b/src/app/api/time-blocks/route.ts
@@ -18,7 +18,8 @@ export const GET = withErrorHandler(async (request) => {
   }
 
   const rows = await sql`
-    SELECT tb.*, a.title AS assignment_title, a.course_name, a.course_color
+    SELECT tb.*, a.title AS assignment_title, a.course_name, a.course_color,
+           a.assignment_type
     FROM app.time_blocks tb
     LEFT JOIN app.assignments a ON a.id = tb.assignment_id AND a.user_id = ${user.user_id}::uuid
     WHERE tb.user_id = ${user.user_id}::uuid

--- a/src/components/assignments/assignment-tracker.tsx
+++ b/src/components/assignments/assignment-tracker.tsx
@@ -39,6 +39,7 @@ import {
   type CourseVisibilityItem,
 } from "@/components/course-visibility/course-visibility-manager";
 import NewTaskModal from "./new-task-modal";
+import AssignmentTypeIcon from "./assignment-type-icon";
 
 interface AssignmentTrackerProps {
   surface?: "compact" | "full";
@@ -441,11 +442,14 @@ export default function AssignmentTracker({
             )}
           </div>
 
-          <h3
-            className={`mt-1 text-sm font-medium leading-snug ${completed ? "text-text-tertiary line-through" : "text-text-secondary"}`}
-          >
-            {assignment.title}
-          </h3>
+          <div className="mt-1 flex min-w-0 items-start gap-1.5">
+            <AssignmentTypeIcon type={assignment.assignment_type} />
+            <h3
+              className={`min-w-0 text-sm font-medium leading-snug ${completed ? "text-text-tertiary line-through" : "text-text-secondary"}`}
+            >
+              {assignment.title}
+            </h3>
+          </div>
 
           <div className="mt-1.5 flex items-center gap-2 text-xs">
             {due.text && <span className={toneClasses[due.tone]}>{due.text}</span>}

--- a/src/components/assignments/assignment-type-icon.tsx
+++ b/src/components/assignments/assignment-type-icon.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import {
+  ClipboardDocumentListIcon,
+  DocumentTextIcon,
+  PencilSquareIcon,
+  QuestionMarkCircleIcon,
+} from "@heroicons/react/24/outline";
+import {
+  getAssignmentTypeLabel,
+  normalizeAssignmentType,
+  type AssignmentType,
+} from "@/lib/notes/utils/assignment-type";
+
+interface AssignmentTypeIconProps {
+  type: AssignmentType | null | undefined;
+  className?: string;
+  label?: string;
+}
+
+export default function AssignmentTypeIcon({
+  type,
+  className = "h-3.5 w-3.5",
+  label,
+}: AssignmentTypeIconProps) {
+  const normalized = normalizeAssignmentType(type);
+  const accessibleLabel = label ?? getAssignmentTypeLabel(normalized);
+  const iconClassName = `${className} shrink-0`;
+
+  const icon = (() => {
+    switch (normalized) {
+      case "quiz":
+        return <QuestionMarkCircleIcon className={iconClassName} aria-hidden="true" />;
+      case "assignment":
+        return <DocumentTextIcon className={iconClassName} aria-hidden="true" />;
+      case "manual":
+        return <PencilSquareIcon className={iconClassName} aria-hidden="true" />;
+      case "unknown":
+        return <ClipboardDocumentListIcon className={iconClassName} aria-hidden="true" />;
+    }
+  })();
+
+  return (
+    <span
+      role="img"
+      aria-label={accessibleLabel}
+      title={accessibleLabel}
+      className="inline-flex shrink-0 items-center justify-center text-text-tertiary"
+    >
+      {icon}
+    </span>
+  );
+}

--- a/src/components/calendar/day-agenda.tsx
+++ b/src/components/calendar/day-agenda.tsx
@@ -14,6 +14,7 @@ import usePomodoroStore from "@/lib/notes/state/pomodoro.zustand";
 import { isoToDateKey, parseLocalDateKey } from "@/lib/notes/utils/calendar-date";
 import { getEffectiveAssignmentStatus } from "@/lib/notes/utils/assignment-status";
 import useI18n from "@/lib/notes/hooks/use-i18n";
+import AssignmentTypeIcon from "@/components/assignments/assignment-type-icon";
 
 interface DayAgendaProps {
   dateKey: string;
@@ -264,15 +265,18 @@ export default function DayAgenda({
                           )}
                         </button>
                         <div className="min-w-0 flex-1 pt-1">
-                          <h4
-                            className={`text-sm font-medium ${
-                              completed
-                                ? "text-text-tertiary line-through"
-                                : "text-text-secondary"
-                            }`}
-                          >
-                            {assignment.title}
-                          </h4>
+                          <div className="flex min-w-0 items-start gap-1.5">
+                            <AssignmentTypeIcon type={assignment.assignment_type} />
+                            <h4
+                              className={`min-w-0 text-sm font-medium ${
+                                completed
+                                  ? "text-text-tertiary line-through"
+                                  : "text-text-secondary"
+                              }`}
+                            >
+                              {assignment.title}
+                            </h4>
+                          </div>
                           <p className="mt-1 text-xs text-text-tertiary">
                             {assignment.due_at
                               ? timeFormatter.format(new Date(assignment.due_at))

--- a/src/components/calendar/week-view.tsx
+++ b/src/components/calendar/week-view.tsx
@@ -9,6 +9,8 @@ import useI18n from "@/lib/notes/hooks/use-i18n";
 import {
   formatDateKey,
 } from "@/lib/notes/utils/calendar-date";
+import AssignmentTypeIcon from "@/components/assignments/assignment-type-icon";
+import { getAssignmentTypeLabel, type AssignmentType } from "@/lib/notes/utils/assignment-type";
 
 const MIN_HOUR_HEIGHT = 56;
 const START_HOUR = 6;
@@ -148,6 +150,8 @@ export default function WeekView({ onSelectDate, onAddStudyBlock }: WeekViewProp
       top: number;
       title: string;
       color: string;
+      type: AssignmentType;
+      typeLabel: string;
     }[] = [];
     for (const a of assignments) {
       if (!a.due_at) continue;
@@ -162,6 +166,8 @@ export default function WeekView({ onSelectDate, onAddStudyBlock }: WeekViewProp
         top: (hour - START_HOUR) * hourHeight,
         title: a.title,
         color: a.course_color ?? "#ef4444",
+        type: a.assignment_type,
+        typeLabel: getAssignmentTypeLabel(a.assignment_type),
       });
     }
     return markers;
@@ -358,13 +364,20 @@ export default function WeekView({ onSelectDate, onAddStudyBlock }: WeekViewProp
                       top: marker.top,
                       borderColor: marker.color,
                     }}
-                    title={t("Due: {title}", { title: marker.title })}
+                    title={t("Due: {title}", {
+                      title: `${marker.typeLabel}: ${marker.title}`,
+                    })}
                   >
                     <span
-                      className="absolute right-0 top-0 max-w-[calc(100%-0.25rem)] -translate-y-full truncate rounded-t-radius-sm px-1 py-0.5 text-[10px] font-medium text-white shadow-sm"
+                      className="absolute right-0 top-0 flex max-w-[calc(100%-0.25rem)] -translate-y-full items-center gap-1 truncate rounded-t-radius-sm px-1 py-0.5 text-[10px] font-medium text-white shadow-sm"
                       style={{ backgroundColor: marker.color }}
                     >
-                      {marker.title}
+                      <AssignmentTypeIcon
+                        type={marker.type}
+                        className="h-3 w-3 text-white"
+                        label={marker.typeLabel}
+                      />
+                      <span className="truncate">{marker.title}</span>
                     </span>
                   </div>
                 ))}

--- a/src/lib/canvas/sync-assignments.js
+++ b/src/lib/canvas/sync-assignments.js
@@ -52,6 +52,23 @@ function isSubmitted(assignment) {
   return !!(submission?.submitted_at || ws === "submitted" || ws === "graded");
 }
 
+export function deriveAssignmentType(assignment) {
+  if (!assignment || typeof assignment !== "object") return "unknown";
+
+  if (assignment.is_quiz_assignment === true) return "quiz";
+
+  const submissionTypes = Array.isArray(assignment.submission_types)
+    ? assignment.submission_types
+    : [];
+  if (submissionTypes.some((type) => type === "online_quiz" || type === "quiz")) {
+    return "quiz";
+  }
+
+  if (submissionTypes.length > 0) return "assignment";
+
+  return "unknown";
+}
+
 export function shouldSyncAssignment(assignment) {
   if (!assignment) return false;
   if (assignment.locked_for_user === true) return false;
@@ -93,18 +110,19 @@ export async function syncAssignmentMetadata(
     if (!shouldSyncAssignment(a)) continue;
     try {
       const status = deriveStatus(a);
+      const assignmentType = deriveAssignmentType(a);
       const submission = a.submission;
 
       await sql`
         INSERT INTO app.assignments (
           user_id, canvas_course_id, canvas_assignment_id,
           title, description, course_name, course_color,
-          due_at, status, source,
+          due_at, status, source, assignment_type,
           submitted_at, score, points_possible
         ) VALUES (
           ${userId}::uuid, ${Number(courseId)}, ${a.id},
           ${a.name}, ${a.description ?? null}, ${courseTitle}, ${courseColor},
-          ${a.due_at ?? null}, ${status}, 'canvas',
+          ${a.due_at ?? null}, ${status}, 'canvas', ${assignmentType},
           ${submission?.submitted_at ?? null},
           ${submission?.score ?? null},
           ${a.points_possible ?? null}
@@ -123,6 +141,7 @@ export async function syncAssignmentMetadata(
           submitted_at = EXCLUDED.submitted_at,
           score = EXCLUDED.score,
           points_possible = EXCLUDED.points_possible,
+          assignment_type = EXCLUDED.assignment_type,
           updated_at = NOW()
       `;
       synced++;

--- a/src/lib/notes/state/assignments.zustand.ts
+++ b/src/lib/notes/state/assignments.zustand.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { AssignmentType } from "@/lib/notes/utils/assignment-type";
 
 export interface Assignment {
   id: string;
@@ -13,6 +14,7 @@ export interface Assignment {
   estimated_hours: number | null;
   logged_hours: number;
   source: "canvas" | "manual";
+  assignment_type: AssignmentType;
   submitted_at: string | null;
   score: number | null;
   points_possible: number | null;

--- a/src/lib/notes/state/calendar.zustand.ts
+++ b/src/lib/notes/state/calendar.zustand.ts
@@ -6,6 +6,7 @@ import {
   formatDateKey,
   parseLocalDateKey,
 } from "@/lib/notes/utils/calendar-date";
+import type { AssignmentType } from "@/lib/notes/utils/assignment-type";
 
 export type CalendarView = "month" | "week";
 
@@ -20,6 +21,7 @@ export interface TimeBlock {
   assignment_title?: string;
   course_name?: string;
   course_color?: string;
+  assignment_type?: AssignmentType | null;
 }
 
 interface CalendarState {

--- a/src/lib/notes/utils/assignment-type.ts
+++ b/src/lib/notes/utils/assignment-type.ts
@@ -1,0 +1,27 @@
+export type AssignmentType = "quiz" | "assignment" | "manual" | "unknown";
+
+const ASSIGNMENT_TYPES = new Set<string>([
+  "quiz",
+  "assignment",
+  "manual",
+  "unknown",
+]);
+
+export function normalizeAssignmentType(value: unknown): AssignmentType {
+  return typeof value === "string" && ASSIGNMENT_TYPES.has(value)
+    ? (value as AssignmentType)
+    : "unknown";
+}
+
+export function getAssignmentTypeLabel(value: unknown): string {
+  switch (normalizeAssignmentType(value)) {
+    case "quiz":
+      return "Quiz";
+    case "assignment":
+      return "Assignment";
+    case "manual":
+      return "Manual task";
+    case "unknown":
+      return "Task";
+  }
+}


### PR DESCRIPTION
## Summary
- add persisted assignment_type for assignment-backed task rows with safe manual/canvas backfill
- derive Canvas assignment types from structured quiz flags/submission types only
- expose assignment_type through assignment and time-block APIs and render accessible icons in tracker/calendar surfaces

## Scope notes
- deliberately limited to quiz, assignment, manual, unknown
- discussions/announcements remain out of scope for #315 until planner-item contract work (#378)

## Verification
- npm run test:ci -- src/__tests__/lib/sync-assignments.test.ts src/__tests__/lib/assignment-type.test.ts src/__tests__/lib/notes/assignments.zustand.test.ts src/__tests__/lib/notes/calendar.zustand.test.ts
- npm run typecheck
- npm run lint -- src/lib/canvas/sync-assignments.js src/app/api/assignments/route.ts src/app/api/time-blocks/route.ts src/lib/notes/state/assignments.zustand.ts src/lib/notes/state/calendar.zustand.ts src/lib/notes/utils/assignment-type.ts src/components/assignments/assignment-type-icon.tsx src/components/assignments/assignment-tracker.tsx src/components/calendar/day-agenda.tsx src/components/calendar/week-view.tsx
- npm run lint -- src/__tests__/lib/sync-assignments.test.ts src/__tests__/lib/assignment-type.test.ts
- npm run build
- precommit: npm run lint:all, Dockerfile.marker validation; 136 files / 923 tests passed

Closes #315