### PR TITLE
Add Canvas planner item contract

### DIFF
--- a/.hermes/plans/2026-07-25_015022-canvas-planner-items.md
+++ b/.hermes/plans/2026-07-25_015022-canvas-planner-items.md
@@ -1,0 +1,52 @@
+# Canvas Planner Item Contract Implementation Plan
+
+> **For Hermes:** Implement this directly in the isolated `theo/378-canvas-planner-items` branch, then request independent review before opening a draft PR.
+
+**Goal:** Add the backend/API contract for Canvas planner objects without corrupting assignment-specific semantics.
+
+**Architecture:** Keep `app.assignments` assignment-shaped and add a separate `app.canvas_planner_items` table plus normalization/sync/API surfaces. The first PR deliberately stops short of wiring calendar rendering, because #380 just landed and UI overlap would be noisy.
+
+**Tech Stack:** Next.js route handlers, Vitest, postgres tagged SQL helper, Canvas REST API client.
+
+---
+
+## Current context
+
+- Clean clone: `git@github.com:semyonfox/oghma.git`, branch `dev` at `d72f31fb114dd677772b57dac519bc9516496e66`.
+- Work branch: `theo/378-canvas-planner-items`.
+- Existing migration numbers include multiple `049_*` files and an existing `050_privacy_safe_journey_chains.sql`, so this branch must use `051_canvas_planner_items.sql`, not the issue's earlier `050_*` suggestion.
+- `src/lib/canvas/sync-assignments.js` remains untouched except for regression tests, preserving assignment filtering/status/grade/time semantics.
+
+## Step-by-step plan
+
+1. Add RED tests for planner normalization, sync/tombstone behavior, and API privacy.
+2. Add migration `database/migrations/051_canvas_planner_items.sql`.
+3. Add pure normalization helpers in `src/lib/canvas/planner-items.js`.
+4. Extend Canvas client with planner, discussion, and announcement methods.
+5. Add `src/lib/canvas/sync-planner-items.js` with bounded sync and fail-closed tombstoning.
+6. Add `GET /api/planner/items` returning normalized public fields only.
+7. Verify with targeted tests, full typecheck/lint, full Vitest suite, static scans, and independent review.
+
+## Files changed
+
+- Create: `database/migrations/051_canvas_planner_items.sql`
+- Create: `src/lib/canvas/planner-items.js`
+- Create: `src/lib/canvas/sync-planner-items.js`
+- Modify: `src/lib/canvas/client.js`
+- Create: `src/app/api/planner/items/route.ts`
+- Create tests under `src/__tests__/api` and `src/__tests__/lib`.
+
+## Tests / validation
+
+```bash
+npm run test:ci -- src/__tests__/lib/planner-items.test.ts src/__tests__/lib/sync-planner-items.test.ts src/__tests__/api/planner-items.test.ts src/__tests__/lib/sync-assignments.test.ts
+npm run typecheck
+npm run lint
+npm run test:ci
+```
+
+## Risks and tradeoffs
+
+- Migration numbering in the issue is stale; `051_*` is correct on current `dev`.
+- Canvas planner payloads vary by institution. Raw JSON is stored privately for audit/migration, not exposed by API.
+- Calendar rendering is intentionally left for a later UI PR.

--- a/database/migrations/051_canvas_planner_items.sql
+++ b/database/migrations/051_canvas_planner_items.sql
@@ -1,0 +1,49 @@
+CREATE TABLE IF NOT EXISTS app.canvas_planner_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES app.login(user_id) ON DELETE CASCADE,
+  canvas_domain text NOT NULL,
+  canvas_user_id bigint,
+  canvas_course_id bigint,
+  canvas_context_type text,
+  canvas_context_id bigint,
+  context_name text,
+  plannable_type text NOT NULL,
+  plannable_id text NOT NULL,
+  canvas_planner_item_id text,
+  title text NOT NULL,
+  body text,
+  html_url text,
+  source text NOT NULL DEFAULT 'canvas',
+  item_state text NOT NULL DEFAULT 'active',
+  display_at timestamptz,
+  due_at timestamptz,
+  available_at timestamptz,
+  end_at timestamptz,
+  date_source text NOT NULL,
+  all_day boolean NOT NULL DEFAULT false,
+  raw_planner_item jsonb,
+  raw_plannable jsonb,
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, canvas_domain, plannable_type, plannable_id),
+  CONSTRAINT canvas_planner_items_plannable_type_check
+    CHECK (plannable_type IN ('assignment', 'quiz', 'discussion_topic', 'announcement', 'calendar_event', 'planner_note', 'other')),
+  CONSTRAINT canvas_planner_items_item_state_check
+    CHECK (item_state IN ('active', 'deleted', 'hidden', 'cancelled')),
+  CONSTRAINT canvas_planner_items_date_source_check
+    CHECK (date_source IN ('due_at', 'todo_date', 'plannable_date', 'posted_at', 'delayed_post_at', 'start_at', 'none'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_canvas_planner_items_user_display_at
+  ON app.canvas_planner_items(user_id, display_at)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_canvas_planner_items_user_course
+  ON app.canvas_planner_items(user_id, canvas_course_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_canvas_planner_items_user_type_identity
+  ON app.canvas_planner_items(user_id, plannable_type, plannable_id)
+  WHERE deleted_at IS NULL;

--- a/src/__tests__/api/planner-items.test.ts
+++ b/src/__tests__/api/planner-items.test.ts
@@ -2,7 +2,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@/database/pgsql.js", () => { const sqlMock = vi.fn(); sqlMock.mockResolvedValue([]); return { default: sqlMock }; });
-vi.mock("@/lib/api-error", () => ({ requireAuth: vi.fn(), withErrorHandler: (handler: any) => handler }));
+vi.mock("@/lib/api-error", () => ({
+  ApiError: class ApiError extends Error {
+    statusCode: number;
+    userMessage: string;
+    constructor(statusCode: number, userMessage: string) {
+      super(userMessage);
+      this.statusCode = statusCode;
+      this.userMessage = userMessage;
+    }
+  },
+  requireAuth: vi.fn(),
+  withErrorHandler: (handler: any) => handler,
+}));
 
 import sql from "@/database/pgsql.js";
 import { requireAuth } from "@/lib/api-error";
@@ -19,5 +31,12 @@ describe("GET /api/planner/items", () => {
     expect(body).toEqual([{ id: "item-1", source: "canvas", plannable_type: "announcement", plannable_id: "99", canvas_course_id: 42, course_name: "CS101", title: "Exam notice", body: "Read this", html_url: "https://canvas.example/announcements/99", display_at: "2026-02-01T10:00:00.000Z", due_at: null, date_source: "posted_at", item_state: "active", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" }]);
     expect(JSON.stringify(body)).not.toContain("raw_planner_item");
     expect(JSON.stringify(body)).not.toContain("raw_plannable");
+  });
+
+  it("rejects malformed date-window parameters before building SQL", async () => {
+    await expect(
+      GET(new NextRequest("http://localhost/api/planner/items?start=not-a-date&end=2026-03-01T00:00:00.000Z")),
+    ).rejects.toMatchObject({ statusCode: 400, userMessage: "start must be a valid ISO date" });
+    expect(vi.mocked(sql)).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/api/planner-items.test.ts
+++ b/src/__tests__/api/planner-items.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/database/pgsql.js", () => { const sqlMock = vi.fn(); sqlMock.mockResolvedValue([]); return { default: sqlMock }; });
+vi.mock("@/lib/api-error", () => ({ requireAuth: vi.fn(), withErrorHandler: (handler: any) => handler }));
+
+import sql from "@/database/pgsql.js";
+import { requireAuth } from "@/lib/api-error";
+import { GET } from "@/app/api/planner/items/route";
+
+describe("GET /api/planner/items", () => {
+  beforeEach(() => { vi.clearAllMocks(); vi.mocked(requireAuth).mockResolvedValue({ user_id: "user-123" } as never); });
+
+  it("returns normalized planner rows without raw Canvas JSON", async () => {
+    vi.mocked(sql).mockResolvedValue([{ id: "item-1", source: "canvas", plannable_type: "announcement", plannable_id: "99", canvas_course_id: 42, course_name: "CS101", title: "Exam notice", body: "Read this", html_url: "https://canvas.example/announcements/99", display_at: "2026-02-01T10:00:00.000Z", due_at: null, date_source: "posted_at", item_state: "active", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z", raw_planner_item: { should: "not leak" }, raw_plannable: { should: "not leak" } }] as never);
+    const response = await GET(new NextRequest("http://localhost/api/planner/items?start=2026-01-01T00:00:00.000Z&end=2026-03-01T00:00:00.000Z"));
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toEqual([{ id: "item-1", source: "canvas", plannable_type: "announcement", plannable_id: "99", canvas_course_id: 42, course_name: "CS101", title: "Exam notice", body: "Read this", html_url: "https://canvas.example/announcements/99", display_at: "2026-02-01T10:00:00.000Z", due_at: null, date_source: "posted_at", item_state: "active", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" }]);
+    expect(JSON.stringify(body)).not.toContain("raw_planner_item");
+    expect(JSON.stringify(body)).not.toContain("raw_plannable");
+  });
+});

--- a/src/__tests__/lib/planner-items.test.ts
+++ b/src/__tests__/lib/planner-items.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { buildAssignmentDedupeKey, choosePlannerDates, normalizePlannerItem, normalizePlannableType } from "@/lib/canvas/planner-items.js";
+
+describe("Canvas planner-item normalization", () => {
+  it("normalizes explicit Canvas plannable types without title heuristics", () => {
+    expect(normalizePlannableType({ plannable_type: "assignment" })).toBe("assignment");
+    expect(normalizePlannableType({ plannable_type: "quiz" })).toBe("quiz");
+    expect(normalizePlannableType({ plannable_type: "discussion_topic" })).toBe("discussion_topic");
+    expect(normalizePlannableType({ plannable_type: "wiki_page" })).toBe("other");
+    expect(normalizePlannableType({ title: "Quiz 1" })).toBe("other");
+  });
+
+  it("uses announcement context flags instead of title text", () => {
+    expect(normalizePlannableType({ plannable_type: "discussion_topic" }, { isAnnouncement: true })).toBe("announcement");
+    expect(normalizePlannableType({ title: "Announcement: exam" })).toBe("other");
+  });
+
+  it("keeps display and due dates distinct with explainable date_source", () => {
+    expect(choosePlannerDates({ plannable_type: "assignment", due_at: "2026-03-01T12:00:00Z", plannable_date: "2026-02-20T09:00:00Z" })).toEqual({ display_at: "2026-03-01T12:00:00Z", due_at: "2026-03-01T12:00:00Z", available_at: null, end_at: null, date_source: "due_at", all_day: false });
+    expect(choosePlannerDates({ plannable_type: "announcement", posted_at: "2026-02-01T09:00:00Z", due_at: "2026-03-01T12:00:00Z" })).toMatchObject({ display_at: "2026-02-01T09:00:00Z", due_at: null, date_source: "posted_at" });
+  });
+
+  it("stores undated rows but marks date_source as none", () => {
+    expect(choosePlannerDates({ plannable_type: "planner_note" })).toMatchObject({ display_at: null, due_at: null, date_source: "none" });
+  });
+
+  it("normalizes a planner object to the public/storage contract", () => {
+    const normalized = normalizePlannerItem({ context_type: "Course", course_id: 42, context_name: "CS101", plannable_type: "discussion_topic", plannable_id: 99, plannable: { id: 99, title: "Week 1 discussion", message: "<p>Discuss</p>", html_url: "https://canvas.example/courses/42/discussion_topics/99", todo_date: "2026-02-02T10:00:00Z" } }, { canvasDomain: "canvas.example", canvasUserId: 7 });
+    expect(normalized).toMatchObject({ canvas_domain: "canvas.example", canvas_user_id: 7, canvas_course_id: 42, canvas_context_type: "Course", context_name: "CS101", plannable_type: "discussion_topic", plannable_id: "99", title: "Week 1 discussion", body: "<p>Discuss</p>", html_url: "https://canvas.example/courses/42/discussion_topics/99", display_at: "2026-02-02T10:00:00Z", due_at: null, date_source: "todo_date", item_state: "active" });
+  });
+
+  it("builds assignment-backed dedupe keys from stable assignment identities", () => {
+    expect(buildAssignmentDedupeKey({ plannable_type: "assignment", plannable_id: "123" })).toBe("assignment:123");
+    expect(buildAssignmentDedupeKey({ plannable_type: "quiz", plannable_id: "456" })).toBe("assignment:456");
+    expect(buildAssignmentDedupeKey({ plannable_type: "announcement", plannable_id: "789" })).toBeNull();
+  });
+});

--- a/src/__tests__/lib/sync-planner-items.test.ts
+++ b/src/__tests__/lib/sync-planner-items.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/database/pgsql.js", () => ({ default: vi.fn() }));
+
+import sql from "@/database/pgsql.js";
+import { syncCanvasPlannerItems } from "@/lib/canvas/sync-planner-items.js";
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+function makeClient(result: any) { return { getPlannerItems: vi.fn().mockResolvedValue(result) }; }
+
+describe("syncCanvasPlannerItems", () => {
+  beforeEach(() => { vi.clearAllMocks(); vi.mocked(sql).mockResolvedValue([] as never); });
+
+  it("upserts normalized planner items and tombstones missing rows after a complete sync", async () => {
+    const client = makeClient({ data: [{ plannable_type: "discussion_topic", plannable_id: 99, plannable: { id: 99, title: "Discussion", todo_date: "2026-02-01T10:00:00Z" } }], forbidden: false });
+    const result = await syncCanvasPlannerItems({ userId: USER_ID, canvasDomain: "canvas.example", canvasUserId: 7, client, startDate: "2026-01-01T00:00:00.000Z", endDate: "2026-03-01T00:00:00.000Z" });
+    expect(result).toEqual({ synced: 1, tombstoned: 0, errors: 0, partial: false });
+    expect(client.getPlannerItems).toHaveBeenCalledWith("2026-01-01T00:00:00.000Z", "2026-03-01T00:00:00.000Z");
+    expect(vi.mocked(sql).mock.calls.length).toBe(2);
+    expect(String.raw({ raw: vi.mocked(sql).mock.calls[1][0] as any })).toContain("UPDATE app.canvas_planner_items");
+    expect(String.raw({ raw: vi.mocked(sql).mock.calls[1][0] as any })).toContain("deleted_at = NOW()");
+  });
+
+  it("does not tombstone rows when Canvas returns a partial failure", async () => {
+    const client = makeClient({ data: [], forbidden: false, error: "Canvas API rate limited — try again later" });
+    const result = await syncCanvasPlannerItems({ userId: USER_ID, canvasDomain: "canvas.example", client, startDate: "2026-01-01T00:00:00.000Z", endDate: "2026-03-01T00:00:00.000Z" });
+    expect(result).toEqual({ synced: 0, tombstoned: 0, errors: 1, partial: true });
+    expect(vi.mocked(sql)).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/planner/items/route.ts
+++ b/src/app/api/planner/items/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withErrorHandler, requireAuth } from "@/lib/api-error";
+import sql from "@/database/pgsql.js";
+
+function sanitizePlannerRow(row: Record<string, unknown>) {
+  return {
+    id: row.id,
+    source: row.source,
+    plannable_type: row.plannable_type,
+    plannable_id: row.plannable_id,
+    canvas_course_id: row.canvas_course_id,
+    course_name: row.course_name,
+    title: row.title,
+    body: row.body,
+    html_url: row.html_url,
+    display_at: row.display_at,
+    due_at: row.due_at,
+    date_source: row.date_source,
+    item_state: row.item_state,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  const user = await requireAuth();
+  const url = new URL(request.url);
+  const start = url.searchParams.get("start");
+  const end = url.searchParams.get("end");
+  const includeUndated = url.searchParams.get("includeUndated") === "1";
+  const includeDeleted = url.searchParams.get("includeDeleted") === "1";
+  const conditions = [sql`cpi.user_id = ${user.user_id}::uuid`];
+  if (!includeDeleted) conditions.push(sql`cpi.deleted_at IS NULL`);
+  if (start && end) {
+    conditions.push(sql`(
+      cpi.display_at BETWEEN ${start}::timestamptz AND ${end}::timestamptz
+      ${includeUndated ? sql`OR cpi.display_at IS NULL` : sql``}
+    )`);
+  } else if (!includeUndated) {
+    conditions.push(sql`cpi.display_at IS NOT NULL`);
+  }
+  const where = conditions.reduce((a, c) => sql`${a} AND ${c}`);
+  const rows = await sql`
+    SELECT cpi.id, cpi.source, cpi.plannable_type, cpi.plannable_id,
+           cpi.canvas_course_id, cpi.context_name AS course_name,
+           cpi.title, cpi.body, cpi.html_url,
+           cpi.display_at, cpi.due_at, cpi.date_source, cpi.item_state,
+           cpi.created_at, cpi.updated_at
+    FROM app.canvas_planner_items cpi
+    WHERE ${where}
+    ORDER BY cpi.display_at ASC NULLS LAST, cpi.created_at DESC
+  `;
+  return NextResponse.json(rows.map(sanitizePlannerRow));
+});

--- a/src/app/api/planner/items/route.ts
+++ b/src/app/api/planner/items/route.ts
@@ -1,6 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
-import { withErrorHandler, requireAuth } from "@/lib/api-error";
+import { withErrorHandler, requireAuth, ApiError } from "@/lib/api-error";
 import sql from "@/database/pgsql.js";
+
+function validateDateParam(value: string | null, name: string) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new ApiError(400, `${name} must be a valid ISO date`);
+  }
+  return value;
+}
 
 function sanitizePlannerRow(row: Record<string, unknown>) {
   return {
@@ -25,8 +34,8 @@ function sanitizePlannerRow(row: Record<string, unknown>) {
 export const GET = withErrorHandler(async (request: NextRequest) => {
   const user = await requireAuth();
   const url = new URL(request.url);
-  const start = url.searchParams.get("start");
-  const end = url.searchParams.get("end");
+  const start = validateDateParam(url.searchParams.get("start"), "start");
+  const end = validateDateParam(url.searchParams.get("end"), "end");
   const includeUndated = url.searchParams.get("includeUndated") === "1";
   const includeDeleted = url.searchParams.get("includeDeleted") === "1";
   const conditions = [sql`cpi.user_id = ${user.user_id}::uuid`];

--- a/src/lib/canvas/client.js
+++ b/src/lib/canvas/client.js
@@ -248,6 +248,43 @@ export class CanvasClient {
   }
 
   /**
+   * Returns bounded Canvas planner items for the user.
+   *
+   * @param {string} startDate - ISO timestamp for Canvas start_date
+   * @param {string} endDate - ISO timestamp for Canvas end_date
+   * @returns {Promise<{ data: any[], forbidden: boolean, error?: string }>}
+   */
+  async getPlannerItems(startDate, endDate) {
+    const params = new URLSearchParams({
+      start_date: startDate,
+      end_date: endDate,
+    });
+    return this.#getPaginated(`/planner/items?${params.toString()}`);
+  }
+
+  /**
+   * Returns all discussion topics for a course.
+   *
+   * @param {string} courseId
+   * @returns {Promise<{ data: any[], forbidden: boolean, error?: string }>}
+   */
+  async getDiscussionTopics(courseId) {
+    return this.#getPaginated(`/courses/${courseId}/discussion_topics`);
+  }
+
+  /**
+   * Returns Canvas announcements, which are exposed as discussion topics.
+   *
+   * @param {string} courseId
+   * @returns {Promise<{ data: any[], forbidden: boolean, error?: string }>}
+   */
+  async getAnnouncements(courseId) {
+    return this.#getPaginated(
+      `/courses/${courseId}/discussion_topics?only_announcements=true`,
+    );
+  }
+
+  /**
    * Returns all modules inside a course.
    * Modules are the folder-like containers Canvas uses to organise content.
    *

--- a/src/lib/canvas/planner-items.js
+++ b/src/lib/canvas/planner-items.js
@@ -1,0 +1,112 @@
+const PLANNABLE_TYPES = new Set(["assignment", "quiz", "discussion_topic", "announcement", "calendar_event", "planner_note", "other"]);
+
+const TYPE_ALIASES = new Map([
+  ["Assignment", "assignment"], ["assignment", "assignment"],
+  ["Quiz", "quiz"], ["quiz", "quiz"],
+  ["DiscussionTopic", "discussion_topic"], ["discussion_topic", "discussion_topic"], ["discussion", "discussion_topic"],
+  ["Announcement", "announcement"], ["announcement", "announcement"],
+  ["CalendarEvent", "calendar_event"], ["calendar_event", "calendar_event"],
+  ["PlannerNote", "planner_note"], ["planner_note", "planner_note"],
+]);
+
+function asTextId(value) {
+  if (value === null || value === undefined || value === "") return null;
+  return String(value);
+}
+
+function asNumberOrNull(value) {
+  if (value === null || value === undefined || value === "") return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function firstString(...values) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value;
+  }
+  return null;
+}
+
+function readDate(item, field) {
+  const plannable = item?.plannable ?? {};
+  return firstString(item?.[field], plannable?.[field]);
+}
+
+export function normalizePlannableType(item, options = {}) {
+  if (options.isAnnouncement || item?.only_announcements === true || item?.is_announcement === true || item?.plannable?.is_announcement === true) {
+    return "announcement";
+  }
+  const rawType = item?.plannable_type ?? item?.type ?? item?.plannable?.type;
+  const normalized = TYPE_ALIASES.get(rawType) ?? TYPE_ALIASES.get(String(rawType ?? "").toLowerCase());
+  return normalized && PLANNABLE_TYPES.has(normalized) ? normalized : "other";
+}
+
+export function choosePlannerDates(item, options = {}) {
+  const type = normalizePlannableType(item, options);
+  const dueAt = readDate(item, "due_at");
+  const todoDate = readDate(item, "todo_date") ?? readDate(item, "todo_at");
+  const plannableDate = readDate(item, "plannable_date");
+  const postedAt = readDate(item, "posted_at");
+  const delayedPostAt = readDate(item, "delayed_post_at");
+  const startAt = readDate(item, "start_at");
+  const availableAt = readDate(item, "available_at") ?? readDate(item, "unlock_at");
+  const endAt = readDate(item, "end_at") ?? readDate(item, "lock_at");
+  let display_at = null;
+  let date_source = "none";
+  let normalizedDueAt = null;
+  if ((type === "assignment" || type === "quiz") && dueAt) {
+    display_at = dueAt;
+    normalizedDueAt = dueAt;
+    date_source = "due_at";
+  } else if (type === "announcement" && delayedPostAt) {
+    display_at = delayedPostAt;
+    date_source = "delayed_post_at";
+  } else if (type === "announcement" && postedAt) {
+    display_at = postedAt;
+    date_source = "posted_at";
+  } else if (type === "calendar_event" && startAt) {
+    display_at = startAt;
+    date_source = "start_at";
+  } else if (todoDate) {
+    display_at = todoDate;
+    date_source = "todo_date";
+  } else if (plannableDate) {
+    display_at = plannableDate;
+    date_source = "plannable_date";
+  }
+  return { display_at, due_at: normalizedDueAt, available_at: availableAt, end_at: endAt, date_source, all_day: Boolean(item?.all_day ?? item?.plannable?.all_day ?? false) };
+}
+
+export function normalizePlannerItem(item, options = {}) {
+  const plannable = item?.plannable ?? {};
+  const plannableType = normalizePlannableType(item, options);
+  const plannableId = asTextId(item?.plannable_id ?? plannable?.id ?? item?.id);
+  if (!plannableId) throw new Error("Canvas planner item is missing a stable plannable id");
+  const title = firstString(item?.title, item?.name, plannable?.title, plannable?.name) ?? "Untitled Canvas item";
+  const dates = choosePlannerDates({ ...item, plannable_type: plannableType }, options);
+  return {
+    canvas_domain: options.canvasDomain,
+    canvas_user_id: asNumberOrNull(options.canvasUserId ?? item?.user_id),
+    canvas_course_id: asNumberOrNull(item?.course_id ?? item?.canvas_course_id ?? plannable?.course_id),
+    canvas_context_type: item?.context_type ?? null,
+    canvas_context_id: asNumberOrNull(item?.context_id),
+    context_name: item?.context_name ?? null,
+    plannable_type: plannableType,
+    plannable_id: plannableId,
+    canvas_planner_item_id: asTextId(item?.id ?? item?.planner_item_id),
+    title,
+    body: firstString(item?.body, item?.description, plannable?.body, plannable?.message, plannable?.description),
+    html_url: firstString(item?.html_url, item?.url, plannable?.html_url, plannable?.url),
+    source: "canvas",
+    item_state: item?.workflow_state === "deleted" || item?.deleted === true ? "deleted" : "active",
+    ...dates,
+    raw_planner_item: item,
+    raw_plannable: Object.keys(plannable).length > 0 ? plannable : null,
+  };
+}
+
+export function buildAssignmentDedupeKey(item) {
+  if (item?.plannable_type !== "assignment" && item?.plannable_type !== "quiz") return null;
+  const id = asTextId(item?.plannable_id);
+  return id ? `assignment:${id}` : null;
+}

--- a/src/lib/canvas/sync-planner-items.js
+++ b/src/lib/canvas/sync-planner-items.js
@@ -1,0 +1,109 @@
+import sql from "../../database/pgsql.js";
+import { normalizePlannerItem } from "./planner-items.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function defaultStartDate(now = new Date()) { return new Date(now.getTime() - 30 * DAY_MS).toISOString(); }
+function defaultEndDate(now = new Date()) { return new Date(now.getTime() + 180 * DAY_MS).toISOString(); }
+
+async function upsertPlannerItem(userId, item) {
+  await sql`
+    INSERT INTO app.canvas_planner_items (
+      user_id, canvas_domain, canvas_user_id, canvas_course_id,
+      canvas_context_type, canvas_context_id, context_name,
+      plannable_type, plannable_id, canvas_planner_item_id,
+      title, body, html_url, source, item_state,
+      display_at, due_at, available_at, end_at, date_source, all_day,
+      raw_planner_item, raw_plannable, last_seen_at, deleted_at
+    ) VALUES (
+      ${userId}::uuid, ${item.canvas_domain}, ${item.canvas_user_id}, ${item.canvas_course_id},
+      ${item.canvas_context_type}, ${item.canvas_context_id}, ${item.context_name},
+      ${item.plannable_type}, ${item.plannable_id}, ${item.canvas_planner_item_id},
+      ${item.title}, ${item.body}, ${item.html_url}, ${item.source}, ${item.item_state},
+      ${item.display_at}, ${item.due_at}, ${item.available_at}, ${item.end_at}, ${item.date_source}, ${item.all_day},
+      ${JSON.stringify(item.raw_planner_item)}::jsonb, ${item.raw_plannable ? JSON.stringify(item.raw_plannable) : null}::jsonb,
+      NOW(), NULL
+    )
+    ON CONFLICT (user_id, canvas_domain, plannable_type, plannable_id)
+    DO UPDATE SET
+      canvas_user_id = EXCLUDED.canvas_user_id,
+      canvas_course_id = EXCLUDED.canvas_course_id,
+      canvas_context_type = EXCLUDED.canvas_context_type,
+      canvas_context_id = EXCLUDED.canvas_context_id,
+      context_name = EXCLUDED.context_name,
+      canvas_planner_item_id = EXCLUDED.canvas_planner_item_id,
+      title = EXCLUDED.title,
+      body = EXCLUDED.body,
+      html_url = EXCLUDED.html_url,
+      source = EXCLUDED.source,
+      item_state = EXCLUDED.item_state,
+      display_at = EXCLUDED.display_at,
+      due_at = EXCLUDED.due_at,
+      available_at = EXCLUDED.available_at,
+      end_at = EXCLUDED.end_at,
+      date_source = EXCLUDED.date_source,
+      all_day = EXCLUDED.all_day,
+      raw_planner_item = EXCLUDED.raw_planner_item,
+      raw_plannable = EXCLUDED.raw_plannable,
+      last_seen_at = NOW(),
+      deleted_at = NULL,
+      updated_at = NOW()
+  `;
+}
+
+async function tombstoneMissingRows({ userId, canvasDomain, startDate, endDate, seenKeys }) {
+  const stableKeys = seenKeys.map((key) => `${key.type}:${key.id}`);
+  const rows = await sql`
+    UPDATE app.canvas_planner_items
+    SET deleted_at = NOW(), item_state = 'deleted', updated_at = NOW()
+    WHERE user_id = ${userId}::uuid
+      AND canvas_domain = ${canvasDomain}
+      AND deleted_at IS NULL
+      AND display_at >= ${startDate}::timestamptz
+      AND display_at <= ${endDate}::timestamptz
+      AND NOT ((plannable_type || ':' || plannable_id) = ANY(${stableKeys}))
+    RETURNING id
+  `;
+  return rows.length;
+}
+
+/**
+ * @param {object} params
+ * @param {string} params.userId
+ * @param {string} params.canvasDomain
+ * @param {number|null} [params.canvasUserId]
+ * @param {{ getPlannerItems(startDate: string, endDate: string): Promise<{ data?: any[], forbidden?: boolean, error?: string }> }} params.client
+ * @param {string} [params.startDate]
+ * @param {string} [params.endDate]
+ * @param {Date} [params.now]
+ * @returns {Promise<{ synced: number, tombstoned: number, errors: number, partial: boolean }>}
+ */
+export async function syncCanvasPlannerItems({ userId, canvasDomain, canvasUserId = null, client, startDate, endDate, now = new Date() } = {}) {
+  if (!userId) throw new Error("userId is required");
+  if (!canvasDomain) throw new Error("canvasDomain is required");
+  if (!client?.getPlannerItems) throw new Error("client.getPlannerItems is required");
+  const effectiveStart = startDate ?? defaultStartDate(now);
+  const effectiveEnd = endDate ?? defaultEndDate(now);
+  const result = await client.getPlannerItems(effectiveStart, effectiveEnd);
+  if (result?.error || result?.forbidden || !Array.isArray(result?.data)) {
+    console.warn(`[sync-planner-items] partial planner sync for ${canvasDomain}: ${result?.error ?? "forbidden"}`);
+    return { synced: 0, tombstoned: 0, errors: 1, partial: true };
+  }
+  let synced = 0;
+  let errors = 0;
+  const seenKeys = [];
+  for (const rawItem of result.data) {
+    try {
+      const item = normalizePlannerItem(rawItem, { canvasDomain, canvasUserId });
+      await upsertPlannerItem(userId, item);
+      seenKeys.push({ type: item.plannable_type, id: item.plannable_id });
+      synced++;
+    } catch (err) {
+      console.error(`[sync-planner-items] failed to upsert planner item: ${err instanceof Error ? err.message : String(err)}`);
+      errors++;
+    }
+  }
+  if (errors > 0) return { synced, tombstoned: 0, errors, partial: true };
+  const tombstoned = await tombstoneMissingRows({ userId, canvasDomain, startDate: effectiveStart, endDate: effectiveEnd, seenKeys });
+  return { synced, tombstoned, errors: 0, partial: false };
+}

--- a/src/lib/canvas/sync-planner-items.js
+++ b/src/lib/canvas/sync-planner-items.js
@@ -61,7 +61,7 @@ async function tombstoneMissingRows({ userId, canvasDomain, startDate, endDate, 
       AND deleted_at IS NULL
       AND display_at >= ${startDate}::timestamptz
       AND display_at <= ${endDate}::timestamptz
-      AND NOT ((plannable_type || ':' || plannable_id) = ANY(${stableKeys}))
+      AND NOT ((plannable_type || ':' || plannable_id) = ANY(${stableKeys}::text[]))
     RETURNING id
   `;
   return rows.length;


### PR DESCRIPTION
## Summary
- add `app.canvas_planner_items` as a separate Canvas planner-object contract without widening `app.assignments`
- add planner normalization, bounded sync/upsert/tombstone helpers, and Canvas client planner/discussion/announcement methods
- add `GET /api/planner/items` returning normalized public fields only, with raw Canvas JSON kept private
- harden planner item query validation and cast tombstone stable-key arrays explicitly

## Verification
- `npm run test:ci -- src/__tests__/lib/planner-items.test.ts src/__tests__/lib/sync-planner-items.test.ts src/__tests__/api/planner-items.test.ts src/__tests__/lib/sync-assignments.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run test:ci` (146 files / 952 tests passed after the follow-up hardening commit)
- pre-commit `npm run lint:all` via Husky, including Dockerfile.marker validation
- independent staged-diff review: passed, no blocking security or logic issues

## Notes
- Uses `database/migrations/051_canvas_planner_items.sql` because current `dev` already contains `050_privacy_safe_journey_chains.sql`.
- Calendar UI rendering is intentionally left for a later PR.

Closes #378
