### PR TITLE
fix(security): patch @hono/node-server traversal advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2290,12 +2290,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "vitest": "4.1.9"
   },
   "overrides": {
+    "@hono/node-server": "2.0.11",
     "ioredis": "$ioredis",
     "postcss": "$postcss",
     "typescript-eslint": "8.61.1"

--- a/src/lib/canvas-mcp/package-lock.json
+++ b/src/lib/canvas-mcp/package-lock.json
@@ -501,12 +501,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/src/lib/canvas-mcp/package.json
+++ b/src/lib/canvas-mcp/package.json
@@ -26,5 +26,8 @@
     "tsx": "4.22.4",
     "typescript": "^7.0.2",
     "vitest": "4.1.9"
+  },
+  "overrides": {
+    "@hono/node-server": "2.0.11"
   }
 }


### PR DESCRIPTION
## Summary
- force `@hono/node-server` 2.0.11 in both root and Canvas MCP dependency graphs
- resolves GHSA-frvp-7c67-39w9 (encoded-backslash path traversal on Windows) without taking the intermediate 2.0.5 release, which is vulnerable to GHSA-9mqv-5hh9-4cgg

## Verification
- root: `npm ci --ignore-scripts`, `npm run typecheck`, `npm run test:ci` (139 files, 925 tests)
- Canvas MCP: `npm ci --ignore-scripts`, `npm run typecheck`, `npm test` (18 files, 182 tests)
- production dependency audit finds neither Hono advisory in either lockfile
- `npm ls @hono/node-server --all` confirms 2.0.11 for both dependency graphs