### PR TITLE
Add note references and backlinks

### DIFF
--- a/database/migrations/049_note_links.sql
+++ b/database/migrations/049_note_links.sql
@@ -1,0 +1,18 @@
+-- Store resolved internal note references so backlinks are indexed and do not
+-- require scanning every note body when the inspector opens.
+
+CREATE TABLE IF NOT EXISTS app.note_links (
+    user_id        UUID NOT NULL REFERENCES app.login(user_id) ON DELETE CASCADE,
+    source_note_id UUID NOT NULL REFERENCES app.notes(note_id) ON DELETE CASCADE,
+    target_note_id UUID NOT NULL REFERENCES app.notes(note_id) ON DELETE CASCADE,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, source_note_id, target_note_id),
+    CHECK (source_note_id <> target_note_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_note_links_target
+    ON app.note_links (user_id, target_note_id);
+
+-- `/notes/<uuid>` references are introduced with this migration, so there is
+-- no legacy canonical-link corpus to scan during deployment. Rows are derived
+-- when notes are created or saved.

--- a/docs/engineering/markdown-rendering.md
+++ b/docs/engineering/markdown-rendering.md
@@ -2,7 +2,7 @@
 
 > **Status:** Active compatibility contract
 >
-> **Last reviewed:** 2026-07-15
+> **Last reviewed:** 2026-07-21
 >
 > **Source of truth:** Editor/renderer code and [`src/__tests__/fixtures/markdown-contract.md`](../../src/__tests__/fixtures/markdown-contract.md)
 
@@ -39,13 +39,18 @@ The note preview supports:
 - inline and display math through KaTeX;
 - fenced `mermaid` diagrams with lazy, strict, sanitized SVG rendering and source fallback;
 - lazy images and Marker-style note-asset rewriting when a note ID is available;
+- internal note references stored as portable Markdown links to stable
+  `/notes/<uuid>` routes, inserted through the editor toolbar or `[[` picker;
 - a small sanitized raw-HTML subset used by notes, including `mark`, `details`, `summary`, `kbd`, `sup`, and `sub`.
 
 Fenced code is rendered by [`CodeBlock`](../../src/lib/markdown/components/code-block.tsx) and highlighted lazily with **Shiki**, not `rehype-highlight`. Known aliases are normalized; unsupported languages fall back to plaintext; missing languages display a `CODE` label. Highlighting must never turn code content into executable HTML.
 
 Rendered notes, chat answers, and quiz content use the same semantic colours, spacing rhythm, code chrome, table treatment, task controls, and display-math surface. Compact contexts may reduce type and spacing through their renderer variant, but must not redefine Markdown elements component-by-component. Write-mode math uses the same surface tokens so switching between editing and rendered content does not introduce a new visual language.
 
-Wikilinks/backlinks, callouts, footnotes, frontmatter rendering, arbitrary local paths, and MDX components are not part of this contract unless added deliberately with tests.
+Backlinks are derived from canonical internal note references and displayed in
+the note inspector. Obsidian-style wikilink storage, transclusion, callouts,
+footnotes, frontmatter rendering, arbitrary local paths, and MDX components are
+not part of this contract unless added deliberately with tests.
 
 ## Security boundary
 

--- a/scripts/e2e/reset-db.mjs
+++ b/scripts/e2e/reset-db.mjs
@@ -547,6 +547,7 @@ async function main() {
       "042_resumable_chat_generations.sql",
       "043_chat_session_pinning.sql",
       "045_imported_file_cache.sql",
+      "049_note_links.sql",
     ]) {
       await sql.unsafe(
         await readFile(

--- a/src/__tests__/lib/internal-note-links.test.ts
+++ b/src/__tests__/lib/internal-note-links.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildInternalNoteHref,
+  extractInternalNoteIds,
+  parseInternalNoteHref,
+} from "@/lib/notes/internal-links";
+
+const FIRST = "01962eb7-3571-7a2b-9c4d-5e6f7a8b9c0d";
+const SECOND = "123e4567-e89b-42d3-a456-426614174000";
+
+describe("internal note links", () => {
+  it("builds and parses canonical note routes", () => {
+    expect(buildInternalNoteHref(FIRST)).toBe(`/notes/${FIRST}`);
+    expect(parseInternalNoteHref(`/notes/${FIRST}`)).toBe(FIRST);
+    expect(parseInternalNoteHref(`/notes/${SECOND}#overview`)).toBe(SECOND);
+  });
+
+  it("rejects external and non-note routes", () => {
+    expect(parseInternalNoteHref(`https://example.com/notes/${FIRST}`)).toBeNull();
+    expect(parseInternalNoteHref(`/chat/${FIRST}`)).toBeNull();
+    expect(parseInternalNoteHref(`/notes/not-a-uuid`)).toBeNull();
+  });
+
+  it("extracts unique note targets from Markdown", () => {
+    const content = [
+      `[First](/notes/${FIRST})`,
+      `[First again](/notes/${FIRST}#details)`,
+      `[Second](/notes/${SECOND})`,
+      `[External](https://example.com)`,
+    ].join("\n");
+
+    expect(extractInternalNoteIds(content)).toEqual([FIRST, SECOND]);
+  });
+});

--- a/src/__tests__/lib/markdown-renderer.test.ts
+++ b/src/__tests__/lib/markdown-renderer.test.ts
@@ -48,6 +48,17 @@ describe("MarkdownRenderer variants", () => {
     expect(html).not.toContain("onerror=");
   });
 
+  it("keeps internal note references in-app while external links open separately", () => {
+    const noteId = "01962eb7-3571-7a2b-9c4d-5e6f7a8b9c0d";
+    const html = renderMarkdown(
+      `[Internal](/notes/${noteId}) [External](https://example.com)`,
+    );
+
+    expect(html).toContain(`href="/notes/${noteId}"`);
+    expect(html).not.toContain(`href="/notes/${noteId}" target="_blank"`);
+    expect(html).toContain('href="https://example.com" target="_blank"');
+  });
+
   it("keeps chat and quiz raw HTML disabled and sanitized explicitly", () => {
     expect(markdownRendererVariants.chat).toMatchObject({
       allowRawHtml: false,

--- a/src/__tests__/lib/note-type.test.ts
+++ b/src/__tests__/lib/note-type.test.ts
@@ -20,7 +20,9 @@ describe("NOTE_ID_REGEXP", () => {
 
 describe("isNoteLink", () => {
   it("accepts a valid v7 note path", () => {
-    expect(isNoteLink("/01962eb7-3571-7a2b-9c4d-5e6f7a8b9c0d")).toBe(true);
+    expect(
+      isNoteLink("/notes/01962eb7-3571-7a2b-9c4d-5e6f7a8b9c0d"),
+    ).toBe(true);
   });
 
   it("rejects a path without a leading slash", () => {
@@ -28,9 +30,9 @@ describe("isNoteLink", () => {
   });
 
   it("rejects a path with trailing segments", () => {
-    expect(isNoteLink("/01962eb7-3571-7a2b-9c4d-5e6f7a8b9c0d/history")).toBe(
-      false,
-    );
+    expect(
+      isNoteLink("/notes/01962eb7-3571-7a2b-9c4d-5e6f7a8b9c0d/history"),
+    ).toBe(false);
   });
 
   it("rejects plain strings", () => {
@@ -39,7 +41,9 @@ describe("isNoteLink", () => {
     expect(isNoteLink("")).toBe(false);
   });
 
-  it("rejects v4 UUIDs (wrong version nibble)", () => {
-    expect(isNoteLink("/123e4567-e89b-42d3-a456-426614174000")).toBe(false);
+  it("accepts legacy v4 UUID note routes", () => {
+    expect(
+      isNoteLink("/notes/123e4567-e89b-42d3-a456-426614174000"),
+    ).toBe(true);
   });
 });

--- a/src/__tests__/lib/portal-preview.test.ts
+++ b/src/__tests__/lib/portal-preview.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import usePortalStore from "@/lib/notes/state/portal";
+
+describe("note preview close coordination", () => {
+  afterEach(() => {
+    usePortalStore.getState().preview.close();
+    vi.useRealTimers();
+  });
+
+  it("keeps the preview open when the pointer reaches the preview card", () => {
+    vi.useFakeTimers();
+    const preview = usePortalStore.getState().preview;
+
+    preview.open();
+    preview.scheduleClose(500);
+    vi.advanceTimersByTime(300);
+    preview.cancelClose();
+    vi.advanceTimersByTime(500);
+
+    expect(usePortalStore.getState().preview.visible).toBe(true);
+  });
+
+  it("closes after the scheduled grace period", () => {
+    vi.useFakeTimers();
+    const preview = usePortalStore.getState().preview;
+
+    preview.open();
+    preview.scheduleClose(500);
+    vi.advanceTimersByTime(500);
+
+    expect(usePortalStore.getState().preview.visible).toBe(false);
+  });
+});

--- a/src/app/api/notes/[id]/backlinks/route.ts
+++ b/src/app/api/notes/[id]/backlinks/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateSession } from "@/lib/auth";
+import { isValidUUID } from "@/lib/utils/uuid";
+import { withErrorHandler, tracedError } from "@/lib/api-error";
+import sql from "@/database/pgsql.js";
+
+type NoteRouteContext = { params: Promise<{ id: string }> };
+
+export const GET = withErrorHandler(
+  async (_request: NextRequest, { params }: NoteRouteContext) => {
+    const user = await validateSession();
+    if (!user) return tracedError("Unauthorized", 401);
+
+    const { id } = await params;
+    if (!isValidUUID(id)) return tracedError("Invalid note ID", 400);
+
+    const incoming = await sql`
+      SELECT source.note_id AS id, source.title,
+             LEFT(COALESCE(source.content, ''), 280) AS excerpt
+      FROM app.note_links link
+      JOIN app.notes source
+        ON source.note_id = link.source_note_id
+       AND source.user_id = link.user_id
+       AND source.deleted_at IS NULL
+      WHERE link.user_id = ${user.user_id}::uuid
+        AND link.target_note_id = ${id}::uuid
+      ORDER BY source.updated_at DESC
+    `;
+
+    const outgoing = await sql`
+      SELECT target.note_id AS id, target.title,
+             LEFT(COALESCE(target.content, ''), 280) AS excerpt
+      FROM app.note_links link
+      JOIN app.notes target
+        ON target.note_id = link.target_note_id
+       AND target.user_id = link.user_id
+       AND target.deleted_at IS NULL
+      WHERE link.user_id = ${user.user_id}::uuid
+        AND link.source_note_id = ${id}::uuid
+      ORDER BY target.title ASC
+    `;
+
+    return NextResponse.json({ incoming, outgoing });
+  },
+);

--- a/src/app/api/notes/[id]/route.ts
+++ b/src/app/api/notes/[id]/route.ts
@@ -13,6 +13,7 @@ import { deleteNoteRagIndex, replaceNoteEmbeddings } from "@/lib/rag/indexing";
 import { processExtractedText } from "@/lib/canvas/text-processing";
 import { noteUpdateSchema, validateBody } from "@/lib/validations/schemas";
 import { withErrorHandler, tracedError } from "@/lib/api-error";
+import { replaceNoteLinks } from "@/lib/notes/storage/note-links";
 
 interface NoteRouteParams {
   id: string;
@@ -115,7 +116,7 @@ export const PUT = withErrorHandler(async (request: NextRequest, { params }: Not
   if (!bodyValidation.success) return bodyValidation.response;
   const body = bodyValidation.data;
 
-  if (body.title && body.title.length > MAX_TITLE_LENGTH) {
+  if (body.title !== undefined && body.title.length > MAX_TITLE_LENGTH) {
     logger.warn("note title exceeds max length", {
       length: body.title.length,
       noteId,
@@ -125,7 +126,7 @@ export const PUT = withErrorHandler(async (request: NextRequest, { params }: Not
       400,
     );
   }
-  if (body.content && body.content.length > MAX_CONTENT_LENGTH) {
+  if (body.content !== undefined && body.content.length > MAX_CONTENT_LENGTH) {
     logger.warn("note content exceeds max length", {
       length: body.content.length,
       noteId,
@@ -151,15 +152,15 @@ export const PUT = withErrorHandler(async (request: NextRequest, { params }: Not
 
   const updatedRows = (await sql`
      UPDATE app.notes
-     SET title = ${body.title || existingNote.title},
-         content = ${body.content || existingNote.content},
+     SET title = ${body.title ?? existingNote.title},
+         content = ${body.content ?? existingNote.content},
          updated_at = NOW()
      WHERE note_id = ${noteId}::uuid AND user_id = ${user.user_id}::uuid
      RETURNING note_id, title, content, is_folder, s3_key, shared, pinned, created_at, updated_at
    `) as NoteSummaryRow[];
 
   const keysToInvalidate = [cacheKeys.note(user.user_id, noteId)];
-  if (body.title && body.title !== existingNote.title) {
+  if (body.title !== undefined && body.title !== existingNote.title) {
     keysToInvalidate.push(
       cacheKeys.treeFull(user.user_id),
       cacheKeys.notesList(user.user_id, 0, undefined),
@@ -167,7 +168,13 @@ export const PUT = withErrorHandler(async (request: NextRequest, { params }: Not
   }
   await cacheInvalidate(...keysToInvalidate);
 
-  if (body.content && body.content !== existingNote.content) {
+  if (body.content !== undefined && body.content !== existingNote.content) {
+    try {
+      await replaceNoteLinks(user.user_id, noteId, body.content);
+    } catch (linkErr) {
+      logger.error("note link index update failed", { noteId, error: linkErr });
+    }
+
     const cleanedText = processExtractedText(body.content);
     if (cleanedText !== (existingNote.extracted_text ?? "")) {
       try {

--- a/src/app/api/notes/route.js
+++ b/src/app/api/notes/route.js
@@ -8,6 +8,7 @@ import { cacheGet, cacheSet, cacheInvalidate, cacheKeys } from "@/lib/cache";
 import sql from "@/database/pgsql.js";
 import logger from "@/lib/logger";
 import { noteCreateSchema, validateBody } from "@/lib/validations/schemas";
+import { replaceNoteLinks } from "@/lib/notes/storage/note-links";
 
 // Constants
 const MAX_TITLE_LENGTH = parseInt(process.env.MAX_TITLE_LENGTH ?? "500", 10);
@@ -24,6 +25,7 @@ export const GET = withErrorHandler(async (request) => {
   const fieldsParam = url.searchParams.get("fields");
   const skipParam = url.searchParams.get("skip");
   const limitParam = url.searchParams.get("limit");
+  const query = url.searchParams.get("q")?.trim().slice(0, 200) || null;
 
   // Parse fields from comma-separated string
   const fields = fieldsParam
@@ -31,20 +33,26 @@ export const GET = withErrorHandler(async (request) => {
     : undefined;
 
   // Parse pagination
-  const skip = skipParam ? parseInt(skipParam, 10) : 0;
-  const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+  const parsedSkip = skipParam ? parseInt(skipParam, 10) : 0;
+  const parsedLimit = limitParam ? parseInt(limitParam, 10) : undefined;
+  const skip = Number.isFinite(parsedSkip) && parsedSkip >= 0 ? parsedSkip : 0;
+  const limit =
+    parsedLimit !== undefined && Number.isFinite(parsedLimit)
+      ? Math.min(Math.max(parsedLimit, 1), 200)
+      : undefined;
 
   // check cache for this page (before field filtering)
   const listKey = cacheKeys.notesList(user.user_id, skip, limit);
-  const cachedList = await cacheGet(listKey);
-  if (cachedList) {
+  const cachedList = query ? null : await cacheGet(listKey);
+  if (!query && cachedList) {
     const filtered = cachedList.map((note) => filterNoteFields(note, fields));
     return NextResponse.json(filtered);
   }
 
   // Get user's notes from PostgreSQL with SQL-level pagination
   // content is excluded from the list query — fetch individual notes for full content
-  const sqlLimit = limit ?? 200;
+  const sqlLimit = query ? 50 : (limit ?? 200);
+  const searchPattern = query ? `%${query}%` : null;
   const notes = await sql`
     SELECT n.note_id, n.title, n.is_folder, n.s3_key, n.shared, n.pinned,
            n.created_at, n.updated_at,
@@ -52,14 +60,16 @@ export const GET = withErrorHandler(async (request) => {
             WHERE a.note_id = n.note_id AND a.user_id = n.user_id AND a.s3_key = n.s3_key
             LIMIT 1) AS mime_type
     FROM app.notes n
-    WHERE n.user_id = ${user.user_id}::uuid AND n.deleted_at IS NULL
+    WHERE n.user_id = ${user.user_id}::uuid
+      AND n.deleted_at IS NULL
+      AND (${searchPattern}::text IS NULL OR n.title ILIKE ${searchPattern})
     ORDER BY n.created_at DESC
     LIMIT ${sqlLimit} OFFSET ${skip}
   `;
 
   // Map to NoteModel format and cache full list (pre-field-filter)
   const mapped = notes.map(mapNoteFromDB);
-  await cacheSet(listKey, mapped, 120);
+  if (!query) await cacheSet(listKey, mapped, 120);
 
   // Filter fields if requested
   const filtered = mapped.map((note) => filterNoteFields(note, fields));
@@ -109,6 +119,17 @@ export const POST = withErrorHandler(async (request) => {
   // If pid is provided, use it; otherwise add to root (parent_id = null)
   const parentId = body.pid || null;
   await addNoteToTree(user.user_id, note.note_id, parentId);
+
+  if (body.content) {
+    try {
+      await replaceNoteLinks(user.user_id, note.note_id, body.content);
+    } catch (linkErr) {
+      logger.error("note link index creation failed", {
+        noteId: note.note_id,
+        error: linkErr,
+      });
+    }
+  }
 
   // invalidate tree + note list caches
   await cacheInvalidate(

--- a/src/components/editor/markdown-editor.tsx
+++ b/src/components/editor/markdown-editor.tsx
@@ -426,6 +426,8 @@ const MarkdownEditor: FC<MarkdownEditorProps> = ({ pane, file }) => {
               }}
               onSave={handleSave}
               placeholder={t("Start writing...")}
+              currentNoteId={file.fileId}
+              onOpenNote={(noteId) => router.push(`/notes/${noteId}`)}
             />
           </div>
         ) : (

--- a/src/components/editor/milkdown-write-editor.tsx
+++ b/src/components/editor/milkdown-write-editor.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Crepe, CrepeFeature } from "@milkdown/crepe";
 import { editorViewCtx, parserCtx } from "@milkdown/kit/core";
+import { linkSchema } from "@milkdown/kit/preset/commonmark";
 import { Slice } from "@milkdown/kit/prose/model";
 import { Decoration, DecorationSet } from "@milkdown/kit/prose/view";
 import { Plugin } from "@milkdown/kit/prose/state";
@@ -10,12 +11,33 @@ import { $prose } from "@milkdown/kit/utils";
 import DOMPurify from "dompurify";
 import { renderMermaidElement } from "@/lib/markdown/mermaid";
 import { markdownSanitizeSchema } from "@/lib/markdown/sanitize-schema";
+import {
+  buildInternalNoteHref,
+  parseInternalNoteHref,
+} from "@/lib/notes/internal-links";
+import usePortalStore from "@/lib/notes/state/portal";
 
 interface MilkdownWriteEditorProps {
   value: string;
   onChange: (value: string, programmaticUpdate?: boolean) => void;
   onSave?: () => void;
   placeholder?: string;
+  currentNoteId?: string;
+  onOpenNote?: (noteId: string) => void;
+}
+
+interface NoteOption {
+  id: string;
+  title?: string;
+  isFolder?: boolean;
+}
+
+const NOTE_LINK_ICON = `<svg class="oghma-note-link-icon" viewBox="0 0 24 24" role="img"><title>Reference note</title><path d="M7 3.75h7l3 3v5.5M14 3.75v3h3M9.5 14.5l-1 1a2.12 2.12 0 0 0 3 3l1.25-1.25m1.75-2.75 1-1a2.12 2.12 0 0 0-3-3l-1.25 1.25m-.75 4.25 4-4" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+
+function enhanceNoteReferenceButton(root: HTMLElement) {
+  const button = root.querySelector(".oghma-note-link-icon")?.closest("button");
+  button?.setAttribute("title", "Reference note");
+  button?.setAttribute("aria-label", "Reference note");
 }
 
 function replaceExternalMarkdown(crepe: Crepe, markdown: string) {
@@ -275,15 +297,84 @@ export default function MilkdownWriteEditor({
   onChange,
   onSave,
   placeholder = "Start writing...",
+  currentNoteId,
+  onOpenNote,
 }: MilkdownWriteEditorProps) {
   const rootRef = useRef<HTMLDivElement>(null);
+  const pickerListRef = useRef<HTMLDivElement>(null);
   const crepeRef = useRef<Crepe | null>(null);
   const onChangeRef = useRef(onChange);
   const latestValueRef = useRef(value);
+  const pickerSelectionRef = useRef({ from: 0, to: 0 });
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerQuery, setPickerQuery] = useState("");
+  const [noteOptions, setNoteOptions] = useState<NoteOption[]>([]);
+  const [pickerLoading, setPickerLoading] = useState(false);
+  const [selectedOption, setSelectedOption] = useState(0);
+  const preview = usePortalStore((state) => state.preview);
+  const openPickerRef = useRef<(from: number, to: number) => void>(() => {});
+
+  openPickerRef.current = (from, to) => {
+    pickerSelectionRef.current = { from, to };
+    setPickerQuery("");
+    setSelectedOption(0);
+    setPickerOpen(true);
+  };
+
+  const filteredNotes = useMemo(() => {
+    const query = pickerQuery.trim().toLocaleLowerCase();
+    return noteOptions
+      .filter((note) => !note.isFolder && note.id !== currentNoteId)
+      .filter(
+        (note) =>
+          !query ||
+          (note.title || "Untitled").toLocaleLowerCase().includes(query),
+      )
+      .slice(0, 12);
+  }, [currentNoteId, noteOptions, pickerQuery]);
 
   useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
+
+  useEffect(() => {
+    if (!pickerOpen) return;
+    pickerListRef.current
+      ?.querySelector<HTMLElement>(`[data-option-index="${selectedOption}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [pickerOpen, selectedOption]);
+
+  useEffect(() => {
+    if (!pickerOpen) return;
+    let cancelled = false;
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      setPickerLoading(true);
+      const query = pickerQuery.trim();
+      const params = query
+        ? `q=${encodeURIComponent(query)}`
+        : "limit=200";
+      fetch(`/api/notes?${params}`, { signal: controller.signal })
+        .then((response) => {
+          if (!response.ok) throw new Error("Unable to load notes");
+          return response.json();
+        })
+        .then((notes: NoteOption[]) => {
+          if (!cancelled) setNoteOptions(notes);
+        })
+        .catch((error) => {
+          if (!cancelled && error.name !== "AbortError") setNoteOptions([]);
+        })
+        .finally(() => {
+          if (!cancelled) setPickerLoading(false);
+        });
+    }, pickerQuery ? 150 : 0);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [pickerOpen, pickerQuery]);
 
   useEffect(() => {
     const root = rootRef.current;
@@ -298,6 +389,18 @@ export default function MilkdownWriteEditor({
       },
       featureConfigs: {
         [CrepeFeature.Placeholder]: { text: placeholder },
+        [CrepeFeature.TopBar]: {
+          buildTopBar: (builder) => {
+            builder.getGroup("insert").addItem("note-reference", {
+              icon: NOTE_LINK_ICON,
+              active: () => false,
+              onRun: (ctx) => {
+                const { from, to } = ctx.get(editorViewCtx).state.selection;
+                openPickerRef.current(from, to);
+              },
+            });
+          },
+        },
         [CrepeFeature.CodeMirror]: {
           copyIcon: COPY_ICON,
           copyText: "",
@@ -319,19 +422,47 @@ export default function MilkdownWriteEditor({
     });
 
     let observer: MutationObserver | null = null;
+    let disposed = false;
+    const handleBeforeInput = (event: InputEvent) => {
+      if (event.data !== "[") return;
+      const view = crepe.editor.ctx.get(editorViewCtx);
+      const { from, empty } = view.state.selection;
+      if (
+        !empty ||
+        from < 1 ||
+        view.state.doc.textBetween(from - 1, from) !== "["
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      view.dispatch(view.state.tr.delete(from - 1, from));
+      openPickerRef.current(from - 1, from - 1);
+    };
+    root.addEventListener("beforeinput", handleBeforeInput as EventListener, true);
     void crepe.create().then(() => {
-      if (!root.isConnected) return;
+      if (disposed || !root.isConnected) {
+        void crepe.destroy();
+        return;
+      }
       crepeRef.current = crepe;
       if (crepe.getMarkdown() !== latestValueRef.current) {
         replaceExternalMarkdown(crepe, latestValueRef.current);
       }
       enhanceMilkdownCodeBlocks(root);
-      observer = new MutationObserver(() => enhanceMilkdownCodeBlocks(root));
+      enhanceNoteReferenceButton(root);
+      observer = new MutationObserver(() => {
+        enhanceMilkdownCodeBlocks(root);
+        enhanceNoteReferenceButton(root);
+      });
       observer.observe(root, { childList: true, subtree: true });
     });
 
     return () => {
+      disposed = true;
       observer?.disconnect();
+      root.removeEventListener("beforeinput", handleBeforeInput as EventListener, true);
       crepeRef.current = null;
       void crepe.destroy();
     };
@@ -346,17 +477,161 @@ export default function MilkdownWriteEditor({
     replaceExternalMarkdown(crepe, value);
   }, [value]);
 
+  const insertNoteReference = (note: NoteOption) => {
+    const crepe = crepeRef.current;
+    if (!crepe) return;
+
+    crepe.editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      const { from, to } = pickerSelectionRef.current;
+      const safeFrom = Math.min(from, view.state.doc.content.size);
+      const safeTo = Math.min(to, view.state.doc.content.size);
+      const label = note.title || "Untitled";
+      const mark = linkSchema.type(ctx).create({
+        href: buildInternalNoteHref(note.id),
+        title: null,
+      });
+      const transaction =
+        safeFrom === safeTo
+          ? view.state.tr
+              .insertText(label, safeFrom)
+              .addMark(safeFrom, safeFrom + label.length, mark)
+          : view.state.tr.addMark(safeFrom, safeTo, mark);
+      view.dispatch(transaction.scrollIntoView());
+      view.focus();
+    });
+    setPickerOpen(false);
+  };
+
   return (
     <div
-      className="oghma-milkdown-editor h-full min-h-0 overflow-auto bg-app-page"
+      className="oghma-milkdown-editor relative h-full min-h-0 overflow-auto bg-app-page"
       onKeyDownCapture={(event) => {
         if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
           event.preventDefault();
           onSave?.();
         }
       }}
+      onClickCapture={(event) => {
+        const anchor = (event.target as HTMLElement).closest<HTMLAnchorElement>(
+          "a[href]",
+        );
+        const noteId = parseInternalNoteHref(anchor?.getAttribute("href"));
+        if (!noteId) return;
+        event.preventDefault();
+        if (event.metaKey || event.ctrlKey) {
+          window.open(buildInternalNoteHref(noteId), "_blank");
+        } else {
+          onOpenNote?.(noteId);
+        }
+      }}
+      onMouseOver={(event) => {
+        const anchor = (event.target as HTMLElement).closest<HTMLAnchorElement>(
+          "a[href]",
+        );
+        const noteId = parseInternalNoteHref(anchor?.getAttribute("href"));
+        if (!anchor || !noteId) return;
+        preview.cancelClose();
+        preview.setAnchor(anchor);
+        preview.setData({ id: noteId });
+        preview.open();
+      }}
+      onMouseOut={(event) => {
+        const anchor = (event.target as HTMLElement).closest<HTMLAnchorElement>(
+          "a[href]",
+        );
+        if (!parseInternalNoteHref(anchor?.getAttribute("href"))) return;
+        preview.scheduleClose();
+      }}
     >
       <div ref={rootRef} className="mx-auto min-h-full" />
+      {pickerOpen && (
+        <div
+          className="sticky bottom-4 z-50 mx-auto w-[min(28rem,calc(100%-2rem))] rounded-radius-lg border border-border-subtle bg-surface-elevated p-2 shadow-2xl"
+          role="dialog"
+          aria-label="Reference a note"
+          onKeyDown={(event) => {
+            if (event.key === "Escape") setPickerOpen(false);
+          }}
+        >
+          <div className="flex items-center gap-1.5">
+            <input
+              autoFocus
+              role="combobox"
+              aria-autocomplete="list"
+              aria-expanded="true"
+              aria-controls="note-reference-options"
+              value={pickerQuery}
+              onChange={(event) => {
+                setPickerQuery(event.target.value);
+                setSelectedOption(0);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "ArrowDown") {
+                  event.preventDefault();
+                  if (!filteredNotes.length) return;
+                  setSelectedOption((index) =>
+                    Math.min(index + 1, filteredNotes.length - 1),
+                  );
+                }
+                if (event.key === "ArrowUp") {
+                  event.preventDefault();
+                  setSelectedOption((index) => Math.max(index - 1, 0));
+                }
+                if (event.key === "Enter" && filteredNotes[selectedOption]) {
+                  event.preventDefault();
+                  insertNoteReference(filteredNotes[selectedOption]);
+                }
+              }}
+              placeholder="Search notes…"
+              className="min-w-0 flex-1 rounded-radius-md border border-border-subtle bg-background px-3 py-2 text-sm text-text outline-none focus:border-primary-500"
+            />
+            <button
+              type="button"
+              onClick={() => setPickerOpen(false)}
+              className="flex h-9 w-9 items-center justify-center rounded-radius-md text-lg text-text-tertiary hover:bg-subtle hover:text-text"
+              aria-label="Close note picker"
+            >
+              ×
+            </button>
+          </div>
+          <div
+            ref={pickerListRef}
+            id="note-reference-options"
+            className="mt-1 max-h-64 overflow-y-auto"
+            role="listbox"
+          >
+            {pickerLoading ? (
+              <p className="px-3 py-4 text-sm text-text-tertiary">
+                Loading notes…
+              </p>
+            ) : filteredNotes.length ? (
+              filteredNotes.map((note, index) => (
+                <button
+                  key={note.id}
+                  type="button"
+                  role="option"
+                  aria-selected={index === selectedOption}
+                  data-option-index={index}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => insertNoteReference(note)}
+                  className={`block w-full rounded-radius-sm px-3 py-2 text-left text-sm ${
+                    index === selectedOption
+                      ? "bg-primary-500/15 text-text"
+                      : "text-text-secondary hover:bg-subtle"
+                  }`}
+                >
+                  {note.title || "Untitled"}
+                </button>
+              ))
+            ) : (
+              <p className="px-3 py-4 text-sm text-text-tertiary">
+                No matching notes
+              </p>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/notes/note-inspector-panel.tsx
+++ b/src/components/notes/note-inspector-panel.tsx
@@ -18,6 +18,7 @@ import {
   rememberSidebarChatSession,
 } from "@/lib/chat/sidebar-session";
 import { buildChatSessionHref, buildNewChatHref } from "@/lib/chat/routes";
+import { removeMarkdown } from "@/lib/notes/utils/markdown";
 
 const ChatInterface = dynamic(
   () => import("@/components/chat/chat-interface"),
@@ -34,6 +35,17 @@ interface InspectorNote {
   content?: string;
   createdAt?: string;
   updatedAt?: string;
+}
+
+interface NoteReference {
+  id: string;
+  title?: string;
+  excerpt?: string;
+}
+
+interface NoteReferences {
+  incoming: NoteReference[];
+  outgoing: NoteReference[];
 }
 
 function NoteSidebarChat({
@@ -106,6 +118,45 @@ function formatTimestamp(value?: string) {
   };
 }
 
+function ReferenceList({
+  title,
+  emptyLabel,
+  references,
+}: {
+  title: string;
+  emptyLabel: string;
+  references: NoteReference[];
+}) {
+  return (
+    <section>
+      <h4 className="mb-2 text-xs font-medium text-text-tertiary">{title}</h4>
+      {references.length ? (
+        <ul className="space-y-1.5">
+          {references.map((reference) => (
+            <li key={reference.id}>
+              <a
+                href={`/notes/${reference.id}`}
+                className="block rounded-radius-sm border border-border-subtle px-2.5 py-2 transition-colors hover:bg-subtle"
+              >
+                <span className="block truncate text-sm text-text-secondary">
+                  {reference.title || "Untitled"}
+                </span>
+                {reference.excerpt && (
+                  <span className="mt-0.5 block line-clamp-2 text-xs text-text-tertiary">
+                    {removeMarkdown(reference.excerpt)}
+                  </span>
+                )}
+              </a>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-xs text-text-tertiary/70">{emptyLabel}</p>
+      )}
+    </section>
+  );
+}
+
 export default function NoteInspectorPanel({
   presentation = "desktop",
 }: {
@@ -123,6 +174,10 @@ export default function NoteInspectorPanel({
   } = useLayoutStore();
   const activeFile = activePane === "B" && paneB ? paneB : paneA;
   const [note, setNote] = useState<InspectorNote | null>(null);
+  const [references, setReferences] = useState<NoteReferences>({
+    incoming: [],
+    outgoing: [],
+  });
   const [loading, setLoading] = useState(false);
   // tab state is driven by the layout store so icon-nav and file-view-pane can control it
   const activeTab = rightPanelTab;
@@ -130,6 +185,7 @@ export default function NoteInspectorPanel({
   useEffect(() => {
     if (!activeFile?.fileId) {
       setNote(null);
+      setReferences({ incoming: [], outgoing: [] });
       return;
     }
 
@@ -138,15 +194,22 @@ export default function NoteInspectorPanel({
     const loadNote = async () => {
       setLoading(true);
       try {
-        const response = await fetch(`/api/notes/${activeFile.fileId}`);
+        const [response, referencesResponse] = await Promise.all([
+          fetch(`/api/notes/${activeFile.fileId}`),
+          fetch(`/api/notes/${activeFile.fileId}/backlinks`),
+        ]);
         if (!response.ok) {
           if (!cancelled) setNote(null);
           return;
         }
 
         const data = await response.json();
+        const referencesData = referencesResponse.ok
+          ? await referencesResponse.json()
+          : { incoming: [], outgoing: [] };
         if (!cancelled) {
           setNote(data);
+          setReferences(referencesData);
         }
       } catch {
         if (!cancelled) setNote(null);
@@ -156,9 +219,15 @@ export default function NoteInspectorPanel({
     };
 
     void loadNote();
+    const handleNoteSave = (event: Event) => {
+      const detail = (event as CustomEvent<{ fileId?: string }>).detail;
+      if (detail?.fileId === activeFile.fileId) void loadNote();
+    };
+    window.addEventListener("note-content-sync", handleNoteSave);
 
     return () => {
       cancelled = true;
+      window.removeEventListener("note-content-sync", handleNoteSave);
     };
   }, [activeFile?.fileId]);
 
@@ -400,6 +469,19 @@ export default function NoteInspectorPanel({
                       <PlusIcon className="w-3.5 h-3.5" />
                     </button>
                   </div>
+                </div>
+
+                <div className="space-y-4 border-t border-border-subtle pt-4">
+                  <ReferenceList
+                    title={t("Linked from")}
+                    emptyLabel={t("No backlinks yet")}
+                    references={references.incoming}
+                  />
+                  <ReferenceList
+                    title={t("Links to")}
+                    emptyLabel={t("No note references yet")}
+                    references={references.outgoing}
+                  />
                 </div>
               </>
             ) : (

--- a/src/components/notes/preview-modal.tsx
+++ b/src/components/notes/preview-modal.tsx
@@ -8,6 +8,7 @@ import noteCache from "@/lib/notes/cache/note";
 import Link from "next/link";
 import { useSWR } from "@/lib/notes/hooks/use-swr";
 import useI18n from "@/lib/notes/hooks/use-i18n";
+import { removeMarkdown } from "@/lib/notes/utils/markdown";
 
 const PreviewModal: FC = () => {
   const { t } = useI18n();
@@ -15,8 +16,16 @@ const PreviewModal: FC = () => {
   const previewId = preview.data?.id;
   const { data: previewNote } = useSWR(
     previewId ? `preview:${previewId}` : "preview:none",
-    () =>
-      previewId ? noteCache.getItem(previewId) : Promise.resolve(undefined),
+    async () => {
+      if (!previewId) return undefined;
+      const cached = await noteCache.getItem(previewId);
+      if (cached) return cached;
+
+      const response = await fetch(`/api/notes/${previewId}`);
+      if (!response.ok) return undefined;
+      const note = await response.json();
+      return { ...note, rawContent: removeMarkdown(note.content) };
+    },
   );
 
   const title = previewNote?.title || t("Untitled");
@@ -32,28 +41,25 @@ const PreviewModal: FC = () => {
   const left = Math.min(rect.left, window.innerWidth - 320);
 
   return (
-    <>
-      {/* backdrop to catch clicks */}
-      <div className="fixed inset-0 z-40" onClick={() => preview.close()} />
-      <div
-        className="fixed z-50 w-72 max-h-48 bg-surface rounded-lg shadow-xl ring-1 ring-border-subtle overflow-hidden"
-        style={{ top, left }}
-        onMouseLeave={() => preview.close()}
+    <div
+      className="fixed z-50 w-72 max-h-48 bg-surface rounded-lg shadow-xl ring-1 ring-border-subtle overflow-hidden"
+      style={{ top, left }}
+      onMouseEnter={() => preview.cancelClose()}
+      onMouseLeave={() => preview.close()}
+    >
+      <Link
+        href={`/notes/${preview.data.id}`}
+        className="block p-3 hover:bg-subtle transition-colors"
+        onClick={() => preview.close()}
       >
-        <Link
-          href={`/notes/${preview.data.id}`}
-          className="block p-3 hover:bg-subtle transition-colors"
-          onClick={() => preview.close()}
-        >
-          <h4 className="text-sm font-medium text-text truncate mb-1">
-            {title}
-          </h4>
-          {content && (
-            <p className="text-xs text-text-tertiary line-clamp-3">{content}</p>
-          )}
-        </Link>
-      </div>
-    </>
+        <h4 className="text-sm font-medium text-text truncate mb-1">
+          {title}
+        </h4>
+        {content && (
+          <p className="text-xs text-text-tertiary line-clamp-3">{content}</p>
+        )}
+      </Link>
+    </div>
   );
 };
 

--- a/src/lib/markdown/renderer.tsx
+++ b/src/lib/markdown/renderer.tsx
@@ -11,6 +11,7 @@ import type { Components } from "react-markdown";
 import type { Pluggable, PluggableList } from "unified";
 import CodeBlock from "./components/code-block";
 import { markdownSanitizeSchema } from "./sanitize-schema";
+import { parseInternalNoteHref } from "@/lib/notes/internal-links";
 
 export type MarkdownRendererVariant = "note" | "chat" | "quiz";
 
@@ -105,17 +106,20 @@ export interface MarkdownRendererProps {
 }
 
 const baseComponents: Partial<Components> = {
-  a: ({ href, children, ...props }: any) => (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="text-[var(--md-link)] underline underline-offset-2 hover:text-[var(--md-link-hover)] transition-colors"
-      {...props}
-    >
-      {children}
-    </a>
-  ),
+  a: ({ href, children, ...props }: any) => {
+    const isInternalNote = Boolean(parseInternalNoteHref(href));
+    return (
+      <a
+        href={href}
+        target={isInternalNote ? undefined : "_blank"}
+        rel={isInternalNote ? undefined : "noopener noreferrer"}
+        className="text-[var(--md-link)] underline underline-offset-2 hover:text-[var(--md-link-hover)] transition-colors"
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  },
   // pre extracts language and delegates to CodeBlock; CodeBlock owns async Shiki highlighting.
   pre: ({ children }: any) => {
     const codeEl = (children as any)?.props;

--- a/src/lib/notes/cache/note.ts
+++ b/src/lib/notes/cache/note.ts
@@ -1,7 +1,8 @@
 // extracted from Notea (MIT License)
 import { TreeModel } from '@/lib/notes/types/tree';
 import { noteCacheInstance, NoteCacheItem } from '@/lib/notes/cache';
-import { isNoteLink, NoteModel } from '@/lib/notes/types/note';
+import { NoteModel } from '@/lib/notes/types/note';
+import { parseInternalNoteHref } from '@/lib/notes/internal-links';
 import { removeMarkdown } from '@/lib/notes/utils/markdown';
 import markdownLinkExtractor from 'markdown-link-extractor';
 
@@ -45,9 +46,8 @@ async function setItem(id: string, note: NoteModel) {
     const linkIds: string[] = [];
     if (Array.isArray(extractorLinks) && extractorLinks.length) {
         extractorLinks.forEach((link) => {
-            if (isNoteLink(link)) {
-                linkIds.push(link.slice(1));
-            }
+            const noteId = parseInternalNoteHref(link);
+            if (noteId) linkIds.push(noteId);
         });
     }
     return noteCacheInstance.setItem<NoteCacheItem>(id, {

--- a/src/lib/notes/internal-links.ts
+++ b/src/lib/notes/internal-links.ts
@@ -1,0 +1,33 @@
+import markdownLinkExtractor from "markdown-link-extractor";
+
+// Accept any RFC 4122 version so links to pre-v7 notes remain usable.
+const UUID_PATTERN =
+  "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
+
+const INTERNAL_NOTE_LINK = new RegExp(
+  `^/notes/(${UUID_PATTERN})(?:[?#].*)?$`,
+  "i",
+);
+
+export function buildInternalNoteHref(noteId: string): string {
+  return `/notes/${noteId}`;
+}
+
+export function parseInternalNoteHref(href: string | undefined | null) {
+  if (!href) return null;
+  const match = INTERNAL_NOTE_LINK.exec(href.trim());
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+export function extractInternalNoteIds(content: string): string[] {
+  const links = markdownLinkExtractor(content, false);
+  if (!Array.isArray(links)) return [];
+
+  return [
+    ...new Set(
+      links
+        .map((href) => parseInternalNoteHref(href))
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ];
+}

--- a/src/lib/notes/state/portal.ts
+++ b/src/lib/notes/state/portal.ts
@@ -18,13 +18,25 @@ interface AnchorInstance<T> {
   setData: (data?: T) => void;
 }
 
+interface PreviewAnchorInstance extends AnchorInstance<{ id?: string }> {
+  cancelClose: () => void;
+  scheduleClose: (delayMs?: number) => void;
+}
+
 interface PortalState {
   search: ModalInstance;
   trash: ModalInstance;
   menu: AnchorInstance<NoteModel>;
   share: AnchorInstance<NoteModel>;
-  preview: AnchorInstance<{ id?: string }>;
+  preview: PreviewAnchorInstance;
   linkToolbar: AnchorInstance<{ href: string; view?: any }>;
+}
+
+let previewCloseTimer: ReturnType<typeof setTimeout> | null = null;
+
+function cancelPreviewClose() {
+  if (previewCloseTimer) clearTimeout(previewCloseTimer);
+  previewCloseTimer = null;
 }
 
 const usePortalStore = create<PortalState>((set) => ({
@@ -63,10 +75,22 @@ const usePortalStore = create<PortalState>((set) => ({
   preview: {
     anchor: null,
     visible: false,
-    open: () =>
-      set((state) => ({ preview: { ...state.preview, visible: true } })),
-    close: () =>
-      set((state) => ({ preview: { ...state.preview, visible: false } })),
+    open: () => {
+      cancelPreviewClose();
+      set((state) => ({ preview: { ...state.preview, visible: true } }));
+    },
+    close: () => {
+      cancelPreviewClose();
+      set((state) => ({ preview: { ...state.preview, visible: false } }));
+    },
+    cancelClose: cancelPreviewClose,
+    scheduleClose: (delayMs = 500) => {
+      cancelPreviewClose();
+      previewCloseTimer = setTimeout(() => {
+        previewCloseTimer = null;
+        set((state) => ({ preview: { ...state.preview, visible: false } }));
+      }, delayMs);
+    },
     setAnchor: (anchor) =>
       set((state) => ({ preview: { ...state.preview, anchor } })),
     setData: (data) =>

--- a/src/lib/notes/storage/note-links.ts
+++ b/src/lib/notes/storage/note-links.ts
@@ -1,0 +1,33 @@
+import sql from "@/database/pgsql.js";
+import { extractInternalNoteIds } from "@/lib/notes/internal-links";
+import type postgres from "postgres";
+
+export async function replaceNoteLinks(
+  userId: string,
+  sourceNoteId: string,
+  content: string,
+) {
+  const targetIds = extractInternalNoteIds(content).filter(
+    (targetId) => targetId !== sourceNoteId.toLowerCase(),
+  );
+
+  await sql.begin(async (transaction: postgres.TransactionSql) => {
+    await transaction`
+      DELETE FROM app.note_links
+      WHERE user_id = ${userId}::uuid
+        AND source_note_id = ${sourceNoteId}::uuid
+    `;
+
+    for (const targetId of targetIds) {
+      await transaction`
+        INSERT INTO app.note_links (user_id, source_note_id, target_note_id)
+        SELECT ${userId}::uuid, ${sourceNoteId}::uuid, target.note_id
+        FROM app.notes target
+        WHERE target.note_id = ${targetId}::uuid
+          AND target.user_id = ${userId}::uuid
+          AND target.deleted_at IS NULL
+        ON CONFLICT DO NOTHING
+      `;
+    }
+  });
+}

--- a/src/lib/notes/types/note.ts
+++ b/src/lib/notes/types/note.ts
@@ -1,6 +1,7 @@
 // extracted from Notea (MIT License)
 
 import { NOTE_DELETED, NOTE_PINNED, NOTE_SHARED } from "./meta";
+import { parseInternalNoteHref } from "@/lib/notes/internal-links";
 
 export interface NoteModel {
   id: string; // UUID v7 format
@@ -23,13 +24,11 @@ export interface NoteModel {
 }
 
 /**
- * UUID v7 format: xxxxxxxx-xxxx-7xxx-yxxx-xxxxxxxxxxxx
- * like `/550e8400-e29b-41d4-a716-446655440000`
+ * @deprecated Use parseInternalNoteHref for canonical `/notes/<uuid>` links.
+ * This wrapper accepts legacy UUID versions as well as current v7 note IDs.
  */
-export const isNoteLink = (str: string) => {
-  return new RegExp(`^/${NOTE_ID_REGEXP}$`).test(str);
-};
+export const isNoteLink = (str: string) => Boolean(parseInternalNoteHref(str));
 
-// UUID v7 pattern: 8-4-4-4-12 hex digits with hyphens
+// Strict UUID v7 pattern for newly generated note IDs.
 export const NOTE_ID_REGEXP =
   "[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";

--- a/tests/e2e/full/note-references.spec.ts
+++ b/tests/e2e/full/note-references.spec.ts
@@ -1,0 +1,114 @@
+import { createNoteViaApi, expect, test } from "../fixtures";
+
+test("a toolbar user can reference a note and create a backlink", async ({
+  loggedInPage: page,
+}) => {
+  const suffix = Date.now();
+  const target = await createNoteViaApi(
+    page,
+    `Reference target ${suffix}`,
+    "The target note provides supporting detail.",
+  );
+  const source = await createNoteViaApi(
+    page,
+    `Reference source ${suffix}`,
+    "This note needs a reference.",
+  );
+
+  await page.goto(`/notes/${source.id}`);
+  const editor = page.getByRole("main", { name: "Note editor" });
+  await expect(editor.getByRole("button", { name: "Reference note" })).toBeVisible();
+
+  await editor.getByRole("button", { name: "Reference note" }).click();
+  const picker = editor.getByRole("dialog", { name: "Reference a note" });
+  await picker.getByPlaceholder("Search notes…").fill(target.title);
+  await picker.getByRole("option", { name: target.title }).click();
+
+  const content = editor
+    .locator(".oghma-milkdown-editor [contenteditable='true']")
+    .first();
+  await expect(content).toContainText(target.title);
+  await editor.getByRole("button", { name: "Unsaved" }).click();
+  await expect(editor.getByText("Saved", { exact: true })).toBeVisible();
+
+  await expect
+    .poll(async () => {
+      const response = await page.request.get(`/api/notes/${source.id}`);
+      return (await response.json()).content;
+    })
+    .toContain(`[${target.title}](/notes/${target.id})`);
+
+  await expect
+    .poll(async () => {
+      const response = await page.request.get(`/api/notes/${target.id}/backlinks`);
+      const payload = await response.json();
+      return payload.incoming.map((note: { id: string }) => note.id);
+    })
+    .toContain(source.id);
+
+  await editor.getByRole("button", { name: "Toggle metadata panel" }).click();
+  const linksTo = page.getByText("Links to", { exact: true });
+  await expect(linksTo).toBeVisible();
+  await expect(linksTo.locator("..").getByText(target.title)).toBeVisible();
+
+  await content.focus();
+  await page.keyboard.press("End");
+  await page.keyboard.type("[[");
+  await expect(
+    editor.getByRole("dialog", { name: "Reference a note" }),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  const deleteResponse = await page.request.delete(`/api/notes/${target.id}`, {
+    headers: { origin: new URL(page.url()).origin },
+  });
+  expect(deleteResponse.status()).toBe(200);
+  const hiddenWhileDeleted = await page.request.get(
+    `/api/notes/${source.id}/backlinks`,
+  );
+  expect(
+    (await hiddenWhileDeleted.json()).outgoing.map(
+      (note: { id: string }) => note.id,
+    ),
+  ).not.toContain(target.id);
+
+  const restoreResponse = await page.request.post("/api/trash", {
+    data: { action: "restore", data: { id: target.id } },
+    headers: { origin: new URL(page.url()).origin },
+  });
+  expect(restoreResponse.status()).toBe(200);
+  const restoredLinks = await page.request.get(
+    `/api/notes/${source.id}/backlinks`,
+  );
+  expect(
+    (await restoredLinks.json()).outgoing.map((note: { id: string }) => note.id),
+  ).toContain(target.id);
+
+  const clearResponse = await page.request.put(`/api/notes/${source.id}`, {
+    data: { content: "" },
+    headers: { origin: new URL(page.url()).origin },
+  });
+  expect(clearResponse.status()).toBe(200);
+  expect((await clearResponse.json()).content).toBe("");
+  const backlinksAfterClear = await page.request.get(
+    `/api/notes/${target.id}/backlinks`,
+  );
+  expect(
+    (await backlinksAfterClear.json()).incoming.map(
+      (note: { id: string }) => note.id,
+    ),
+  ).not.toContain(source.id);
+
+  const selfReferenceResponse = await page.request.put(
+    `/api/notes/${source.id}`,
+    {
+      data: { content: `[Self](/notes/${source.id})` },
+      headers: { origin: new URL(page.url()).origin },
+    },
+  );
+  expect(selfReferenceResponse.status()).toBe(200);
+  const selfReferences = await page.request.get(
+    `/api/notes/${source.id}/backlinks`,
+  );
+  expect((await selfReferences.json()).outgoing).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- add portable Markdown note links with a Milkdown toolbar picker and `[[` shortcut
- add hover previews plus incoming/outgoing references in the note inspector
- maintain a user-scoped note-link index for fast backlinks, including edit, empty-content, soft-delete, and restore behavior
- document the canonical internal-link format and add migration 049

## Opus review follow-up
- fixed hover-preview timer races
- changed the picker to debounced server-side title search instead of a static note list
- retained link rows through soft deletion so restored notes regain their references
- improved keyboard and screen-reader behavior and guarded Milkdown setup under React Strict Mode
- expanded unit and end-to-end coverage for insertion, saving, backlinks, inspector refresh, deletion/restore, empty content, and self-reference filtering

## Verification
- `npm run lint:all`
- `npm run build`
- 137 unit test files / 922 tests passed
- `npm run e2e -- tests/e2e/full/note-references.spec.ts --project=chromium`
- pre-commit Dockerfile marker validation passed